### PR TITLE
[480472] Dependency upper range for org.eclipse.m2e.maven.runtime opened

### DIFF
--- a/org.eclipse.xtend.m2e/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.m2e/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.m2e.core;bundle-version="1.0.0";resolution:=optional
  org.eclipse.xtext.ui,
  org.eclipse.xtext.builder,
  org.eclipse.xtend.core,
- org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,1.6.0)";resolution:=optional
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,2.0.0)";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtend.m2e;x-internal:=true
 Import-Package: org.apache.maven.plugin;provider=m2e;resolution:=optional,


### PR DESCRIPTION
Due to availability of version 1.7.0 and for further 1.x versions

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>