### PR TITLE
[#43] Set cursor without selection after opening the editor for a new file

### DIFF
--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/wizards/AbstractNewXtendElementWizard.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/wizards/AbstractNewXtendElementWizard.java
@@ -15,9 +15,6 @@ import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.wizards.NewElementWizard;
 import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.jface.text.TextSelection;
-import org.eclipse.jface.viewers.ISelection;
-import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PartInitException;
@@ -71,10 +68,7 @@ public class AbstractNewXtendElementWizard extends NewElementWizard {
 					try {
 						editor = IDE.openEditor(JavaPlugin.getActivePage(), (IFile) resource);
 						if (editor instanceof ITextEditor) {
-							final ITextEditor textEditor = (ITextEditor) editor;
-							ISelectionProvider selectionProvider = textEditor.getSelectionProvider();
-							ISelection selection = new TextSelection(size - 2, 0);
-							selectionProvider.setSelection(selection);
+							((ITextEditor) editor).selectAndReveal(size -2, -1);
 						}
 					} catch (PartInitException e) {
 						throw new RuntimeException(e);


### PR DESCRIPTION
With this change the cursor is placed in the element body without selection:

<img width="266" alt="screenshot 33" src="https://cloud.githubusercontent.com/assets/265597/18939059/c184bee4-85fd-11e6-910c-29f999e16b1a.png">

Signed-off-by: Karsten Thoms karsten.thoms@itemis.de
