### PR TITLE
Ignore xtend-gen content for example projects

### DIFF
--- a/org.eclipse.xtend.examples/.gitignore
+++ b/org.eclipse.xtend.examples/.gitignore
@@ -1,1 +1,2 @@
 /contents/
+xtend-gen


### PR DESCRIPTION
When importing Xtend projects the sources for the example projects are generated. So far they are not checked in. I propose that we do not check in them, but ignore them.

![screenshot 121](https://cloud.githubusercontent.com/assets/265597/20749829/3e25f072-b6f4-11e6-9227-32dcfc43cc68.png)


Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>