### PR TITLE
[478377] Add null guard condition

### DIFF
--- a/org.eclipse.xtend.ide.common/src/org/eclipse/xtend/ide/common/highlighting/XtendHighlightingCalculator.java
+++ b/org.eclipse.xtend.ide.common/src/org/eclipse/xtend/ide/common/highlighting/XtendHighlightingCalculator.java
@@ -250,7 +250,9 @@ public class XtendHighlightingCalculator extends XbaseHighlightingCalculator imp
 				}
 			} else {
 				EStructuralFeature nameFeature = target.eClass().getEStructuralFeature("name");
-				highlightFeature(acceptor, target, nameFeature, XbaseHighlightingStyles.DEPRECATED_MEMBERS);
+				if (nameFeature!=null) {
+					highlightFeature(acceptor, target, nameFeature, XbaseHighlightingStyles.DEPRECATED_MEMBERS);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
If 'name' feature does not exist for the EClass, a null reference is passed into highlightFeature, which causes a NPE when NodeModelUtils is called.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>