### PR TITLE
#68: Unexpected "Invalid return inside throw."

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug406762Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug406762Test.xtend
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2016 TypeFox.io (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.core.tests.compiler
+
+import org.junit.Test
+
+/**
+ * @author Lorenzo Bettini - Initial contribution and API
+ */
+class CompilerBug406762Test extends AbstractXtendCompilerTest {
+	
+	@Test def testMyExceptionReturnsThisAsThrowable() {
+		'''
+			class Bug {
+				private static final class MyException extends Exception {
+					override synchronized Throwable fillInStackTrace() {
+						return this;
+					}
+				}
+			}
+		'''.assertCompilesTo('''
+			@SuppressWarnings("all")
+			public class Bug {
+			  private static final class MyException extends Exception {
+			    public synchronized Throwable fillInStackTrace() {
+			      return this;
+			    }
+			  }
+			}
+		''')
+	}
+
+	@Test def testMyExceptionImpicitlyReturnsThisAsThrowable() {
+		'''
+			class Bug {
+				private static final class MyException extends Exception {
+					override synchronized Throwable fillInStackTrace() {
+						this
+					}
+				}
+			}
+		'''.assertCompilesTo('''
+			@SuppressWarnings("all")
+			public class Bug {
+			  private static final class MyException extends Exception {
+			    public synchronized Throwable fillInStackTrace() {
+			      return this;
+			    }
+			  }
+			}
+		''')
+	}
+	
+}

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug406762Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug406762Test.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2016 TypeFox.io (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.core.tests.compiler;
+
+import org.eclipse.xtend.core.tests.compiler.AbstractXtendCompilerTest;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.junit.Test;
+
+/**
+ * @author Lorenzo Bettini - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class CompilerBug406762Test extends AbstractXtendCompilerTest {
+  @Test
+  public void testMyExceptionReturnsThisAsThrowable() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Bug {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("private static final class MyException extends Exception {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("override synchronized Throwable fillInStackTrace() {");
+    _builder.newLine();
+    _builder.append("\t\t\t");
+    _builder.append("return this;");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class Bug {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("private static final class MyException extends Exception {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("public synchronized Throwable fillInStackTrace() {");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("return this;");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
+  }
+  
+  @Test
+  public void testMyExceptionImpicitlyReturnsThisAsThrowable() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Bug {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("private static final class MyException extends Exception {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("override synchronized Throwable fillInStackTrace() {");
+    _builder.newLine();
+    _builder.append("\t\t\t");
+    _builder.append("this");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class Bug {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("private static final class MyException extends Exception {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("public synchronized Throwable fillInStackTrace() {");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("return this;");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
+  }
+}


### PR DESCRIPTION
Tests to show the problem went away, thanks to
https://github.com/eclipse/xtext-extras/pull/69

Closes #68 

Task-Url: https://github.com/eclipse/xtext-xtend/issues/68
Signed-off-by: Lorenzo Bettini <lorenzo.bettini@gmail.com>