### PR TITLE
[507077] Do not emit empty concatenation

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug440006Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug440006Test.xtend
@@ -36,7 +36,7 @@ class CompilerBug440006Test extends AbstractXtendCompilerTest {
 			    {
 			      IntegerRange _upTo = new IntegerRange(1, 2);
 			      for(final IntegerRange i : Collections.<IntegerRange>unmodifiableSet(CollectionLiterals.<IntegerRange>newHashSet(_upTo))) {
-			        _builder.append(i, "");
+			        _builder.append(i);
 			      }
 			    }
 			    return _builder;
@@ -67,7 +67,7 @@ class CompilerBug440006Test extends AbstractXtendCompilerTest {
 			    {
 			      IntegerRange _upTo = new IntegerRange(1, 2);
 			      for(final IntegerRange i : Collections.<IntegerRange>unmodifiableList(CollectionLiterals.<IntegerRange>newArrayList(_upTo))) {
-			        _builder.append(i, "");
+			        _builder.append(i);
 			      }
 			    }
 			    return _builder;

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.xtend
@@ -1347,7 +1347,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			    {
 			      char[] _charArray = it.toCharArray();
 			      for(final char it_1 : _charArray) {
-			        _builder.append(it_1, "");
+			        _builder.append(it_1);
 			        _builder.newLineIfNotEmpty();
 			      }
 			    }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug440006Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug440006Test.java
@@ -63,7 +63,7 @@ public class CompilerBug440006Test extends AbstractXtendCompilerTest {
     _builder_1.append("for(final IntegerRange i : Collections.<IntegerRange>unmodifiableSet(CollectionLiterals.<IntegerRange>newHashSet(_upTo))) {");
     _builder_1.newLine();
     _builder_1.append("        ");
-    _builder_1.append("_builder.append(i, \"\");");
+    _builder_1.append("_builder.append(i);");
     _builder_1.newLine();
     _builder_1.append("      ");
     _builder_1.append("}");
@@ -129,7 +129,7 @@ public class CompilerBug440006Test extends AbstractXtendCompilerTest {
     _builder_1.append("for(final IntegerRange i : Collections.<IntegerRange>unmodifiableList(CollectionLiterals.<IntegerRange>newArrayList(_upTo))) {");
     _builder_1.newLine();
     _builder_1.append("        ");
-    _builder_1.append("_builder.append(i, \"\");");
+    _builder_1.append("_builder.append(i);");
     _builder_1.newLine();
     _builder_1.append("      ");
     _builder_1.append("}");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.java
@@ -3065,7 +3065,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("for(final char it_1 : _charArray) {");
     _builder_1.newLine();
     _builder_1.append("        ");
-    _builder_1.append("_builder.append(it_1, \"\");");
+    _builder_1.append("_builder.append(it_1);");
     _builder_1.newLine();
     _builder_1.append("        ");
     _builder_1.append("_builder.newLineIfNotEmpty();");

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendCompiler.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendCompiler.java
@@ -328,9 +328,14 @@ public class XtendCompiler extends XbaseCompiler {
 				else
 					tracingAppendable.append(".append(");
 				internalToJavaExpression(expression, tracingAppendable);
-				tracingAppendable.append(", \"");
-				tracingAppendable.append(Strings.convertToJavaString(indentation.toString(), false));
-				tracingAppendable.append("\");");
+
+				String javaIndentation = Strings.convertToJavaString(indentation.toString(), false);
+				if (immediate || !javaIndentation.isEmpty()) {
+					tracingAppendable.append(", \"");
+					tracingAppendable.append(javaIndentation);
+					tracingAppendable.append("\"");
+				}
+				tracingAppendable.append(");");
 			}
 		}
 

--- a/org.eclipse.xtend.maven.plugin/src/test/java/org/eclipse/xtend/maven/XtendCompilerMojoIT.java
+++ b/org.eclipse.xtend.maven.plugin/src/test/java/org/eclipse/xtend/maven/XtendCompilerMojoIT.java
@@ -74,7 +74,7 @@ public class XtendCompilerMojoIT {
 		String gen = verifier.getBasedir() + "/src/main/generated-sources/xtend/test/XtendA.java";
 		assertFileContainsUTF16(verifier, gen, "Mühlheim-Kärlicher Bürger");
 		assertFileContainsUTF16(verifier, gen, "_builder.append(\"möchte meine \");");
-		assertFileContainsUTF16(verifier, gen, "_builder.append(\"tür ölen\", \"\");");
+		assertFileContainsUTF16(verifier, gen, "_builder.append(\"tür ölen\");");
 	}
 
 	@Test


### PR DESCRIPTION
Java code generated from Xtend routinely contains output
like:

  public CharSequence packageDefinition() {
    StringConcatenation _builder = new StringConcatenation();
    _builder.append("package ");
    String _packageName = this.type.getPackageName();
    _builder.append(_packageName, "");
    _builder.append(";");
    return _builder;
  }

While StringConcatenation will detect the fact the indentation
string is empty, it is at the cost of runtime performance.

Before emitting the call to StringConcatenation, check if our
literal would end up being an empty string and if it would,
call the no-indentation append() variant instead.

Signed-off-by: Robert Varga <nite@hq.sk>