### PR TITLE
[eclipse/xtext#1089] Replace (not)equal operators by triple (not)equals

### DIFF
--- a/org.eclipse.xtend.core.tests/longrunning/src/org/eclipse/xtend/core/tests/smoke/Case_9.xtend
+++ b/org.eclipse.xtend.core.tests/longrunning/src/org/eclipse/xtend/core/tests/smoke/Case_9.xtend
@@ -10,7 +10,7 @@ import java.util.List
 class Case_9 extends Case_8 {
 	
 	def dispatch CharSequence generateTypeRef(ENamedElement c) {
-		  if (c.eContainer != null)
+		  if (c.eContainer !== null)
 		    c.eContainer.generateTypeRef
 		  else if (c.eIsProxy)
 		    '''«c.name»'''

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/EmfModelsTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/EmfModelsTest.xtend
@@ -123,7 +123,7 @@ class EmfModelsTest {
 							debug(eClassifier.getName() + ": Overridden setter " + setter.getName());
 					}
 					if (eStructuralFeature instanceof EReference && !(eStructuralFeature as EReference).isContainment() &&
-						(eStructuralFeature as EReference).getEOpposite() == null) {
+						(eStructuralFeature as EReference).getEOpposite() === null) {
 						val String basicGetterName = "basic" + Strings.toFirstUpper(getterName);
 						val Method basicGetter = obj.getClass().getMethod(basicGetterName);
 						if (isCustom(basicGetter))
@@ -137,7 +137,7 @@ class EmfModelsTest {
 	}
 
 	def toJavaClass(EClassifier eClassifier) {
-		if (eClassifier.getInstanceClass() != null) {
+		if (eClassifier.getInstanceClass() !== null) {
 			return eClassifier.getInstanceClass();
 		}
 		return null;

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerTraceTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerTraceTest.xtend
@@ -810,7 +810,7 @@ class CompilerTraceTest extends AbstractXtendTestCase {
 			for(AbstractTraceRegion child: regions) {
 				rootLocation = rootLocation.merge(new TextRegionWithLineInformation(child.getMyOffset(), child.getMyLength(), child.getMyLineNumber(), child.getMyEndLineNumber()));
 				var childAssociation = child.getMergedAssociatedLocation();
-				if (childAssociation != null)
+				if (childAssociation !== null)
 					associated = associated.merge(childAssociation);
 			}
 			val root = new RootTraceRegionForTesting(rootLocation, associated)

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/batch/TestBatchCompiler.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/batch/TestBatchCompiler.xtend
@@ -454,7 +454,7 @@ class TestBatchCompiler {
 
 	def private boolean isSymlink(File file) {
 		var File canon
-		if (file.getParent() == null) {
+		if (file.getParent() === null) {
 			canon = file
 		} else {
 			var File canonDir = file.getParentFile().getCanonicalFile()

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/debug/LineNumberMappingTests.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/debug/LineNumberMappingTests.xtend
@@ -175,7 +175,7 @@ class LineNumberMappingTests extends AbstractXtendTestCase {
 		for (lineNumber : 0..lines.size-1) {
 			val mapping = findMapping(normalizedMappings, lineNumber)
 			val line = lines.get(lineNumber)
-			if (mapping != null) {
+			if (mapping !== null) {
 				if (line.indexOf("//") == -1) {
 					fail('''Line «lineNumber» is mapped to «mapping.targetStartLine»('«line»')'''.toString)
 				}

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/imports/ImportOrganizerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/imports/ImportOrganizerTest.xtend
@@ -33,7 +33,7 @@ class ImportOrganizerTest extends AbstractXtendTestCase {
 		val sortedChanges= changes.sortBy[offset]
 		var ReplaceRegion lastChange = null
 		for(it: sortedChanges) {
-			if(lastChange != null && lastChange.endOffset > offset)
+			if(lastChange !== null && lastChange.endOffset > offset)
 				fail("Overlapping text edits: " + lastChange + ' and ' +it)
 			lastChange = it
 		}

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/AccessObjectProcessor.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/AccessObjectProcessor.xtend
@@ -78,9 +78,9 @@ class AccessObjectProcessor implements TransformationParticipant<MutableClassDec
 			
 			val PVersionName = pkg+"P"+it.simpleName;
 			val p = findClass(PVersionName)
-			if ( p == null )
+			if ( p === null )
 				addError("Class "+PVersionName+" not found")
-			if ( p!=null && ser != null) {
+			if ( p!==null && ser !== null) {
 				val pIfcs = new LinkedList
 				pIfcs.add(ser)
 				p.setImplementedInterfaces(pIfcs)
@@ -88,9 +88,9 @@ class AccessObjectProcessor implements TransformationParticipant<MutableClassDec
 			
 			val GVersionName = pkg+"G"+it.simpleName;
 			val g = findClass(GVersionName)
-			if ( g == null )
+			if ( g === null )
 				addError("Class "+GVersionName+" not found")
-			if ( g!=null && ser != null) {
+			if ( g!==null && ser !== null) {
 				val gIfcs = new LinkedList
 				gIfcs.add(ser)
 				g.setImplementedInterfaces(gIfcs)

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/ActiveAnnotationsRuntimeTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/ActiveAnnotationsRuntimeTest.xtend
@@ -284,7 +284,7 @@ class DelegatingClassloader extends ClassLoader {
 	
 	override findClass(String name) throws ClassNotFoundException {
 		val result = classFinder.getCompiledClass(name)
-		if (result != null)
+		if (result !== null)
 			return result
 		super.findClass(name)
 	}

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/HttpGetAnnotationTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/HttpGetAnnotationTest.xtend
@@ -49,7 +49,7 @@ class GetProcessor implements TransformationParticipant<MutableMethodDeclaration
 		for (m : methods) {
 			val annotation = m.findAnnotation(typeof(Get).findTypeGlobally)
 			val pattern = annotation.getValue('value')
-			if (pattern == null) {
+			if (pattern === null) {
 				annotation.addError('A URL pattern must be provided.')
 			} else {
 				

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/TypeReferenceAssignabilityTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/TypeReferenceAssignabilityTest.xtend
@@ -29,11 +29,11 @@ class TypeReferenceAssignabilityTest extends AssignabilityTest {
 		val operation = function.directlyInferredOperation
 		val xtendFile = EcoreUtil.getRootContainer(function) as XtendFile
 		xtendFile.asCompilationUnit [ it |
-			val lhsType = if (lhsAndParams.key != null)
+			val lhsType = if (lhsAndParams.key !== null)
 					toTypeReference(operation.parameters.head.parameterType)
 				else
 					toTypeReference(owner.newAnyTypeReference)
-			val rhsType = if (rhs != null)
+			val rhsType = if (rhs !== null)
 					toTypeReference(operation.parameters.last.parameterType)
 				else
 					toTypeReference(owner.newAnyTypeReference)

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/declaration/ConstantExpressionsInterpreterTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/declaration/ConstantExpressionsInterpreterTest.xtend
@@ -298,7 +298,7 @@ class ConstantExpressionsInterpreterTest extends AbstractXtendTestCase {
 		val expression = typeAndExpression.value
 		val function = function('def '+(type?:'void')+' testFoo() { '+expression+' }')
 		val expr = (function.expression as XBlockExpression).expressions.head
-		val value = interpreter.evaluate(expr, if (type!=null) function.returnType)
+		val value = interpreter.evaluate(expr, if (type!==null) function.returnType)
 		assertions.apply(value)
 	}
 }

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/ActualTypeArgumentCollectorTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/ActualTypeArgumentCollectorTest.xtend
@@ -50,7 +50,7 @@ class ActualTypeArgumentCollectorTest extends AbstractTestingTypeReferenceOwner 
 				return mapping
 			}
 		}
-		if (mappedTypes != null)
+		if (mappedTypes !== null)
 			fail('''No mapping for «typeParamName» in «mapping.keySet.map[simpleName]»'''.toString)
 		return mapping
 	}

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/ActualTypeArgumentMergeTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/ActualTypeArgumentMergeTest.xtend
@@ -57,7 +57,7 @@ class ActualTypeArgumentMergeTest extends AbstractTestingTypeReferenceOwner {
 	}
 	
 	def to(Pair<Map<JvmTypeParameter, List<LightweightBoundTypeArgument>>, LightweightMergedBoundTypeArgument> merged, String type, VarianceInfo variance) {
-		if (type == null) {
+		if (type === null) {
 			assertNull(merged.value)
 		} else {
 			assertEquals(type, merged.value.typeReference.toString)

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/AssignabilityTests.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/AssignabilityTests.xtend
@@ -72,8 +72,8 @@ abstract class AbstractAssignabilityTest extends AbstractTestingTypeReferenceOwn
 			rhs.fixup» rhs) {}'''
 		val function = function(signature.toString)
 		val operation = function.directlyInferredOperation
-		val lhsType = if (lhsAndParams.key != null) operation.parameters.head.parameterType.toLightweightTypeReference else owner.newAnyTypeReference
-		val rhsType = if (rhs != null) operation.parameters.last.parameterType.toLightweightTypeReference else owner.newAnyTypeReference
+		val lhsType = if (lhsAndParams.key !== null) operation.parameters.head.parameterType.toLightweightTypeReference else owner.newAnyTypeReference
+		val rhsType = if (rhs !== null) operation.parameters.last.parameterType.toLightweightTypeReference else owner.newAnyTypeReference
 		assertEquals(lhsType.simpleName + " := " + rhsType.simpleName, expectation, lhsType.testIsAssignable(rhsType))
 		if (expectation) {
 			for(superType: lhsType.allSuperTypes) {

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/BoundTypeArgumentMergerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/BoundTypeArgumentMergerTest.xtend
@@ -71,7 +71,7 @@ class BoundTypeArgumentMergerTest extends AbstractTestingTypeReferenceOwner {
 	
 	
 	def to(LightweightMergedBoundTypeArgument merged, String type, VarianceInfo variance) {
-		if (type == null) {
+		if (type === null) {
 			assertNull(merged)
 		} else {
 			assertEquals(type, merged.typeReference.simpleName)

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/CommonSuperTypeTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/CommonSuperTypeTest.xtend
@@ -46,14 +46,14 @@ class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
 			computedSuperType = getServices.typeConformanceComputer.getCommonSuperType((typeReferences + newImmutableList(owner.newAnyTypeReference, owner.newAnyTypeReference)).toList, owner)
 			assertEquals(superTypeAndParam.key, computedSuperType?.simpleName)
 		}
-		if (computedSuperType != null) {
+		if (computedSuperType !== null) {
 			computedSuperType => [ superType |
 				typeReferences.forEach [
 					assertEquals(superTypeAndParam.key, conformanceComputer.getCommonSuperType(#[it, superType], superType.owner)?.simpleName)
 				]
 			]
 		}
-		if (computedSuperType != null) {
+		if (computedSuperType !== null) {
 			for(subType: typeReferences) {
 				assertTrue(computedSuperType.isAssignableFrom(subType))
 			}

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/DeferredTypeParameterHintCollectorTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/DeferredTypeParameterHintCollectorTest.xtend
@@ -185,7 +185,7 @@ class MockTypeParameterSubstitutor extends TypeParameterSubstitutor<Set<JvmTypeP
 			}
 			try {
 				val mappedReference = getTypeParameterMapping().get(type);
-				if (mappedReference != null) {
+				if (mappedReference !== null) {
 					return mappedReference.typeReference.accept(this, visiting)
 				} else {
 					val result = new SimpleUnboundTypeReference(owner, type, new Object)

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/SynonmyTypesTests.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/SynonmyTypesTests.xtend
@@ -33,7 +33,7 @@ class SynonmyTypesTest extends AbstractTestingTypeReferenceOwner {
 			typeAndTypeParams.key» p) {}'''
 		val function = function(signature.toString)
 		val operation = function.directlyInferredOperation
-		val primary = if (typeAndTypeParams.key != null) operation.parameters.head.parameterType.toLightweightTypeReference else owner.newAnyTypeReference
+		val primary = if (typeAndTypeParams.key !== null) operation.parameters.head.parameterType.toLightweightTypeReference else owner.newAnyTypeReference
 		val actualSynonyms = newHashSet
 		primary.collectSynonymTypes [ type, conformance | actualSynonyms.add(type.simpleName) ]
 		assertEquals(actualSynonyms.toString, expectedSynonyms.length, actualSynonyms.size)

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/EmfModelsTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/EmfModelsTest.java
@@ -204,7 +204,7 @@ public class EmfModelsTest {
             }
           }
           if ((((eStructuralFeature instanceof EReference) && (!((EReference) eStructuralFeature).isContainment())) && 
-            Objects.equal(((EReference) eStructuralFeature).getEOpposite(), null))) {
+            (((EReference) eStructuralFeature).getEOpposite() == null))) {
             String _firstUpper_2 = Strings.toFirstUpper(getterName);
             final String basicGetterName = ("basic" + _firstUpper_2);
             Class<? extends EObject> _class_2 = obj.getClass();
@@ -232,8 +232,8 @@ public class EmfModelsTest {
   
   public Class<?> toJavaClass(final EClassifier eClassifier) {
     Class<?> _instanceClass = eClassifier.getInstanceClass();
-    boolean _notEquals = (!Objects.equal(_instanceClass, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_instanceClass != null);
+    if (_tripleNotEquals) {
       return eClassifier.getInstanceClass();
     }
     return null;

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerTraceTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerTraceTest.java
@@ -1633,8 +1633,7 @@ public class CompilerTraceTest extends AbstractXtendTestCase {
           ITextRegionWithLineInformation _merge = rootLocation.merge(_textRegionWithLineInformation);
           rootLocation = _merge;
           ILocationData childAssociation = child.getMergedAssociatedLocation();
-          boolean _notEquals = (!Objects.equal(childAssociation, null));
-          if (_notEquals) {
+          if ((childAssociation != null)) {
             ITextRegionWithLineInformation _merge_1 = associated.merge(childAssociation);
             associated = _merge_1;
           }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/batch/TestBatchCompiler.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/batch/TestBatchCompiler.java
@@ -8,7 +8,6 @@
 package org.eclipse.xtend.core.tests.compiler.batch;
 
 import com.google.common.base.Charsets;
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.io.File;
 import java.io.FilenameFilter;
@@ -810,8 +809,8 @@ public class TestBatchCompiler {
     try {
       File canon = null;
       String _parent = file.getParent();
-      boolean _equals = Objects.equal(_parent, null);
-      if (_equals) {
+      boolean _tripleEquals = (_parent == null);
+      if (_tripleEquals) {
         canon = file;
       } else {
         File _parentFile = file.getParentFile();
@@ -822,8 +821,8 @@ public class TestBatchCompiler {
       }
       File _canonicalFile = canon.getCanonicalFile();
       File _absoluteFile = canon.getAbsoluteFile();
-      boolean _equals_1 = _canonicalFile.equals(_absoluteFile);
-      return (!_equals_1);
+      boolean _equals = _canonicalFile.equals(_absoluteFile);
+      return (!_equals);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/debug/LineNumberMappingTests.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/debug/LineNumberMappingTests.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtend.core.tests.debug;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.List;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -332,8 +331,7 @@ public class LineNumberMappingTests extends AbstractXtendTestCase {
       {
         final LineMappingProvider.LineMapping mapping = this.findMapping(normalizedMappings, lineNumber);
         final String line = lines[(lineNumber).intValue()];
-        boolean _notEquals = (!Objects.equal(mapping, null));
-        if (_notEquals) {
+        if ((mapping != null)) {
           int _indexOf = line.indexOf("//");
           boolean _equals = (_indexOf == (-1));
           if (_equals) {
@@ -355,8 +353,8 @@ public class LineNumberMappingTests extends AbstractXtendTestCase {
           int expTargetStart = (-1);
           int expTargetEnd = (-1);
           int _indexOf_2 = expectation.indexOf("..");
-          boolean _notEquals_1 = (_indexOf_2 != (-1));
-          if (_notEquals_1) {
+          boolean _notEquals = (_indexOf_2 != (-1));
+          if (_notEquals) {
             final int idx = expectation.indexOf("..");
             String _substring_1 = expectation.substring(0, idx);
             int _parseInt = Integer.parseInt(_substring_1);
@@ -373,8 +371,8 @@ public class LineNumberMappingTests extends AbstractXtendTestCase {
           Assert.assertEquals(("unexpected end in line : " + line), expTargetEnd, mapping.targetEndLine);
         } else {
           int _indexOf_3 = line.indexOf("//");
-          boolean _notEquals_2 = (_indexOf_3 != (-1));
-          if (_notEquals_2) {
+          boolean _notEquals_1 = (_indexOf_3 != (-1));
+          if (_notEquals_1) {
             Assert.fail(("Unmatched expectation : " + line));
           }
         }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/imports/ImportOrganizerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/imports/ImportOrganizerTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.tests.imports;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.List;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -53,7 +52,7 @@ public class ImportOrganizerTest extends AbstractXtendTestCase {
       ReplaceRegion lastChange = null;
       for (final ReplaceRegion it : sortedChanges) {
         {
-          if (((!Objects.equal(lastChange, null)) && (lastChange.getEndOffset() > it.getOffset()))) {
+          if (((lastChange != null) && (lastChange.getEndOffset() > it.getOffset()))) {
             Assert.fail(((("Overlapping text edits: " + lastChange) + " and ") + it));
           }
           lastChange = it;

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/AccessObjectProcessor.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/AccessObjectProcessor.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtend.core.tests.macro;
 
-import com.google.common.base.Objects;
 import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
@@ -63,11 +62,10 @@ public class AccessObjectProcessor implements TransformationParticipant<MutableC
       String _simpleName_1 = it.getSimpleName();
       final String PVersionName = ((pkg + "P") + _simpleName_1);
       final MutableClassDeclaration p = ctx.findClass(PVersionName);
-      boolean _equals = Objects.equal(p, null);
-      if (_equals) {
+      if ((p == null)) {
         ctx.addError(it, (("Class " + PVersionName) + " not found"));
       }
-      if (((!Objects.equal(p, null)) && (!Objects.equal(ser, null)))) {
+      if (((p != null) && (ser != null))) {
         final LinkedList<TypeReference> pIfcs = new LinkedList<TypeReference>();
         pIfcs.add(ser);
         p.setImplementedInterfaces(pIfcs);
@@ -75,11 +73,10 @@ public class AccessObjectProcessor implements TransformationParticipant<MutableC
       String _simpleName_2 = it.getSimpleName();
       final String GVersionName = ((pkg + "G") + _simpleName_2);
       final MutableClassDeclaration g = ctx.findClass(GVersionName);
-      boolean _equals_1 = Objects.equal(g, null);
-      if (_equals_1) {
+      if ((g == null)) {
         ctx.addError(it, (("Class " + GVersionName) + " not found"));
       }
-      if (((!Objects.equal(g, null)) && (!Objects.equal(ser, null)))) {
+      if (((g != null) && (ser != null))) {
         final LinkedList<TypeReference> gIfcs = new LinkedList<TypeReference>();
         gIfcs.add(ser);
         g.setImplementedInterfaces(gIfcs);

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/DelegatingClassloader.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/DelegatingClassloader.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtend.core.tests.macro;
 
-import com.google.common.base.Objects;
 import java.net.URL;
 import org.eclipse.xtext.xbase.compiler.CompilationTestHelper;
 
@@ -32,8 +31,7 @@ public class DelegatingClassloader extends ClassLoader {
     Class<?> _xblockexpression = null;
     {
       final Class<?> result = this.classFinder.getCompiledClass(name);
-      boolean _notEquals = (!Objects.equal(result, null));
-      if (_notEquals) {
+      if ((result != null)) {
         return result;
       }
       _xblockexpression = super.findClass(name);

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/GetProcessor.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/GetProcessor.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtend.core.tests.macro;
 
-import com.google.common.base.Objects;
 import java.util.List;
 import org.eclipse.xtend.core.tests.macro.Get;
 import org.eclipse.xtend.lib.macro.TransformationContext;
@@ -19,8 +18,7 @@ public class GetProcessor implements TransformationParticipant<MutableMethodDecl
         Type _findTypeGlobally = context.findTypeGlobally(Get.class);
         final AnnotationReference annotation = m.findAnnotation(_findTypeGlobally);
         final Object pattern = annotation.getValue("value");
-        boolean _equals = Objects.equal(pattern, null);
-        if (_equals) {
+        if ((pattern == null)) {
           context.addError(annotation, "A URL pattern must be provided.");
         } else {
         }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/TypeReferenceAssignabilityTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/TypeReferenceAssignabilityTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.tests.macro;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import org.eclipse.emf.common.util.EList;
@@ -72,8 +71,8 @@ public class TypeReferenceAssignabilityTest extends AssignabilityTest {
       final Procedure1<CompilationUnitImpl> _function = (CompilationUnitImpl it) -> {
         TypeReference _xifexpression = null;
         String _key_1 = lhsAndParams.getKey();
-        boolean _notEquals = (!Objects.equal(_key_1, null));
-        if (_notEquals) {
+        boolean _tripleNotEquals = (_key_1 != null);
+        if (_tripleNotEquals) {
           EList<JvmFormalParameter> _parameters = operation.getParameters();
           JvmFormalParameter _head = IterableExtensions.<JvmFormalParameter>head(_parameters);
           JvmTypeReference _parameterType = _head.getParameterType();
@@ -85,8 +84,7 @@ public class TypeReferenceAssignabilityTest extends AssignabilityTest {
         }
         final TypeReference lhsType = _xifexpression;
         TypeReference _xifexpression_1 = null;
-        boolean _notEquals_1 = (!Objects.equal(rhs, null));
-        if (_notEquals_1) {
+        if ((rhs != null)) {
           EList<JvmFormalParameter> _parameters_1 = operation.getParameters();
           JvmFormalParameter _last = IterableExtensions.<JvmFormalParameter>last(_parameters_1);
           JvmTypeReference _parameterType_1 = _last.getParameterType();

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/declaration/ConstantExpressionsInterpreterTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/declaration/ConstantExpressionsInterpreterTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.tests.macro.declaration;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import org.eclipse.emf.common.util.EList;
@@ -617,8 +616,7 @@ public class ConstantExpressionsInterpreterTest extends AbstractXtendTestCase {
       EList<XExpression> _expressions = ((XBlockExpression) _expression).getExpressions();
       final XExpression expr = IterableExtensions.<XExpression>head(_expressions);
       JvmTypeReference _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(type, null));
-      if (_notEquals) {
+      if ((type != null)) {
         _xifexpression = function.getReturnType();
       }
       final Object value = this.interpreter.evaluate(expr, _xifexpression);

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/AbstractAssignabilityTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/AbstractAssignabilityTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.tests.typesystem;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.List;
 import org.eclipse.emf.common.util.EList;
@@ -125,8 +124,8 @@ public abstract class AbstractAssignabilityTest extends AbstractTestingTypeRefer
       final JvmOperation operation = this._iXtendJvmAssociations.getDirectlyInferredOperation(function);
       LightweightTypeReference _xifexpression = null;
       String _key_1 = lhsAndParams.getKey();
-      boolean _notEquals = (!Objects.equal(_key_1, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_key_1 != null);
+      if (_tripleNotEquals) {
         EList<JvmFormalParameter> _parameters = operation.getParameters();
         JvmFormalParameter _head = IterableExtensions.<JvmFormalParameter>head(_parameters);
         JvmTypeReference _parameterType = _head.getParameterType();
@@ -137,8 +136,7 @@ public abstract class AbstractAssignabilityTest extends AbstractTestingTypeRefer
       }
       final LightweightTypeReference lhsType = _xifexpression;
       LightweightTypeReference _xifexpression_1 = null;
-      boolean _notEquals_1 = (!Objects.equal(rhs, null));
-      if (_notEquals_1) {
+      if ((rhs != null)) {
         EList<JvmFormalParameter> _parameters_1 = operation.getParameters();
         JvmFormalParameter _last = IterableExtensions.<JvmFormalParameter>last(_parameters_1);
         JvmTypeReference _parameterType_1 = _last.getParameterType();

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/ActualTypeArgumentCollectorTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/ActualTypeArgumentCollectorTest.java
@@ -113,8 +113,7 @@ public class ActualTypeArgumentCollectorTest extends AbstractTestingTypeReferenc
         return mapping;
       }
     }
-    boolean _notEquals = (!Objects.equal(mappedTypes, null));
-    if (_notEquals) {
+    if ((mappedTypes != null)) {
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("No mapping for ");
       _builder.append(typeParamName, "");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/ActualTypeArgumentMergeTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/ActualTypeArgumentMergeTest.java
@@ -130,8 +130,7 @@ public class ActualTypeArgumentMergeTest extends AbstractTestingTypeReferenceOwn
   public Map<JvmTypeParameter, List<LightweightBoundTypeArgument>> to(final Pair<Map<JvmTypeParameter, List<LightweightBoundTypeArgument>>, LightweightMergedBoundTypeArgument> merged, final String type, final VarianceInfo variance) {
     Map<JvmTypeParameter, List<LightweightBoundTypeArgument>> _xblockexpression = null;
     {
-      boolean _equals = Objects.equal(type, null);
-      if (_equals) {
+      if ((type == null)) {
         LightweightMergedBoundTypeArgument _value = merged.getValue();
         Assert.assertNull(_value);
       } else {

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/BoundTypeArgumentMergerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/BoundTypeArgumentMergerTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.tests.typesystem;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -152,8 +151,7 @@ public class BoundTypeArgumentMergerTest extends AbstractTestingTypeReferenceOwn
   }
   
   public void to(final LightweightMergedBoundTypeArgument merged, final String type, final VarianceInfo variance) {
-    boolean _equals = Objects.equal(type, null);
-    if (_equals) {
+    if ((type == null)) {
       Assert.assertNull(merged);
     } else {
       LightweightTypeReference _typeReference = merged.getTypeReference();

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/CommonSuperTypeTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/CommonSuperTypeTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.tests.typesystem;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import java.util.ArrayList;
@@ -155,8 +154,7 @@ public class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
         }
         Assert.assertEquals(_key_3, _simpleName_3);
       }
-      boolean _notEquals = (!Objects.equal(computedSuperType, null));
-      if (_notEquals) {
+      if ((computedSuperType != null)) {
         final Procedure1<LightweightTypeReference> _function_1 = (LightweightTypeReference superType) -> {
           final Consumer<LightweightTypeReference> _function_2 = (LightweightTypeReference it) -> {
             String _key_4 = superTypeAndParam.getKey();
@@ -172,8 +170,7 @@ public class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
         };
         ObjectExtensions.<LightweightTypeReference>operator_doubleArrow(computedSuperType, _function_1);
       }
-      boolean _notEquals_1 = (!Objects.equal(computedSuperType, null));
-      if (_notEquals_1) {
+      if ((computedSuperType != null)) {
         for (final LightweightTypeReference subType : typeReferences) {
           boolean _isAssignableFrom = computedSuperType.isAssignableFrom(subType);
           Assert.assertTrue(_isAssignableFrom);

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/MockTypeParameterSubstitutor.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/MockTypeParameterSubstitutor.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.tests.typesystem;
 
-import com.google.common.base.Objects;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -53,8 +52,7 @@ public class MockTypeParameterSubstitutor extends TypeParameterSubstitutor<Set<J
       try {
         Map<JvmTypeParameter, LightweightMergedBoundTypeArgument> _typeParameterMapping = this.getTypeParameterMapping();
         final LightweightMergedBoundTypeArgument mappedReference = _typeParameterMapping.get(type);
-        boolean _notEquals = (!Objects.equal(mappedReference, null));
-        if (_notEquals) {
+        if ((mappedReference != null)) {
           LightweightTypeReference _typeReference = mappedReference.getTypeReference();
           return _typeReference.<Set<JvmTypeParameter>, LightweightTypeReference>accept(this, visiting);
         } else {

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/SynonmyTypesTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/SynonmyTypesTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.tests.typesystem;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.Collection;
 import java.util.HashSet;
@@ -75,8 +74,8 @@ public class SynonmyTypesTest extends AbstractTestingTypeReferenceOwner {
       final JvmOperation operation = this._iXtendJvmAssociations.getDirectlyInferredOperation(function);
       LightweightTypeReference _xifexpression = null;
       String _key_1 = typeAndTypeParams.getKey();
-      boolean _notEquals = (!Objects.equal(_key_1, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_key_1 != null);
+      if (_tripleNotEquals) {
         EList<JvmFormalParameter> _parameters = operation.getParameters();
         JvmFormalParameter _head = IterableExtensions.<JvmFormalParameter>head(_parameters);
         JvmTypeReference _parameterType = _head.getParameterType();

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendGenerator.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendGenerator.xtend
@@ -220,7 +220,7 @@ class XtendGenerator extends JvmModelGenerator implements IGenerator2 {
 						tracedAppendable.append(" ")
 						tracedAppendable.traceSignificant(it).append(simpleName)
 						if (isFinal && isStatic) {
-							if (constantValue != null) {
+							if (constantValue !== null) {
 								tracedAppendable.append(" = ")
 								generateJavaConstant(constantValue, tracedAppendable)
 							} else {

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/documentation/XtendFileHeaderProvider.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/documentation/XtendFileHeaderProvider.xtend
@@ -31,7 +31,7 @@ class XtendFileHeaderProvider extends MultiLineFileHeaderProvider {
 	override getFileHeaderNodes(Resource resource) {
 		if (resource instanceof XtextResource) {
 			val parseResult = resource.parseResult
-			if (parseResult != null) {
+			if (parseResult !== null) {
 				for (leafNode: parseResult.rootNode.leafNodes) {
 					var break = true
 					val grammarElement = leafNode.grammarElement
@@ -56,7 +56,7 @@ class XtendFileHeaderProvider extends MultiLineFileHeaderProvider {
 		val content = resource.contents.head
 		if (content instanceof XtendFile) {
 			val type = content.xtendTypes.head
-			if (type != null) {
+			if (type !== null) {
 				if (documentationProvider instanceof IEObjectDocumentationProviderExtension) {
 					return leafNode == documentationProvider.getDocumentationNodes(type).head
 				}

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/findReferences/Declarators.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/findReferences/Declarators.xtend
@@ -34,7 +34,7 @@ class Declarators {
 	
 	def getDeclaratorData(TargetURIs targetURIs, IReferenceFinder.IResourceAccess resourceAccess) {
 		var result = targetURIs.getUserData(KEY)
-		if (result != null) {
+		if (result !== null) {
 			return result
 		}
 		val declaratorNames = newHashSet()
@@ -42,9 +42,9 @@ class Declarators {
 			resourceAccess.readOnly(uri) [
 				targetURIs.getEObjectURIs(uri).forEach [ objectURI |
 					val object = getEObject(objectURI, true)
-					if (object != null) {
+					if (object !== null) {
 						val type = EcoreUtil2.getContainerOfType(object, JvmType)
-						if (type != null) {
+						if (type !== null) {
 							declaratorNames += nameConverter.toQualifiedName(type.identifier).toLowerCase
 							declaratorNames += nameConverter.toQualifiedName(type.getQualifiedName('.')).toLowerCase
 						}

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/findReferences/XtendReferenceFinder.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/findReferences/XtendReferenceFinder.xtend
@@ -72,7 +72,7 @@ class XtendReferenceFinder extends ReferenceFinder {
 			XImportDeclaration case sourceCandidate.static && !sourceCandidate.wildcard: {
 				addReferenceToFeatureFromStaticImport(sourceCandidate, targetURIs, acceptor)
 			} 
-			XFeatureCall case sourceCandidate.actualReceiver == null && sourceCandidate.static: {
+			XFeatureCall case sourceCandidate.actualReceiver === null && sourceCandidate.static: {
 				addReferenceToTypeFromStaticImport(sourceCandidate, targetURIs, acceptor)
 			}
 			XMemberFeatureCall: { 

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/formatting2/RichStringFormatter.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/formatting2/RichStringFormatter.xtend
@@ -62,7 +62,7 @@ import static org.eclipse.xtext.formatting2.FormatterPreferenceKeys.*
 	val extension ITextRegionExtensions
 
 	def dispatch void format(RichString richString, IFormattableDocument doc) {
-		if (EcoreUtil2.getContainerOfType(richString.eContainer, RichString) != null)
+		if (EcoreUtil2.getContainerOfType(richString.eContainer, RichString) !== null)
 			return;
 		if (richString.regionForEObject.hasSyntaxError)
 			return;
@@ -115,7 +115,7 @@ import static org.eclipse.xtext.formatting2.FormatterPreferenceKeys.*
 		// TODO: remove if https://bugs.eclipse.org/bugs/show_bug.cgi?id=465299 gets fixed 
 		val i = region.node.getAsTreeIterable().iterator();
 		while (i.hasNext()) {
-			if (i.next().getSyntaxErrorMessage() != null)
+			if (i.next().getSyntaxErrorMessage() !== null)
 				return true;
 		}
 		return false;
@@ -160,7 +160,7 @@ import static org.eclipse.xtext.formatting2.FormatterPreferenceKeys.*
 	}
 
 	def protected dispatch  void suppressLineWraps(IHiddenRegionFormatting it) {
-		if (space == null)
+		if (space === null)
 			space = " "
 		it.newLinesMin = null
 		newLinesDefault = null
@@ -267,7 +267,7 @@ class RichStringToLineModel extends AbstractRichStringPartAcceptor.ForLoopOnce {
 		if (lastLiteralEndOffset > 0 && contentStartOffset < 0)
 			contentStartOffset = lastLiteralEndOffset
 		val node = nodeModelAccess.regionForEObject(object)?.regionFor?.feature(XbasePackage.Literals.XSTRING_LITERAL__VALUE)
-		if (node != null) {
+		if (node !== null) {
 			offset = node.offset + node.literalPrefixLenght
 			lastLiteralEndOffset = node.endOffset - node.literalPostfixLenght
 		}

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/formatting2/XtendFormatter.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/formatting2/XtendFormatter.xtend
@@ -47,10 +47,10 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 	def dispatch void format(XtendFile xtendFile, extension IFormattableDocument format) {
 		xtendFile.prepend[noSpace]
 		val pkg = xtendFile.regionFor.feature(XTEND_FILE__PACKAGE)
-		if(pkg != null) {
+		if(pkg !== null) {
 			pkg.prepend[oneSpace]
 			val pkgSemicolon = pkg.immediatelyFollowing.keyword(";")
-			if (pkgSemicolon != null) {
+			if (pkgSemicolon !== null) {
 				pkg.append[noSpace]
 				pkgSemicolon.append(blankLinesAfterPackageDecl)
 			} else {
@@ -211,7 +211,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 		val close = func.regionFor.keyword(")")
 		func.returnType.append[oneSpace]
 		open.prepend[noSpace]
-		if (func.expression != null)
+		if (func.expression !== null)
 			close.append(bracesInNewLine)
 		formatCommaSeparatedList(func.parameters, open, close, format)
 		func.returnType.format
@@ -221,7 +221,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 	def dispatch void format(XtendField field, extension IFormattableDocument document) {
 		formatAnnotations(field, document, newLineAfterFieldAnnotations)
 		formatModifiers(field, document)
-		if (field.name != null)
+		if (field.name !== null)
 			field.type.append[oneSpace]
 		field.regionFor.keyword("=").prepend[oneSpace].append[oneSpace]
 		field.type.format
@@ -261,7 +261,7 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
 	}
 
 	override protected builder(List<XExpression> params) {
-		if (params.last != null) {
+		if (params.last !== null) {
 			val grammarElement = params.last.grammarElement
 			if (grammarElement == XMemberFeatureCallAccess.memberCallArgumentsXClosureParserRuleCall_1_1_4_0 ||
 				grammarElement == XFeatureCallAccess.featureCallArgumentsXClosureParserRuleCall_4_0 ||

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/javaconverter/ASTFlattenerUtils.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/javaconverter/ASTFlattenerUtils.xtend
@@ -67,8 +67,8 @@ class ASTFlattenerUtils {
 			return true
 		}
 		val iMethodBinding = declaration.resolveBinding
-		if (iMethodBinding != null) {
-			return findOverride(iMethodBinding, iMethodBinding.declaringClass) != null
+		if (iMethodBinding !== null) {
+			return findOverride(iMethodBinding, iMethodBinding.declaringClass) !== null
 		}
 		return false
 	}
@@ -80,13 +80,13 @@ class ASTFlattenerUtils {
 	def IMethodBinding findOverride(IMethodBinding method, ITypeBinding type, boolean onlyPrimarylevel) {
 		val superclass = type.superclass
 		var IMethodBinding overridden = null
-		if (superclass != null) {
+		if (superclass !== null) {
 			overridden = internalFindOverride(method, superclass, onlyPrimarylevel)
 		}
-		if (overridden == null) {
+		if (overridden === null) {
 			for (ITypeBinding interfaze : type.interfaces) {
 				overridden = internalFindOverride(method, interfaze, onlyPrimarylevel)
-				if (overridden != null) {
+				if (overridden !== null) {
 					return overridden
 				}
 			}
@@ -144,7 +144,7 @@ class ASTFlattenerUtils {
 	}
 
 	def private boolean isStaticBinding(IBinding binding) {
-		if (binding != null) {
+		if (binding !== null) {
 			return Modifier.isStatic(binding.modifiers)
 		}
 		return false
@@ -168,13 +168,13 @@ class ASTFlattenerUtils {
 
 	def isLambdaCase(ClassInstanceCreation creation) {
 		val anonymousClazz = creation.anonymousClassDeclaration
-		if (anonymousClazz != null && anonymousClazz.bodyDeclarations.size == 1) {
+		if (anonymousClazz !== null && anonymousClazz.bodyDeclarations.size == 1) {
 			val declaredMethod = anonymousClazz.bodyDeclarations.get(0)
-			if (declaredMethod instanceof MethodDeclaration && creation.type.resolveBinding != null) {
+			if (declaredMethod instanceof MethodDeclaration && creation.type.resolveBinding !== null) {
 				val methodBinding = (declaredMethod as MethodDeclaration).resolveBinding
-				if (methodBinding != null) {
+				if (methodBinding !== null) {
 					val overrides = findOverride(methodBinding, methodBinding.declaringClass, true)
-					return overrides != null && Modifier.isAbstract(overrides.modifiers)
+					return overrides !== null && Modifier.isAbstract(overrides.modifiers)
 				}
 			}
 		}
@@ -182,7 +182,7 @@ class ASTFlattenerUtils {
 	}
 
 	def boolean needsReturnValue(ASTNode node) {
-		(node.parent != null) && (!(node.parent instanceof Statement) || (node.parent instanceof ReturnStatement))
+		(node.parent !== null) && (!(node.parent instanceof Statement) || (node.parent instanceof ReturnStatement))
 	}
 
 	def boolean isConstantArrayIndex(Expression node) {
@@ -191,7 +191,7 @@ class ASTFlattenerUtils {
 
 	def boolean canConvertToRichText(InfixExpression node) {
 		val parentFieldDecl = node.findParentOfType(FieldDeclaration)
-		if (parentFieldDecl != null) {
+		if (parentFieldDecl !== null) {
 			val typeDeclr = parentFieldDecl.findParentOfType(TypeDeclaration)
 
 			// Do not convert static final fields
@@ -203,7 +203,7 @@ class ASTFlattenerUtils {
 	}
 
 	def <T extends ASTNode> T findParentOfType(ASTNode someNode, Class<T> parentType) {
-		if (someNode.parent == null) {
+		if (someNode.parent === null) {
 			return null
 		} else if (parentType.isInstance(someNode.parent)) {
 			return parentType.cast(someNode.parent)
@@ -241,9 +241,9 @@ class ASTFlattenerUtils {
 
 	def Type findDeclaredType(SimpleName simpleName) {
 		var ASTNode scope = simpleName.findDeclarationBlocks
-		while (scope != null) {
+		while (scope !== null) {
 			val type = scope.findDeclaredType(simpleName)
-			if (type != null) {
+			if (type !== null) {
 				return type
 			}
 			scope = scope.findDeclarationBlocks
@@ -301,7 +301,7 @@ class ASTFlattenerUtils {
 
 	def Iterable<Expression> findAssignmentsInBlock(Block scope, (Expression)=>Boolean constraint) {
 		val assigments = newHashSet()
-		if (scope != null) {
+		if (scope !== null) {
 			scope.accept(new ASTVisitor() {
 				override visit(Assignment node) {
 					if (constraint.apply(node)) {
@@ -368,7 +368,7 @@ class ASTFlattenerUtils {
 					simpleName = operand
 			}
 			if (simpleName instanceof SimpleName) {
-				return simpleName != null && nameToLookFor.identifier.equals(simpleName.identifier)
+				return simpleName !== null && nameToLookFor.identifier.equals(simpleName.identifier)
 			}
 			return false
 		]).empty
@@ -385,7 +385,7 @@ class ASTFlattenerUtils {
 	def genericChildListProperty(ASTNode node, String propertyName) {
 		val property = node.structuralPropertiesForType.filter(ChildListPropertyDescriptor).filter[propertyName == id].
 			head
-		if (property != null) {
+		if (property !== null) {
 			return node.getStructuralProperty(property) as List<ASTNode>
 		}
 		return null
@@ -401,7 +401,7 @@ class ASTFlattenerUtils {
 
 	def genericChildProperty(ASTNode node, String propertyName) {
 		val property = node.structuralPropertiesForType.filter(ChildPropertyDescriptor).filter[propertyName == id].head
-		if (property != null) {
+		if (property !== null) {
 			return node.getStructuralProperty(property) as ASTNode
 		}
 		return null

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/javaconverter/JavaASTFlattener.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/javaconverter/JavaASTFlattener.xtend
@@ -190,7 +190,7 @@ class JavaASTFlattener extends ASTVisitor {
 	def appendModifiers(ASTNode node, Iterable<IExtendedModifier> ext, (ASTNode)=>StringBuffer callBack) {
 		val appender = [IExtendedModifier p|(p as ASTNode).accept(this)]
 		ext.filter[isAnnotation && (it as Annotation).typeName.toString != "Override"].forEach(appender)
-		if (callBack != null) {
+		if (callBack !== null) {
 			callBack.apply(node)
 		}
 		ext.filter[isModifier && (it as Modifier).keyword.toString != "default"].forEach(appender)
@@ -307,7 +307,7 @@ class JavaASTFlattener extends ASTVisitor {
 	}
 
 	override visit(PackageDeclaration it) {
-		if (javadoc != null) {
+		if (javadoc !== null) {
 			javadoc.accept(this)
 		}
 		annotations.visitAll(" ")
@@ -356,7 +356,7 @@ class JavaASTFlattener extends ASTVisitor {
 	}
 
 	override visit(Initializer it) {
-		if (javadoc != null) {
+		if (javadoc !== null) {
 			javadoc.accept(this)
 		}
 		appendModifiers(modifiers())
@@ -396,7 +396,7 @@ class JavaASTFlattener extends ASTVisitor {
 			addProblem("Non-static inner classes are not supported.")
 		}
 
-		if (javadoc != null) {
+		if (javadoc !== null) {
 			javadoc.accept(this)
 		}
 		appendModifiers(modifiers())
@@ -414,7 +414,7 @@ class JavaASTFlattener extends ASTVisitor {
 			typeParameters.appendTypeParameters
 		}
 		appendSpaceToBuffer
-		if (getSuperclassType() != null) {
+		if (getSuperclassType() !== null) {
 			appendToBuffer("extends ")
 			getSuperclassType.accept(this)
 			appendSpaceToBuffer
@@ -455,7 +455,7 @@ class JavaASTFlattener extends ASTVisitor {
 	}
 
 	def private Iterable<Comment> unAssignedComments(CompilationUnit cu) {
-		cu.commentList.filter[Comment c|!(c.docComment && c.parent != null) && c.notAssigned]
+		cu.commentList.filter[Comment c|!(c.docComment && c.parent !== null) && c.notAssigned]
 	}
 
 	override visit(Javadoc it) {
@@ -522,7 +522,7 @@ class JavaASTFlattener extends ASTVisitor {
 	}
 
 	override visit(FieldDeclaration it) {
-		if (javadoc != null) {
+		if (javadoc !== null) {
 			javadoc.accept(this)
 		}
 		fragments.forEach [ VariableDeclarationFragment frag |
@@ -561,7 +561,7 @@ class JavaASTFlattener extends ASTVisitor {
 
 	override visit(VariableDeclarationFragment it) {
 		name.accept(this)
-		if (getInitializer() != null) {
+		if (getInitializer() !== null) {
 			appendToBuffer("=")
 			val type = findDeclaredType(name)
 			if (type.needPrimitiveCast && !hasDimensions(it)) {
@@ -652,7 +652,7 @@ class JavaASTFlattener extends ASTVisitor {
 	def visitAll(Iterable<? extends ASTNode> iterable, String separator) {
 		iterable.forEach [ ASTNode node, counter |
 			node.accept(this)
-			if (separator != null && counter < iterable.size - 1) {
+			if (separator !== null && counter < iterable.size - 1) {
 				appendToBuffer(separator)
 			}
 		]
@@ -667,7 +667,7 @@ class JavaASTFlattener extends ASTVisitor {
 	}
 
 	override visit(MethodDeclaration it) {
-		if (javadoc != null) {
+		if (javadoc !== null) {
 			javadoc.accept(this)
 		}
 		val afterAnnotationProcessingCallback = [ ASTNode node |
@@ -699,7 +699,7 @@ class JavaASTFlattener extends ASTVisitor {
 			typeParameters.appendTypeParameters
 		}
 		if (!isConstructor()) {
-			if (getReturnType2() != null) {
+			if (getReturnType2() !== null) {
 				getReturnType2.accept(this)
 			} else {
 				appendToBuffer("void")
@@ -745,7 +745,7 @@ class JavaASTFlattener extends ASTVisitor {
 			throwsTypes.visitAllSeparatedByComma
 		}
 		appendSpaceToBuffer
-		if (getBody() != null) {
+		if (getBody() !== null) {
 			getBody.accept(this)
 		} else {
 			appendLineWrapToBuffer
@@ -767,7 +767,7 @@ class JavaASTFlattener extends ASTVisitor {
 		}
 		appendSpaceToBuffer
 		name.accept(this)
-		if (getInitializer() != null) {
+		if (getInitializer() !== null) {
 			appendToBuffer("=")
 			getInitializer.accept(this)
 		}
@@ -775,7 +775,7 @@ class JavaASTFlattener extends ASTVisitor {
 	}
 
 	override boolean visit(ClassInstanceCreation node) {
-		if (node.getExpression() != null) {
+		if (node.getExpression() !== null) {
 			node.getExpression().accept(this)
 			appendToBuffer(".")
 		}
@@ -816,7 +816,7 @@ class JavaASTFlattener extends ASTVisitor {
 				}
 			}
 			appendToBuffer(")")
-			if (node.getAnonymousClassDeclaration() != null) {
+			if (node.getAnonymousClassDeclaration() !== null) {
 				node.getAnonymousClassDeclaration().accept(this)
 			}
 		}
@@ -871,7 +871,7 @@ class JavaASTFlattener extends ASTVisitor {
 	}
 
 	override visit(MethodInvocation it) {
-		if (getExpression() != null) {
+		if (getExpression() !== null) {
 			getExpression.accept(this)
 			if (fallBackStrategy && isStaticMemberCall) {
 				appendToBuffer("::")
@@ -893,7 +893,7 @@ class JavaASTFlattener extends ASTVisitor {
 		appendToBuffer("for (")
 		initializers.visitAll
 		appendToBuffer("; ")
-		if (getExpression() != null) {
+		if (getExpression() !== null) {
 			getExpression.accept(this)
 		}
 		appendToBuffer("; ")
@@ -910,7 +910,7 @@ class JavaASTFlattener extends ASTVisitor {
 	}
 
 	override visit(ThisExpression it) {
-		if (getQualifier() != null) {
+		if (getQualifier() !== null) {
 			getQualifier.accept(this)
 			appendToBuffer(".")
 		}
@@ -923,7 +923,7 @@ class JavaASTFlattener extends ASTVisitor {
 		node.getExpression().accept(this)
 		appendToBuffer(") ")
 		node.getThenStatement().accept(this)
-		if (node.getElseStatement() != null) {
+		if (node.getElseStatement() !== null) {
 			appendToBuffer(" else ")
 			node.getElseStatement().accept(this)
 		}
@@ -1026,7 +1026,7 @@ class JavaASTFlattener extends ASTVisitor {
 		}
 		if (expression instanceof SimpleName) {
 			val declType = findDeclaredType(expression)
-			if (declType != null) {
+			if (declType !== null) {
 				switch declType {
 					case declType.isPrimitiveType: {
 						return (declType as PrimitiveType).getPrimitiveTypeCode == PrimitiveType.BOOLEAN
@@ -1068,7 +1068,7 @@ class JavaASTFlattener extends ASTVisitor {
 
 	override boolean visit(ReturnStatement node) {
 		appendToBuffer("return")
-		if (node.getExpression() != null) {
+		if (node.getExpression() !== null) {
 			appendSpaceToBuffer
 			node.getExpression().accept(this)
 			appendSpaceToBuffer
@@ -1083,7 +1083,7 @@ class JavaASTFlattener extends ASTVisitor {
 	}
 
 	override visit(BlockComment node) {
-		if (javaSources != null) {
+		if (javaSources !== null) {
 			appendToBuffer(node.commentContent)
 			if(node.shouldWrap) appendLineWrapToBuffer
 		}
@@ -1105,7 +1105,7 @@ class JavaASTFlattener extends ASTVisitor {
 	}
 
 	override boolean visit(LineComment node) {
-		if (javaSources != null) {
+		if (javaSources !== null) {
 			appendToBuffer(node.commentContent)
 		}
 		appendLineWrapToBuffer
@@ -1232,7 +1232,7 @@ class JavaASTFlattener extends ASTVisitor {
 	}
 
 	@Override override boolean visit(SuperConstructorInvocation node) {
-		if (node.getExpression() != null) {
+		if (node.getExpression() !== null) {
 			node.getExpression().accept(this)
 			appendToBuffer(".")
 		}
@@ -1246,7 +1246,7 @@ class JavaASTFlattener extends ASTVisitor {
 	}
 
 	@Override override boolean visit(SuperFieldAccess node) {
-		if (node.getQualifier() != null) {
+		if (node.getQualifier() !== null) {
 			node.getQualifier().accept(this)
 			appendToBuffer(".")
 		}
@@ -1256,7 +1256,7 @@ class JavaASTFlattener extends ASTVisitor {
 	}
 
 	@Override override boolean visit(SuperMethodInvocation node) {
-		if (node.getQualifier() != null) {
+		if (node.getQualifier() !== null) {
 			node.getQualifier().accept(this)
 			appendToBuffer(".")
 		}
@@ -1280,7 +1280,7 @@ class JavaASTFlattener extends ASTVisitor {
 		}
 
 		var boolean previousRequiresWhiteSpace = false
-		if (node.getTagName() != null) {
+		if (node.getTagName() !== null) {
 			appendToBuffer(node.getTagName())
 			previousRequiresWhiteSpace = true
 		}
@@ -1344,7 +1344,7 @@ class JavaASTFlattener extends ASTVisitor {
 		node.getBody().accept(this)
 		node.catchClauses.forEach[(it as ASTNode).accept(this)]
 
-		if (node.getFinally() != null) {
+		if (node.getFinally() !== null) {
 			appendToBuffer(" finally ")
 			node.getFinally().accept(this)
 		} else {
@@ -1405,7 +1405,7 @@ class JavaASTFlattener extends ASTVisitor {
 	override boolean visit(WildcardType node) {
 		appendToBuffer("?")
 		var Type bound = node.getBound()
-		if (bound != null) {
+		if (bound !== null) {
 			if (node.isUpperBound()) {
 				appendToBuffer(" extends ")
 			} else {
@@ -1433,7 +1433,7 @@ class JavaASTFlattener extends ASTVisitor {
 
 	/* Start self Converted part*/
 	@Override override boolean visit(AnnotationTypeDeclaration node) {
-		if (node.getJavadoc() != null) {
+		if (node.getJavadoc() !== null) {
 			node.getJavadoc().accept(this)
 		}
 		appendModifiers(node, node.modifiers())
@@ -1447,14 +1447,14 @@ class JavaASTFlattener extends ASTVisitor {
 	}
 
 	@Override override boolean visit(AnnotationTypeMemberDeclaration node) {
-		if (node.getJavadoc() != null) {
+		if (node.getJavadoc() !== null) {
 			node.getJavadoc().accept(this)
 		}
 		appendModifiers(node, node.modifiers())
 		node.getType().accept(this)
 		appendSpaceToBuffer
 		node.getName().accept(this)
-		if (node.getDefault() != null) {
+		if (node.getDefault() !== null) {
 			appendToBuffer(" = ")
 			node.getDefault().accept(this)
 		}
@@ -1512,7 +1512,7 @@ class JavaASTFlattener extends ASTVisitor {
 			node.addProblem("Only one dimension arrays are supported.")
 			return false
 		}
-		if (node.getInitializer() != null) {
+		if (node.getInitializer() !== null) {
 			if(fallBackStrategy) appendToBuffer('(')
 			node.getInitializer().accept(this)
 			if (fallBackStrategy) {
@@ -1561,7 +1561,7 @@ class JavaASTFlattener extends ASTVisitor {
 		node.getExpression().accept(this)
 		appendToBuffer(")) {")
 		appendToBuffer("throw new AssertionError(")
-		if (node.getMessage() != null) {
+		if (node.getMessage() !== null) {
 			node.getMessage().accept(this)
 		}
 		appendToBuffer(")}")
@@ -1571,7 +1571,7 @@ class JavaASTFlattener extends ASTVisitor {
 	@Override override boolean visit(BreakStatement node) {
 		appendToBuffer('''/* FIXME Unsupported BreakStatement */ break''')
 		node.addProblem("Break statement is not supported")
-		if (node.getLabel() != null) {
+		if (node.getLabel() !== null) {
 			appendSpaceToBuffer
 			node.getLabel().accept(this)
 		}
@@ -1611,7 +1611,7 @@ class JavaASTFlattener extends ASTVisitor {
 	@Override override boolean visit(ContinueStatement node) {
 		appendToBuffer("/* FIXME Unsupported continue statement */ continue")
 		node.addProblem("Continue statement is not supported")
-		if (node.getLabel() != null) {
+		if (node.getLabel() !== null) {
 			appendSpaceToBuffer
 			node.getLabel().accept(this)
 		}
@@ -1645,7 +1645,7 @@ class JavaASTFlattener extends ASTVisitor {
 	}
 
 	@Override override boolean visit(EnumConstantDeclaration node) {
-		if (node.getJavadoc() != null) {
+		if (node.getJavadoc() !== null) {
 			node.getJavadoc().accept(this)
 		}
 		appendModifiers(node, node.modifiers())
@@ -1656,7 +1656,7 @@ class JavaASTFlattener extends ASTVisitor {
 			visitAllSeparatedByComma(node.arguments())
 			appendToBuffer(")")
 		}
-		if (node.getAnonymousClassDeclaration() != null) {
+		if (node.getAnonymousClassDeclaration() !== null) {
 			node.addProblem("Enum constant cannot have any anonymous class declarations")
 			node.getAnonymousClassDeclaration().accept(this)
 		}
@@ -1664,7 +1664,7 @@ class JavaASTFlattener extends ASTVisitor {
 	}
 
 	@Override override boolean visit(EnumDeclaration node) {
-		if (node.getJavadoc() != null) {
+		if (node.getJavadoc() !== null) {
 			node.getJavadoc().accept(this)
 		}
 		appendModifiers(node, node.modifiers())
@@ -1706,7 +1706,7 @@ class JavaASTFlattener extends ASTVisitor {
 	}
 
 	@Override override boolean visit(MemberRef node) {
-		if (node.getQualifier() != null) {
+		if (node.getQualifier() !== null) {
 			node.getQualifier().accept(this)
 		}
 		appendToBuffer("#")
@@ -1715,7 +1715,7 @@ class JavaASTFlattener extends ASTVisitor {
 	}
 
 	@Override override boolean visit(MethodRef node) {
-		if (node.getQualifier() != null) {
+		if (node.getQualifier() !== null) {
 			node.getQualifier().accept(this)
 		}
 		appendToBuffer("#")
@@ -1731,7 +1731,7 @@ class JavaASTFlattener extends ASTVisitor {
 		if (node.isVarargs()) {
 			appendToBuffer("...")
 		}
-		if (node.getName() != null) {
+		if (node.getName() !== null) {
 			appendSpaceToBuffer
 			node.getName().accept(this)
 		}

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/javaconverter/JavaConverter.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/javaconverter/JavaConverter.xtend
@@ -47,7 +47,7 @@ class JavaConverter {
 	 * @throws IllegalArgumentException if unitName is <code>null</code> 
 	 */
 	def ConversionResult toXtend(String unitName, String javaSrc) {
-		if (unitName == null)
+		if (unitName === null)
 			throw new IllegalArgumentException()
 		internalToXtend(unitName, javaSrc, null, astParserFactory.createJavaParser(null))
 	}
@@ -60,7 +60,7 @@ class JavaConverter {
 	 * @throws IllegalArgumentException if unitName is <code>null</code> 
 	 */
 	def ConversionResult toXtend(String unitName, String javaSrc, Object classPathContext) {
-		if (unitName == null)
+		if (unitName === null)
 			throw new IllegalArgumentException()
 		internalToXtend(unitName, javaSrc, null, astParserFactory.createJavaParser(classPathContext))
 	}
@@ -139,10 +139,10 @@ class JavaConverter {
 	def private ConversionResult internalToXtend(String unitName, String javaSrc, String[] imports,
 		ASTParserWrapper parser) {
 		val javaSrcBuilder = new StringBuilder()
-		if (imports != null) {
+		if (imports !== null) {
 			imports.forEach[javaSrcBuilder.append("import " + it + ";")]
 		}
-		if (unitName == null) {
+		if (unitName === null) {
 			parser.unitName = "MISSING"
 			javaSrcBuilder.append('''class MISSING { «javaSrc» }''')
 		} else {
@@ -192,7 +192,7 @@ class JavaConverter {
 		def static create(JavaASTFlattener flattener) {
 			val result = new ConversionResult
 			result.xtendCode = flattener.result
-			if (flattener.problems != null)
+			if (flattener.problems !== null)
 				result.problems = flattener.problems
 			return result
 		}

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/ActiveAnnotationContext.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/ActiveAnnotationContext.xtend
@@ -74,7 +74,7 @@ class ActiveAnnotationContexts extends AdapterImpl {
 	
 	def static ActiveAnnotationContexts installNew(Resource resource) {
 		var result = resource.eAdapters.filter(ActiveAnnotationContexts).head
-		if (result != null) {
+		if (result !== null) {
 			result.contexts.clear
 		} else {
 			result = new ActiveAnnotationContexts
@@ -124,7 +124,7 @@ class ActiveAnnotationContextProvider {
 					val processorType = key.getProcessorType
 					try {
 						val processorInstance = processorType.processorInstance
-						if (processorInstance == null) {
+						if (processorInstance === null) {
 							throw new IllegalStateException("Couldn't instantiate the annotation processor of type '" + processorType.identifier + "'. This is usually the case when the processor resides in the same project as the annotated element.");
 						}
 						fa.setProcessorInstance(processorInstance)
@@ -213,7 +213,7 @@ class ActiveAnnotationContextProvider {
 	def private void registerMacroAnnotations(XtendAnnotationTarget candidate, IAcceptor<Pair<JvmAnnotationType, XAnnotation>> acceptor) {
 		for (annotation : candidate.annotations.filter[ processed ]) {
 			val activeAnnotationDeclaration = annotation.tryFindAnnotationType
-			if (activeAnnotationDeclaration != null) {
+			if (activeAnnotationDeclaration !== null) {
 				if (isValid(annotation, activeAnnotationDeclaration)) {
 					acceptor.accept(activeAnnotationDeclaration -> annotation)
 				}
@@ -223,6 +223,6 @@ class ActiveAnnotationContextProvider {
 	
 	def private boolean isValid(XAnnotation annotation, JvmAnnotationType activeAnnotationDeclaration) {
 		//TODO validate the annotationTarget against the annotation processor (compatible types, etc.)
-		return annotation != null
+		return annotation !== null
 	}
 }

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/CompilationContextImpl.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/CompilationContextImpl.xtend
@@ -34,7 +34,7 @@ class CompilationContextImpl implements CompilationStrategy.CompilationContext {
 	}
 
 	override toJavaCode(TypeReference typeref) {
-		val appendable = if (importManager != null) {
+		val appendable = if (importManager !== null) {
 				new StringBuilderBasedAppendable(importManager)
 			} else {
 				new StringBuilderBasedAppendable()

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/ConditionUtils.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/ConditionUtils.xtend
@@ -17,22 +17,22 @@ import org.eclipse.emf.ecore.EObject
 class ConditionUtils {
 	
 	static def notRemoved(EObject object, String name) {
-		Preconditions.checkArgument(object != null, '''«name» cannot be null''')
-		Preconditions.checkArgument(object.eResource != null, '''«name» cannot be removed''')
+		Preconditions.checkArgument(object !== null, '''«name» cannot be null''')
+		Preconditions.checkArgument(object.eResource !== null, '''«name» cannot be removed''')
 	}
 	
 	static def checkInferredTypeReferences(String typeName, TypeReference ... types) {
 		for (type : types) {
-			if (type != null && type.inferred) {
+			if (type !== null && type.inferred) {
 				throw new IllegalArgumentException('''Cannot use inferred type as «typeName».''')
 			}
 		}
 	}
 
 	static def checkIterable(Iterable<?> values, String name) {
-		Preconditions.checkArgument(values != null, '''«name» cannot be null''')
+		Preconditions.checkArgument(values !== null, '''«name» cannot be null''')
 		for (value : values) {
-			Preconditions.checkArgument(value != null, '''«name» cannot contain null''')
+			Preconditions.checkArgument(value !== null, '''«name» cannot contain null''')
 		}
 	}
 
@@ -51,7 +51,7 @@ class ConditionUtils {
 	static def String isNotApplicableMessage(String valueType, String typeName) '''«valueType» is not applicable at this location. Expected «typeName»'''
 
 	static def isValidQualifiedName(String string) {
-		if (string == null || string.length == 0) {
+		if (string === null || string.length == 0) {
 			return false
 		}
 		for (identifier : string.split("\\.")) {
@@ -63,7 +63,7 @@ class ConditionUtils {
 	}
 
 	static def isValidJavaIdentifier(String string) {
-		if (string == null || string.length == 0) {
+		if (string === null || string.length == 0) {
 			return false
 		}
 		val charArray = string.toCharArray

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/ConstantExpressionsInterpreter.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/ConstantExpressionsInterpreter.xtend
@@ -109,11 +109,11 @@ class ConstantExpressionsInterpreter extends AbstractConstantExpressionsInterpre
 		cache.get('visibleFeaturesForAnnotationValues'->container, expression.eResource) [
 			val result = newHashMap
 			val section = importSectionLocator.getImportSection(expression.eResource as XtextResource)
-			if(section != null) {
+			if(section !== null) {
 				for (imp : section.importDeclarations) {
 					if(imp.static) {
 						val importedTypeName = imp.importedTypeName
-						if (importedTypeName != null) {
+						if (importedTypeName !== null) {
 							val type = imp.findTypeByName(importedTypeName)
 							switch type {
 								JvmGenericType: {
@@ -137,7 +137,7 @@ class ConstantExpressionsInterpreter extends AbstractConstantExpressionsInterpre
 	}
 	
 	protected def void collectAllVisibleFields(JvmDeclaredType type, Map<String, JvmIdentifiableElement> result) {
-		if (type == null) {
+		if (type === null) {
 			return;
 		}
 		collectAllVisibleFields(type.declaringType, result)
@@ -158,7 +158,7 @@ class ConstantExpressionsInterpreter extends AbstractConstantExpressionsInterpre
 					if (member instanceof JvmField) {
 						if (member.final && member.static) {
 							val existing = result.put(member.simpleName, member)
-							if (existing != null) {
+							if (existing !== null) {
 								result.put(existing.simpleName, existing)
 							}
 						}
@@ -187,7 +187,7 @@ class ConstantExpressionsInterpreter extends AbstractConstantExpressionsInterpre
 	}
 
 	def dispatch Object internalEvaluate(XNumberLiteral it, Context ctx) {
-		val type = if (ctx.expectedType == null)
+		val type = if (ctx.expectedType === null)
 			javaType
 		else 
 			getJavaType(ctx.expectedType.type,ctx.classFinder) as Class<? extends Number>
@@ -204,7 +204,7 @@ class ConstantExpressionsInterpreter extends AbstractConstantExpressionsInterpre
 		val elements = it.elements.map[
 			evaluate(ctx.cloneWithExpectation(expectedComponentType))
 		]
-		val Class<?> componentType = if (expectedComponentType != null) {
+		val Class<?> componentType = if (expectedComponentType !== null) {
 				expectedComponentType.type.getJavaType(ctx.classFinder)
 			} else if(!elements.empty) {
 				switch cl : elements.head.class {
@@ -244,7 +244,7 @@ class ConstantExpressionsInterpreter extends AbstractConstantExpressionsInterpre
 			switch it: ctx.expectedType {
 				XComputedTypeReferenceImplCustom case equivalentComputed: type
 				XComputedTypeReference,
-				case it == null: null
+				case it === null: null
 				default: type
 			}
 		}
@@ -274,7 +274,7 @@ class ConstantExpressionsInterpreter extends AbstractConstantExpressionsInterpre
 			}
 		}
 		val type = findTypeByName(featureName)
-		if (type != null) {
+		if (type !== null) {
 			resolveType(type)
 			return toTypeReference(type, 0)
 		}
@@ -321,7 +321,7 @@ class ConstantExpressionsInterpreter extends AbstractConstantExpressionsInterpre
 					switch type : receiver.type {
 						JvmEnumerationType : {
 							val enumValue = type.literals.findFirst[simpleName==featureName]
-							if (enumValue == null) {
+							if (enumValue === null) {
 								throw new ConstantExpressionEvaluationException("Couldn't find enum value "+featureName+" on enum "+receiver.simpleName, it)
 							}
 							resolveFeature(enumValue)
@@ -329,7 +329,7 @@ class ConstantExpressionsInterpreter extends AbstractConstantExpressionsInterpre
 						}
 						JvmGenericType : {
 							val field = type.allFeatures.filter(JvmField).findFirst[simpleName==featureName]
-							if (field == null) {
+							if (field === null) {
 								throw new ConstantExpressionEvaluationException("Couldn't find field "+featureName+" on type "+receiver.simpleName, it)
 							}
 							resolveFeature(field)
@@ -342,7 +342,7 @@ class ConstantExpressionsInterpreter extends AbstractConstantExpressionsInterpre
 		} catch (UnresolvableFeatureException e) {
 			val typeName = fullName
 			val type = findTypeByName(typeName)
-			if (type != null) {
+			if (type !== null) {
 				resolveType(type)
 				return toTypeReference(type, 0)
 			} else {

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/FileLocationsImpl.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/FileLocationsImpl.xtend
@@ -40,12 +40,12 @@ class FileLocationsImpl implements FileLocations {
 
 	override Path getTargetFolder(Path path) {
 		val projectFolder = getProjectFolder(path)
-		if (projectFolder == null) {
+		if (projectFolder === null) {
 		 return null
 		}
 		val outputConfiguration = outputConfigurationProvider.getOutputConfigurations(context).head
 		val sourceFolder = getSourceFolder(path)
-		val outputFolder = if (sourceFolder == null) {
+		val outputFolder = if (sourceFolder === null) {
 			outputConfiguration.outputDirectory
 		} else {
 			val projectRelativeSourceFolder = sourceFolder.segments.tail.join('/')

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/ProcessorInstanceForJvmTypeProvider.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/ProcessorInstanceForJvmTypeProvider.xtend
@@ -42,7 +42,7 @@ class ProcessorInstanceForJvmTypeProvider {
 		}
 		
 		override setTarget(Notifier newTarget) {
-			if (newTarget==null) {
+			if (newTarget===null) {
 				discard()
 			}
 		}
@@ -77,7 +77,7 @@ class ProcessorInstanceForJvmTypeProvider {
 	def protected getClassLoader(EObject ctx) {
 		val resourceSet = ctx.eResource.resourceSet
 		val adapter = resourceSet.eAdapters.filter(ProcessorClassloaderAdapter).head
-		if (adapter != null) {
+		if (adapter !== null) {
 			return adapter.getClassLoader
 		}
 		switch resourceSet {
@@ -98,7 +98,7 @@ class ProcessorInstanceForJvmTypeProvider {
 				} else {
 					jvmTypeLoader
 				}
-				if (processorClassLoader != null) {
+				if (processorClassLoader !== null) {
 					resourceSet.eAdapters += new ProcessorClassloaderAdapter(processorClassLoader)
 					return processorClassLoader
 				}

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/RegisterGlobalsContextImpl.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/RegisterGlobalsContextImpl.xtend
@@ -56,14 +56,14 @@ class RegisterGlobalsContextImpl implements RegisterGlobalsContext {
 	
 	private def void setNameAndAccept(JvmDeclaredType newType, String qualifiedName) {
 		checkQualifiedName(qualifiedName, "qualifiedName")
-		Preconditions.checkArgument(qualifiedName.findType == null, '''The type '«qualifiedName»' has already been registered.''');
+		Preconditions.checkArgument(qualifiedName.findType === null, '''The type '«qualifiedName»' has already been registered.''');
 		compilationUnit.checkCanceled
 		val namespaceAndName = getNameParts(qualifiedName)
 		val headerText = compilationUnit.fileHeaderProvider.getFileHeader(compilationUnit.xtendFile.eResource)
 		compilationUnit.jvmTypesBuilder.setFileHeader(newType, headerText)
-		if (namespaceAndName.key != null) {
+		if (namespaceAndName.key !== null) {
 			val parentType = findType(namespaceAndName.key)
-			if (parentType != null) {
+			if (parentType !== null) {
 				parentType.members += newType
 				newType.static = true
 			} else {
@@ -88,7 +88,7 @@ class RegisterGlobalsContextImpl implements RegisterGlobalsContext {
 			}
 			if (string.startsWith(candidateQualifiedName)) {
 				val result = findRecursively(string, type.members.filter(JvmDeclaredType))
-				if (result != null)
+				if (result !== null)
 					return result
 			}
 		}

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/XAnnotationExtensions.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/XAnnotationExtensions.xtend
@@ -95,7 +95,7 @@ class XAnnotationExtensions {
 		]
 		val annoVal = activeAnnotation.values.findFirst [
 			// identifier 'value' is optional
-			operation == null || operation.simpleName == 'value'
+			operation === null || operation.simpleName == 'value'
 		]
 		switch annoVal {
 			JvmTypeAnnotationValue : {

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/AnnotationReferenceBuildContextImpl.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/AnnotationReferenceBuildContextImpl.xtend
@@ -55,7 +55,7 @@ class AnnotationReferenceBuildContextImpl implements AnnotationReferenceBuildCon
 
 		val annotationType = delegate.annotation
 		val jvmOperation = annotationType.declaredOperations.findFirst[simpleName == name]
-		if (jvmOperation == null) {
+		if (jvmOperation === null) {
 			throw new IllegalArgumentException('''The annotation property '«name»' is not declared on the annotation type '«annotationType.identifier»'.''')
 		}
 		return jvmOperation
@@ -67,7 +67,7 @@ class AnnotationReferenceBuildContextImpl implements AnnotationReferenceBuildCon
 	}
 	
 	protected def remove(JvmOperation op) {
-		return Iterators.removeIf(delegate.explicitValues.iterator) [ op == operation || (operation == null && op.simpleName == 'value') ]
+		return Iterators.removeIf(delegate.explicitValues.iterator) [ op == operation || (operation === null && op.simpleName == 'value') ]
 	}
 	
 	protected def findOperation(String name, boolean mustBeArray) {
@@ -306,7 +306,7 @@ class AnnotationReferenceBuildContextImpl implements AnnotationReferenceBuildCon
 	}
 	
 	protected def dispatch void setValue(JvmAnnotationValue it, Object value, String componentType, boolean mustBeArray) {
-		if (componentType == null) {
+		if (componentType === null) {
 			throwNotApplicable(value.class.name)
 		}
 		if (mustBeArray || operation.returnType?.type?.eClass == TypesPackage.Literals.JVM_ARRAY_TYPE) {
@@ -470,7 +470,7 @@ class AnnotationReferenceBuildContextImpl implements AnnotationReferenceBuildCon
 	}
 	
 	protected def checkType(JvmAnnotationValue it, String componentType, boolean mustBeArray) {
-		if (componentType == null) {
+		if (componentType === null) {
 			return
 		}
 		val returnType = operation.returnType?.type

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/AnnotationReferenceProviderImpl.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/AnnotationReferenceProviderImpl.xtend
@@ -50,10 +50,10 @@ class AnnotationReferenceProviderImpl implements AnnotationReferenceProvider {
 
 	override newAnnotationReference(String annotationTypeName, Procedure1<AnnotationReferenceBuildContext> initializer) {
 		checkCanceled
-		Preconditions.checkArgument(annotationTypeName != null, '''annotationTypeName cannot be null''')
-		Preconditions.checkArgument(initializer != null, '''initializer cannot be null''')
+		Preconditions.checkArgument(annotationTypeName !== null, '''annotationTypeName cannot be null''')
+		Preconditions.checkArgument(initializer !== null, '''initializer cannot be null''')
 		val jvmAnnotationReference = typeReferences.findDeclaredType(annotationTypeName, xtendFile).createJvmAnnotationReference
-		if (jvmAnnotationReference == null) {
+		if (jvmAnnotationReference === null) {
 			return null
 		}
 		val buildContext = new AnnotationReferenceBuildContextImpl => [
@@ -66,8 +66,8 @@ class AnnotationReferenceProviderImpl implements AnnotationReferenceProvider {
 
 	override newAnnotationReference(Type annotationTypeDelcaration, Procedure1<AnnotationReferenceBuildContext> initializer) {
 		checkCanceled
-		Preconditions.checkArgument(annotationTypeDelcaration != null, '''annotationTypeDelcaration cannot be null''')
-		Preconditions.checkArgument(initializer != null, '''initializer cannot be null''')
+		Preconditions.checkArgument(annotationTypeDelcaration !== null, '''annotationTypeDelcaration cannot be null''')
+		Preconditions.checkArgument(initializer !== null, '''initializer cannot be null''')
 		val type = switch annotationTypeDelcaration {
 			JvmAnnotationTypeDeclarationImpl: {
 				annotationTypeDelcaration.delegate
@@ -92,14 +92,14 @@ class AnnotationReferenceProviderImpl implements AnnotationReferenceProvider {
 	}
 
 	override newAnnotationReference(Class<?> annotationClass, Procedure1<AnnotationReferenceBuildContext> initializer) {
-		Preconditions.checkArgument(annotationClass != null, '''annotationClass cannot be null''')
+		Preconditions.checkArgument(annotationClass !== null, '''annotationClass cannot be null''')
 		annotationClass.name.newAnnotationReference(initializer)
 	}
 
 	override newAnnotationReference(AnnotationReference annotationReference, Procedure1<AnnotationReferenceBuildContext> initializer) {
 		checkCanceled
-		Preconditions.checkArgument(annotationReference != null, '''annotationReference cannot be null''')
-		Preconditions.checkArgument(initializer != null, '''initializer cannot be null''')
+		Preconditions.checkArgument(annotationReference !== null, '''annotationReference cannot be null''')
+		Preconditions.checkArgument(initializer !== null, '''initializer cannot be null''')
 		if (annotationReference instanceof JvmAnnotationReferenceImpl) {
 			val baseJvmAnnotationReference = annotationReference.delegate
 			baseJvmAnnotationReference.notRemoved("annotationReference")

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/CompilationUnitImpl.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/CompilationUnitImpl.xtend
@@ -214,9 +214,9 @@ class CompilationUnitImpl implements CompilationUnit {
 	MutableFileSystemSupport decoratedFileSystemSupport
 	
 	def MutableFileSystemSupport getFileSystemSupport() {
-		if (decoratedFileSystemSupport == null) {
+		if (decoratedFileSystemSupport === null) {
 			val fileSystemAccessQueue = xtendFile.eResource.resourceSet.eAdapters.filter(FileSystemAccessQueue).head
-			if (fileSystemAccessQueue == null) {
+			if (fileSystemAccessQueue === null) {
 				return createListeningFileSystemSupport()
 			}
 			decoratedFileSystemSupport = new ParallelFileSystemSupport(xtendFile.eResource.URI, createListeningFileSystemSupport(), fileSystemAccessQueue)
@@ -266,7 +266,7 @@ class CompilationUnitImpl implements CompilationUnit {
 
 	def private <IN, OUT> OUT getOrCreate(IN in, (IN)=>OUT provider) {
 		checkCanceled
-		if (in == null)
+		if (in === null)
 			return null
 		if (identityCache.containsKey(in))
 			return identityCache.get(in) as OUT
@@ -505,7 +505,7 @@ class CompilationUnitImpl implements CompilationUnit {
 	}
 
 	def TypeReference toTypeReference(JvmTypeReference delegate) {
-		if (delegate == null)
+		if (delegate === null)
 			return null
 		/*
 		 * We don't need to cache type references, as no mutable state
@@ -528,7 +528,7 @@ class CompilationUnitImpl implements CompilationUnit {
 	
 	def TypeReference toTypeReference(LightweightTypeReference delegate, JvmTypeReference source) {
 		checkCanceled
-		if (delegate == null)
+		if (delegate === null)
 			return null
 		new TypeReferenceImpl => [
 			it.delegate = delegate
@@ -740,7 +740,7 @@ class CompilationUnitImpl implements CompilationUnit {
 	}
 	
 	protected def translateAnnotationValue(Object value, JvmTypeReference expectedType, boolean isArray) {
-		if (value == null) {
+		if (value === null) {
 			return null
 		}
 		if (!isArray || value.class.array) { 
@@ -774,7 +774,7 @@ class CompilationUnitImpl implements CompilationUnit {
 	}
 	
 	protected def findExpectedType(JvmAnnotationValue value) {
-		if (value.operation != null) {
+		if (value.operation !== null) {
 			return value.operation.returnType
 		}
 		return switch container : value.eContainer {
@@ -783,7 +783,7 @@ class CompilationUnitImpl implements CompilationUnit {
 			}
 			JvmAnnotationReference : {
 				val defaultOp = container.annotation.findAllFeaturesByName('value').filter(JvmOperation).head
-				if (defaultOp != null) {
+				if (defaultOp !== null) {
 					defaultOp.returnType
 				}
 			}
@@ -859,13 +859,13 @@ class CompilationUnitImpl implements CompilationUnit {
 		]
 		for (valuePair : annotation.elementValuePairs) {
 			val value = valuePair.value
-			if (value != null) {
+			if (value !== null) {
 				val operation = valuePair.element
 				val annotationValue = value.translateAnnotationValue(operation.returnType)
 				buildContext.set(operation.simpleName, annotationValue)
 			}
 		}
-		if (annotation.value != null) {
+		if (annotation.value !== null) {
 			val annotationValue = annotation.value.translateAnnotationValue(null)
 			buildContext.set('value', annotationValue)
 		}

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/JvmAnnotationReferenceImpl.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/JvmAnnotationReferenceImpl.xtend
@@ -26,7 +26,7 @@ class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationReference> 
 	
 	override getExpression(String property) {
 		val op = findOperation(property)
-		val annotationValue = delegate.values.findFirst[ operation == op || (operation == null && op.simpleName == 'value') ]
+		val annotationValue = delegate.values.findFirst[ operation == op || (operation === null && op.simpleName == 'value') ]
 		switch annotationValue {
 			JvmCustomAnnotationValue : {
 				val expression = annotationValue.values.head as XExpression
@@ -40,9 +40,9 @@ class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationReference> 
 	override getValue(String property) {
 		try {
 			val op = findOperation(property)
-			val annotationValue = delegate.values.findFirst[ operation == op || (operation == null && op.simpleName == 'value') ]
-			val isArrayType = op!=null && compilationUnit.typeReferences.isArray(op.returnType)
-			if (annotationValue != null)
+			val annotationValue = delegate.values.findFirst[ operation == op || (operation === null && op.simpleName == 'value') ]
+			val isArrayType = op!==null && compilationUnit.typeReferences.isArray(op.returnType)
+			if (annotationValue !== null)
 				return compilationUnit.translateAnnotationValue(annotationValue, isArrayType)
 		} catch (ConstantExpressionEvaluationException e) {
 			compilationUnit.problemSupport.addError(this, e.getMessage)
@@ -55,7 +55,7 @@ class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationReference> 
 		
 		val jvmAnnoType = (annotationTypeDeclaration as JvmAnnotationTypeDeclarationImpl).delegate
 		val jvmOperation = jvmAnnoType.declaredOperations.findFirst[it.simpleName == name]
-		if (jvmOperation == null) {
+		if (jvmOperation === null) {
 			throw new IllegalArgumentException("The annotation property '"+name+"' is not declared on the annotation type '"+jvmAnnoType.identifier+"'.")
 		}
 		return jvmOperation
@@ -75,7 +75,7 @@ class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationReference> 
 	
 	override getBooleanValue(String name) {
 		val value = getValue(name)
-		if (value == null) {
+		if (value === null) {
 			return false 
 		}
 		value as Boolean
@@ -87,7 +87,7 @@ class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationReference> 
 	
 	override getByteValue(String name) {
 		val value = getValue(name)
-		if (value == null) {
+		if (value === null) {
 			return 0 as byte
 		}
 		value as Byte
@@ -99,7 +99,7 @@ class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationReference> 
 	
 	override getCharValue(String name) {
 		val value = getValue(name)
-		if (value == null) {
+		if (value === null) {
 			return 0 as char
 		}
 		switch value {
@@ -122,7 +122,7 @@ class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationReference> 
 	
 	override getDoubleValue(String name) {
 		val value = getValue(name)
-		if (value == null) {
+		if (value === null) {
 			return 0
 		}
 		switch value {
@@ -150,7 +150,7 @@ class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationReference> 
 	
 	override getFloatValue(String name) {
 		val value = getValue(name)
-		if (value == null) {
+		if (value === null) {
 			return 0
 		}
 		switch value {
@@ -169,7 +169,7 @@ class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationReference> 
 	
 	override getIntValue(String name) {
 		val value = getValue(name)
-		if (value == null) {
+		if (value === null) {
 			return 0
 		}
 		switch value {
@@ -186,7 +186,7 @@ class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationReference> 
 	
 	override getLongValue(String name) {
 		val value = getValue(name)
-		if (value == null) {
+		if (value === null) {
 			return 0
 		}
 		switch value {
@@ -204,7 +204,7 @@ class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationReference> 
 	
 	override getShortValue(String name) {
 		val value = getValue(name)
-		if (value == null) {
+		if (value === null) {
 			return 0 as short
 		}
 		switch value {

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/JvmBasedDeclarations.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/JvmBasedDeclarations.xtend
@@ -80,12 +80,12 @@ abstract class JvmElementImpl<T extends EObject> extends AbstractElementImpl<T> 
 	
 	def remove() {
 		checkMutable
-		Preconditions.checkState(delegate.eResource != null, '''This element has already been removed: «delegate»''')
+		Preconditions.checkState(delegate.eResource !== null, '''This element has already been removed: «delegate»''')
 		
 		compilationUnit.jvmModelAssociator.removeAllAssociation(delegate)
 		EcoreUtil.remove(delegate)
 		
-		Preconditions.checkState(delegate.eResource == null, '''Couldn't remove: «delegate»''')
+		Preconditions.checkState(delegate.eResource === null, '''Couldn't remove: «delegate»''')
 	}
 	
 	protected final def checkMutable() {
@@ -115,7 +115,7 @@ abstract class JvmAnnotationTargetImpl<T extends JvmAnnotationTarget> extends Jv
 	
 	def addAnnotation(AnnotationReference annotationReference) {
 		checkMutable
-		Preconditions.checkArgument(annotationReference != null, "annotationReference cannot be null")
+		Preconditions.checkArgument(annotationReference !== null, "annotationReference cannot be null")
 		if (annotationReference instanceof JvmAnnotationReferenceImpl) {
 			val jvmAnnotationReference = annotationReference.delegate.cloneWithProxies
 			this.delegate.annotations += jvmAnnotationReference
@@ -149,7 +149,7 @@ abstract class JvmMemberDeclarationImpl<T extends JvmMember> extends JvmAnnotati
 	def setDocComment(String docComment) {
 		checkMutable
 		var adapter = EcoreUtil.getAdapter(delegate.eAdapters(), DocumentationAdapter) as DocumentationAdapter;
-		if (adapter == null) {
+		if (adapter === null) {
 			adapter = new DocumentationAdapter
 			delegate.eAdapters += adapter
 		}
@@ -199,7 +199,7 @@ abstract class JvmMemberDeclarationImpl<T extends JvmMember> extends JvmAnnotati
 		} else {
 			delegate.deprecated = false
 			val existingReference = findAnnotation(compilationUnit.typeLookup.findTypeGlobally(Deprecated))
-			if (existingReference != null) {
+			if (existingReference !== null) {
 				removeAnnotation(existingReference)
 			}
 		}
@@ -222,7 +222,7 @@ abstract class JvmTypeDeclarationImpl<T extends JvmDeclaredType> extends JvmMemb
 	}
 	
 	def isAssignableFrom(Type otherType) {
-		if (otherType == null)
+		if (otherType === null)
 			return false;
 		val thisTypeRef = compilationUnit.typeReferenceProvider.newTypeReference(this as Type)
 		val thatTypeRef = compilationUnit.typeReferenceProvider.newTypeReference(otherType)
@@ -231,10 +231,10 @@ abstract class JvmTypeDeclarationImpl<T extends JvmDeclaredType> extends JvmMemb
 	
 	def addConstructor(Procedure1<MutableConstructorDeclaration> initializer) {
 		checkMutable
-		Preconditions.checkArgument(initializer != null, "initializer cannot be null")
+		Preconditions.checkArgument(initializer !== null, "initializer cannot be null")
 		// remove default constructor
 		val constructor = delegate.members.filter(JvmConstructor).findFirst[compilationUnit.typeExtensions.isSingleSyntheticDefaultConstructor(it)]
-		if (constructor != null) {
+		if (constructor !== null) {
 			EcoreUtil.remove(constructor)
 		}
 		val newConstructor = TypesFactory.eINSTANCE.createJvmConstructor
@@ -249,7 +249,7 @@ abstract class JvmTypeDeclarationImpl<T extends JvmDeclaredType> extends JvmMemb
 	def addField(String name, Procedure1<MutableFieldDeclaration> initializer) {
 		checkMutable
 		checkJavaIdentifier(name, "name")
-		Preconditions.checkArgument(initializer != null, "initializer cannot be null")
+		Preconditions.checkArgument(initializer !== null, "initializer cannot be null")
 		val newField = TypesFactory.eINSTANCE.createJvmField
 		newField.simpleName = name
 		newField.visibility = JvmVisibility.PRIVATE
@@ -262,7 +262,7 @@ abstract class JvmTypeDeclarationImpl<T extends JvmDeclaredType> extends JvmMemb
 	def addMethod(String name, Procedure1<MutableMethodDeclaration> initializer) {
 		checkMutable
 		checkJavaIdentifier(name, "name")
-		Preconditions.checkArgument(initializer != null, "initializer cannot be null")
+		Preconditions.checkArgument(initializer !== null, "initializer cannot be null")
 		val newMethod = TypesFactory.eINSTANCE.createJvmOperation
 		newMethod.visibility = JvmVisibility.PUBLIC
 		newMethod.simpleName = name
@@ -453,7 +453,7 @@ class JvmInterfaceDeclarationImpl extends JvmTypeDeclarationImpl<JvmGenericType>
 	override addMethod(String name, Procedure1<MutableMethodDeclaration> initializer) {
 		checkMutable
 		checkJavaIdentifier(name, "name")
-		Preconditions.checkArgument(initializer != null, "initializer cannot be null")
+		Preconditions.checkArgument(initializer !== null, "initializer cannot be null")
 		val newMethod = TypesFactory.eINSTANCE.createJvmOperation
 		newMethod.visibility = JvmVisibility.PUBLIC
 		newMethod.simpleName = name
@@ -537,7 +537,7 @@ class MutableJvmAnnotationTypeDeclarationImpl extends JvmAnnotationTypeDeclarati
 	override MutableAnnotationTypeElementDeclaration addAnnotationTypeElement(String name, Procedure1<MutableAnnotationTypeElementDeclaration> initializer) {
 		checkMutable
 		checkJavaIdentifier(name, "name")
-		Preconditions.checkArgument(initializer != null, "initializer cannot be null")
+		Preconditions.checkArgument(initializer !== null, "initializer cannot be null")
 		val newAnnotationElement = TypesFactory.eINSTANCE.createJvmOperation
 		newAnnotationElement.simpleName = name
 		newAnnotationElement.visibility = JvmVisibility.PUBLIC
@@ -655,7 +655,7 @@ class MutableJvmEnumerationTypeDeclarationImpl extends JvmEnumerationTypeDeclara
 	override addValue(String name, Procedure1<MutableEnumerationValueDeclaration> initializer) {
 		checkMutable
 		checkJavaIdentifier(name, "name")
-		Preconditions.checkArgument(initializer != null, "initializer cannot be null")
+		Preconditions.checkArgument(initializer !== null, "initializer cannot be null")
 		val jvmLiteral = TypesFactory.eINSTANCE.createJvmEnumerationLiteral
 		jvmLiteral.simpleName = name
 		jvmLiteral.visibility = JvmVisibility.PUBLIC
@@ -770,13 +770,13 @@ class MutableJvmClassDeclarationImpl extends JvmClassDeclarationImpl implements 
 		checkMutable
 		checkInferredTypeReferences("extended class", superclass)
 		val newTypeRef = 
-			if (superclass != null) {
+			if (superclass !== null) {
 				compilationUnit.toJvmTypeReference(superclass)
 			} else {
 				compilationUnit.typeReferences.getTypeForName(Object, compilationUnit.xtendFile)
 			}
 		val oldType = delegate.superTypes.findFirst[it.type instanceof JvmGenericType && !(type as JvmGenericType).isInterface]
-		if (oldType != null)
+		if (oldType !== null)
 			delegate.superTypes.remove(oldType)
 		delegate.superTypes.add(newTypeRef)
 	}
@@ -886,7 +886,7 @@ abstract class JvmExecutableDeclarationImpl<T extends JvmExecutable> extends Jvm
 	
 	def setBody(Expression body) {
 		checkMutable
-		if (body == null) {
+		if (body === null) {
 			compilationUnit.jvmTypesBuilder.removeExistingBody(delegate)
 		} else {
 			compilationUnit.jvmTypesBuilder.setBody(delegate, (body as ExpressionImpl).delegate)
@@ -899,7 +899,7 @@ abstract class JvmExecutableDeclarationImpl<T extends JvmExecutable> extends Jvm
 		checkInferredTypeReferences("exception type", exceptions)
 		delegate.exceptions.clear
 		for (exceptionType : exceptions) {
-			if (exceptionType != null) {
+			if (exceptionType !== null) {
 				delegate.exceptions.add(compilationUnit.toJvmTypeReference(exceptionType))
 			}
 		}
@@ -929,20 +929,20 @@ abstract class JvmExecutableDeclarationImpl<T extends JvmExecutable> extends Jvm
 	
 	def setBody(CompilationStrategy compilationStrategy) {
 		checkMutable
-		Preconditions.checkArgument(compilationStrategy != null, "compilationStrategy cannot be null")
+		Preconditions.checkArgument(compilationStrategy !== null, "compilationStrategy cannot be null")
 		compilationUnit.setCompilationStrategy(delegate, compilationStrategy)
 	}
 	
 	def setBody(StringConcatenationClient compilationTemplate) {
 		checkMutable
-		Preconditions.checkArgument(compilationTemplate != null, "compilationTemplate cannot be null")
+		Preconditions.checkArgument(compilationTemplate !== null, "compilationTemplate cannot be null")
 		compilationUnit.setCompilationTemplate(delegate, compilationTemplate)
 	}
 	
 	def MutableParameterDeclaration addParameter(String name, TypeReference type) {
 		checkMutable
 		checkJavaIdentifier(name, "name");
-		Preconditions.checkArgument(type != null, "type cannot be null");
+		Preconditions.checkArgument(type !== null, "type cannot be null");
 		if (type.inferred)
 			throw new IllegalArgumentException("Cannot use inferred type as parameter type.")
 		val param = TypesFactory.eINSTANCE.createJvmFormalParameter
@@ -1021,7 +1021,7 @@ class MutableJvmMethodDeclarationImpl extends JvmMethodDeclarationImpl implement
 
 	override setReturnType(TypeReference type) {
 		checkMutable
-		Preconditions.checkArgument(type != null, "returnType cannot be null");
+		Preconditions.checkArgument(type !== null, "returnType cannot be null");
 		delegate.setReturnType(compilationUnit.toJvmTypeReference(type))
 	}
 	
@@ -1177,7 +1177,7 @@ class MutableJvmFieldDeclarationImpl extends JvmFieldDeclarationImpl implements 
 	
 	override setInitializer(Expression initializer) {
 		checkMutable
-		if (initializer == null) {
+		if (initializer === null) {
 			compilationUnit.jvmTypesBuilder.removeExistingBody(delegate)
 		} else {
 			compilationUnit.jvmTypesBuilder.setInitializer(delegate, (initializer as ExpressionImpl).delegate)
@@ -1186,13 +1186,13 @@ class MutableJvmFieldDeclarationImpl extends JvmFieldDeclarationImpl implements 
 	
 	override setInitializer(CompilationStrategy initializer) {
 		checkMutable
-		Preconditions.checkArgument(initializer != null, "initializer cannot be null")
+		Preconditions.checkArgument(initializer !== null, "initializer cannot be null")
 		compilationUnit.setCompilationStrategy(delegate, initializer)
 	}
 	
 	override setInitializer(StringConcatenationClient template) {
 		checkMutable
-		Preconditions.checkArgument(template != null, "template cannot be null")
+		Preconditions.checkArgument(template !== null, "template cannot be null")
 		compilationUnit.setCompilationTemplate(delegate, template)
 	}
 	
@@ -1218,7 +1218,7 @@ class MutableJvmFieldDeclarationImpl extends JvmFieldDeclarationImpl implements 
 	
 	override setType(TypeReference type) {
 		checkMutable
-		Preconditions.checkArgument(type != null, "type cannot be null");
+		Preconditions.checkArgument(type !== null, "type cannot be null");
 		delegate.setType(compilationUnit.toJvmTypeReference(type))
 	}
 	
@@ -1229,7 +1229,7 @@ class MutableJvmFieldDeclarationImpl extends JvmFieldDeclarationImpl implements 
 	
 	private def internalGenericSetConstantValue(Object value) {
 		checkMutable
-		Preconditions.checkArgument(value != null, "value cannot be null");
+		Preconditions.checkArgument(value !== null, "value cannot be null");
 		delegate.constant = true
 		delegate.final = true
 		delegate.static = true
@@ -1330,12 +1330,12 @@ class MutableJvmTypeParameterDeclarationImpl extends JvmTypeParameterDeclaration
 	
 	override remove() {
 		checkMutable
-		Preconditions.checkState(delegate.eResource != null, '''This element has already been removed: «delegate»''')
+		Preconditions.checkState(delegate.eResource !== null, '''This element has already been removed: «delegate»''')
 		
 		compilationUnit.jvmModelAssociator.removeAllAssociation(delegate)
 		EcoreUtil.remove(delegate)
 		
-		Preconditions.checkState(delegate.eResource == null, '''Couldn't remove: «delegate»''')
+		Preconditions.checkState(delegate.eResource === null, '''Couldn't remove: «delegate»''')
 	}
 	
 	override addAnnotation(AnnotationReference annotationReference) {
@@ -1372,7 +1372,7 @@ class JvmTypeParameterDeclarationImpl extends TypeParameterDeclarationImpl imple
 	}
 	
 	override isAssignableFrom(Type otherType) {
-		if (otherType == null)
+		if (otherType === null)
 			return false;
 		val thisTypeRef = compilationUnit.typeReferenceProvider.newTypeReference(this)
 		val thatTypeRef = compilationUnit.typeReferenceProvider.newTypeReference(otherType)

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/ProblemSupportImpl.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/ProblemSupportImpl.xtend
@@ -111,7 +111,7 @@ class ProblemSupportImpl implements ProblemSupport {
 				val resource = element.delegate.eResource
 				if (resource == compilationUnit.xtendFile.eResource) {
 					val eobject = compilationUnit.jvmModelAssociations.getPrimarySourceElement(element.delegate)
-					if (eobject == null) {
+					if (eobject === null) {
 						return resource -> element.delegate
 					}
 					return resource -> eobject

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/TypeLookupImpl.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/TypeLookupImpl.xtend
@@ -62,7 +62,7 @@ class TypeLookupImpl implements TypeLookup, SourceTypeLookup, UpstreamTypeLookup
 			[type|type.getQualifiedName('.')],
 			[type|type.members.filter(JvmDeclaredType)]
 		)
-		return if (result != null) {
+		return if (result !== null) {
 			compilationUnit.toType(result)
 		}
 	}
@@ -102,7 +102,7 @@ class TypeLookupImpl implements TypeLookup, SourceTypeLookup, UpstreamTypeLookup
 			[type|compilationUnit.qualifiedNameConverter.toString(compilationUnit.qualifiedNameProvider.getFullyQualifiedName(type))],
 			[type|type.members.filter(XtendTypeDeclaration)]
 		)
-		return if (result != null) {
+		return if (result !== null) {
 			compilationUnit.toXtendTypeDeclaration(result)
 		}
 	}

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/XtendBasedDeclarations.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/XtendBasedDeclarations.xtend
@@ -118,13 +118,13 @@ abstract class XtendTypeDeclarationImpl<T extends XtendTypeDeclaration> extends 
 		val container = decl.eContainer
 		if (container instanceof XtendFile) {
 			val package = container.package
-			if (package == null)
+			if (package === null)
 				return decl.name
 			return package + '.' + decl.name
 		}
 		if (container instanceof XtendTypeDeclaration) {
 			val containerName = container.qualifiedName
-			if (containerName == null)
+			if (containerName === null)
 				return null
 			return containerName + '.' + decl.name
 		}
@@ -140,7 +140,7 @@ abstract class XtendTypeDeclarationImpl<T extends XtendTypeDeclaration> extends 
 	}
 	
 	override isAssignableFrom(Type otherType) {
-		if (otherType == null)
+		if (otherType === null)
 			return false;
 		val thisTypeRef = compilationUnit.typeReferenceProvider.newTypeReference(this)
 		val thatTypeRef = compilationUnit.typeReferenceProvider.newTypeReference(otherType)
@@ -272,7 +272,7 @@ class XtendAnnotationTypeDeclarationImpl extends XtendTypeDeclarationImpl<XtendA
 class XtendMethodDeclarationImpl extends XtendMemberDeclarationImpl<XtendFunction> implements MethodDeclaration {
 	
 	override isAbstract() {
-		delegate.expression == null
+		delegate.expression === null
 	}
 	
 	override isFinal() {
@@ -317,7 +317,7 @@ class XtendMethodDeclarationImpl extends XtendMemberDeclarationImpl<XtendFunctio
 	}
 	
 	override getBody() {
-		if (delegate.expression == null)
+		if (delegate.expression === null)
 			return null
 		return compilationUnit.toExpression(delegate.expression)
 	}
@@ -343,7 +343,7 @@ class XtendMethodDeclarationImpl extends XtendMemberDeclarationImpl<XtendFunctio
 class XtendConstructorDeclarationImpl extends XtendMemberDeclarationImpl<XtendConstructor> implements ConstructorDeclaration {
 	
 	override getBody() {
-		if (delegate.expression == null)
+		if (delegate.expression === null)
 			return null
 		return compilationUnit.toExpression(delegate.expression)
 	}
@@ -401,7 +401,7 @@ class XtendFieldDeclarationImpl extends XtendMemberDeclarationImpl<XtendField> i
 	}
 	
 	override getInitializer() {
-		if (delegate.initialValue == null)
+		if (delegate.initialValue === null)
 			return null
 		return compilationUnit.toExpression(delegate.initialValue)
 	}
@@ -451,13 +451,13 @@ class XtendAnnotationTypeElementDeclarationImpl extends XtendMemberDeclarationIm
 	}
 	
 	override getDefaultValue() {
-		if (delegate.initialValue == null)
+		if (delegate.initialValue === null)
 			return null
 		compilationUnit.evaluate(delegate.initialValue, delegate.type)
 	}
 	
 	override getDefaultValueExpression() {
-		if (delegate.initialValue == null)
+		if (delegate.initialValue === null)
 			return null
 		compilationUnit.toExpression(delegate.initialValue) 
 	}
@@ -496,7 +496,7 @@ class XtendTypeParameterDeclarationImpl extends AbstractElementImpl<JvmTypeParam
 	}
 	
 	override isAssignableFrom(Type otherType) {
-		if (otherType == null)
+		if (otherType === null)
 			return false;
 		val thisTypeRef = compilationUnit.typeReferenceProvider.newTypeReference(this)
 		val thatTypeRef = compilationUnit.typeReferenceProvider.newTypeReference(otherType)
@@ -531,7 +531,7 @@ class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotation> impl
 	
 	override getExpression(String property) {
 		val value = property.findValue
-		if (value != null) {
+		if (value !== null) {
 			return compilationUnit.toExpression(value)
 		}
 		return null
@@ -539,14 +539,14 @@ class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotation> impl
 	
 	override getValue(String property) {
 		val value = property.findValue
-		if (value != null) {
+		if (value !== null) {
 			return value.translateAnnotationValue(property)		
 		}
 		return annotationTypeDeclaration.findDeclaredAnnotationTypeElement(property).defaultValue
 	}
 	
 	protected def findValue(String property) {
-		if (property == 'value' && delegate.value != null) {
+		if (property == 'value' && delegate.value !== null) {
 			return delegate.value
 		}
 		delegate.elementValuePairs.findFirst[element.simpleName == property]?.value
@@ -556,7 +556,7 @@ class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotation> impl
 		val annotationType = delegate.annotationType
 		if (annotationType instanceof JvmAnnotationType) {
 			val operation = annotationType.members.filter(JvmOperation).findFirst[simpleName == property]
-			if (operation != null) {
+			if (operation !== null) {
 				val array = compilationUnit.typeReferences.isArray(operation.returnType)
 				return compilationUnit.translateAnnotationValue(value, operation.returnType, array)
 			}
@@ -578,7 +578,7 @@ class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotation> impl
 	
 	override getBooleanValue(String name) {
 		val value = getValue(name)
-		if (value == null) {
+		if (value === null) {
 			return false 
 		}
 		value as Boolean
@@ -590,7 +590,7 @@ class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotation> impl
 	
 	override getByteValue(String name) {
 		val value = getValue(name)
-		if (value == null) {
+		if (value === null) {
 			return 0 as byte
 		}
 		value as Byte
@@ -602,7 +602,7 @@ class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotation> impl
 	
 	override getCharValue(String name) {
 		val value = getValue(name)
-		if (value == null) {
+		if (value === null) {
 			return 0 as char
 		}
 		switch value {
@@ -625,7 +625,7 @@ class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotation> impl
 	
 	override getDoubleValue(String name) {
 		val value = getValue(name)
-		if (value == null) {
+		if (value === null) {
 			return 0
 		}
 		switch value {
@@ -653,7 +653,7 @@ class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotation> impl
 	
 	override getFloatValue(String name) {
 		val value = getValue(name)
-		if (value == null) {
+		if (value === null) {
 			return 0
 		}
 		switch value {
@@ -672,7 +672,7 @@ class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotation> impl
 	
 	override getIntValue(String name) {
 		val value = getValue(name)
-		if (value == null) {
+		if (value === null) {
 			return 0
 		}
 		switch value {
@@ -689,7 +689,7 @@ class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotation> impl
 	
 	override getLongValue(String name) {
 		val value = getValue(name)
-		if (value == null) {
+		if (value === null) {
 			return 0
 		}
 		switch value {
@@ -707,7 +707,7 @@ class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotation> impl
 	
 	override getShortValue(String name) {
 		val value = getValue(name)
-		if (value == null) {
+		if (value === null) {
 			return 0 as short
 		}
 		switch value {

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/resource/XtendResourceDescriptionManager.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/resource/XtendResourceDescriptionManager.xtend
@@ -70,7 +70,7 @@ class XtendResourceDescription extends DefaultResourceDescription {
 	}
 
 	override protected getLookUp() {
-		if (lookup == null)
+		if (lookup === null)
 			lookup = new EObjectDescriptionLookUp(computeExportedObjects());
 		return lookup;
 	}
@@ -81,18 +81,18 @@ class XtendResourceDescription extends DefaultResourceDescription {
 	
 
 	def override Iterable<QualifiedName> getImportedNames() {
-		if (importedNames != null) {
+		if (importedNames !== null) {
 			return importedNames;
 		}
 		val result = newHashSet()
 		val astRoot = resource.contents.head
-		if (astRoot != null) {
+		if (astRoot !== null) {
 			val types = typeResolver.resolveTypes(astRoot)
 			for (expression : EcoreUtil.getAllContents(astRoot, true).toIterable.filter(XExpression)) {
 				switch expression {
 					// an unresolved member feature call, where the receiver is a type literal could potentially become
 					// a reference to a nested type
-					XMemberFeatureCall case expression.feature != null && expression.feature.eIsProxy && !expression.explicitOperationCallOrBuilderSyntax: {
+					XMemberFeatureCall case expression.feature !== null && expression.feature.eIsProxy && !expression.explicitOperationCallOrBuilderSyntax: {
 						val receiver = expression.actualReceiver
 						switch receiver {
 							XAbstractFeatureCall case receiver.typeLiteral: {
@@ -114,7 +114,7 @@ class XtendResourceDescription extends DefaultResourceDescription {
 					}
 				}
 				val typeRef = types.getActualType(expression)
-				if (typeRef != null) {
+				if (typeRef !== null) {
 					registerAllTypes(typeRef.type) [
 						result += nameConverter.toQualifiedName(it).toLowerCase
 					]
@@ -126,7 +126,7 @@ class XtendResourceDescription extends DefaultResourceDescription {
 						types.getActualType(it)
 				].toIterable
 				for (typeRef : typesOfIdentifiables) {
-					if (typeRef != null) {
+					if (typeRef !== null) {
 						registerAllTypes(typeRef.type) [
 							result += nameConverter.toQualifiedName(it).toLowerCase
 						]
@@ -142,7 +142,7 @@ class XtendResourceDescription extends DefaultResourceDescription {
 	}
 	
 	def void registerAllTypes(JvmType type, (String)=>boolean acceptor) {
-		if (type == null || type.eIsProxy)
+		if (type === null || type.eIsProxy)
 			return;
 		if (!type.local && acceptor.apply(type.identifier)) {
 			switch type {

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/AnnotationValidation.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/AnnotationValidation.xtend
@@ -46,7 +46,7 @@ class AnnotationValidation extends AbstractDeclarativeValidator {
 					IssueCodes.INVALID_ANNOTATION_VALUE_TYPE
 				)
 			}
-			if(initialValue != null) {
+			if(initialValue !== null) {
 				annotationValueValidator.validateAnnotationValue(initialValue, this)
 			}
 		}
@@ -58,7 +58,7 @@ class AnnotationValidation extends AbstractDeclarativeValidator {
 				reference.componentType
 			default : reference
 		}
-		if (toCheck == null)
+		if (toCheck === null)
 			return true;
 		if (toCheck.type instanceof JvmPrimitiveType) 
 			return true

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/compiler/XtendGenerator.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/compiler/XtendGenerator.java
@@ -373,8 +373,8 @@ public class XtendGenerator extends JvmModelGenerator implements IGenerator2 {
             _traceSignificant_2.append(_simpleName_4);
             if ((((JvmField)it_1).isFinal() && ((JvmField)it_1).isStatic())) {
               Object _constantValue = ((JvmField)it_1).getConstantValue();
-              boolean _notEquals = (!Objects.equal(_constantValue, null));
-              if (_notEquals) {
+              boolean _tripleNotEquals = (_constantValue != null);
+              if (_tripleNotEquals) {
                 tracedAppendable_1.append(" = ");
                 Object _constantValue_1 = ((JvmField)it_1).getConstantValue();
                 this.generateJavaConstant(_constantValue_1, tracedAppendable_1);

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/documentation/XtendFileHeaderProvider.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/documentation/XtendFileHeaderProvider.java
@@ -39,8 +39,7 @@ public class XtendFileHeaderProvider extends MultiLineFileHeaderProvider {
   public List<INode> getFileHeaderNodes(final Resource resource) {
     if ((resource instanceof XtextResource)) {
       final IParseResult parseResult = ((XtextResource)resource).getParseResult();
-      boolean _notEquals = (!Objects.equal(parseResult, null));
-      if (_notEquals) {
+      if ((parseResult != null)) {
         ICompositeNode _rootNode = parseResult.getRootNode();
         Iterable<ILeafNode> _leafNodes = _rootNode.getLeafNodes();
         for (final ILeafNode leafNode : _leafNodes) {
@@ -79,8 +78,7 @@ public class XtendFileHeaderProvider extends MultiLineFileHeaderProvider {
     if ((content instanceof XtendFile)) {
       EList<XtendTypeDeclaration> _xtendTypes = ((XtendFile)content).getXtendTypes();
       final XtendTypeDeclaration type = IterableExtensions.<XtendTypeDeclaration>head(_xtendTypes);
-      boolean _notEquals = (!Objects.equal(type, null));
-      if (_notEquals) {
+      if ((type != null)) {
         if ((this.documentationProvider instanceof IEObjectDocumentationProviderExtension)) {
           List<INode> _documentationNodes = ((IEObjectDocumentationProviderExtension)this.documentationProvider).getDocumentationNodes(type);
           INode _head = IterableExtensions.<INode>head(_documentationNodes);

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/findReferences/Declarators.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/findReferences/Declarators.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.findReferences;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.Collection;
 import java.util.HashSet;
@@ -90,8 +89,7 @@ public class Declarators {
   
   public Declarators.DeclaratorsData getDeclaratorData(final TargetURIs targetURIs, final IReferenceFinder.IResourceAccess resourceAccess) {
     Declarators.DeclaratorsData result = targetURIs.<Declarators.DeclaratorsData>getUserData(Declarators.KEY);
-    boolean _notEquals = (!Objects.equal(result, null));
-    if (_notEquals) {
+    if ((result != null)) {
       return result;
     }
     final HashSet<QualifiedName> declaratorNames = CollectionLiterals.<QualifiedName>newHashSet();
@@ -103,11 +101,9 @@ public class Declarators {
           Collection<URI> _eObjectURIs = targetURIs.getEObjectURIs(uri);
           final Consumer<URI> _function_2 = (URI objectURI) -> {
             final EObject object = it.getEObject(objectURI, true);
-            boolean _notEquals_1 = (!Objects.equal(object, null));
-            if (_notEquals_1) {
+            if ((object != null)) {
               final JvmType type = EcoreUtil2.<JvmType>getContainerOfType(object, JvmType.class);
-              boolean _notEquals_2 = (!Objects.equal(type, null));
-              if (_notEquals_2) {
+              if ((type != null)) {
                 String _identifier = type.getIdentifier();
                 QualifiedName _qualifiedName = this.nameConverter.toQualifiedName(_identifier);
                 QualifiedName _lowerCase = _qualifiedName.toLowerCase();

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/findReferences/XtendReferenceFinder.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/findReferences/XtendReferenceFinder.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.findReferences;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.inject.Inject;
 import java.util.Set;
@@ -112,7 +111,7 @@ public class XtendReferenceFinder extends ReferenceFinder {
     }
     if (!_matched_1) {
       if (sourceCandidate instanceof XFeatureCall) {
-        if ((Objects.equal(((XFeatureCall)sourceCandidate).getActualReceiver(), null) && ((XFeatureCall)sourceCandidate).isStatic())) {
+        if (((((XFeatureCall)sourceCandidate).getActualReceiver() == null) && ((XFeatureCall)sourceCandidate).isStatic())) {
           _matched_1=true;
           this.addReferenceToTypeFromStaticImport(((XAbstractFeatureCall)sourceCandidate), targetURIs, acceptor);
         }

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/RichStringFormatter.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/RichStringFormatter.java
@@ -87,8 +87,8 @@ public class RichStringFormatter {
   protected void _format(final RichString richString, final IFormattableDocument doc) {
     EObject _eContainer = richString.eContainer();
     RichString _containerOfType = EcoreUtil2.<RichString>getContainerOfType(_eContainer, RichString.class);
-    boolean _notEquals = (!Objects.equal(_containerOfType, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_containerOfType != null);
+    if (_tripleNotEquals) {
       return;
     }
     IEObjectRegion _regionForEObject = this._iTextRegionExtensions.regionForEObject(richString);
@@ -201,8 +201,8 @@ public class RichStringFormatter {
     while (i.hasNext()) {
       INode _next = i.next();
       SyntaxErrorMessage _syntaxErrorMessage = _next.getSyntaxErrorMessage();
-      boolean _notEquals = (!Objects.equal(_syntaxErrorMessage, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_syntaxErrorMessage != null);
+      if (_tripleNotEquals) {
         return true;
       }
     }
@@ -271,8 +271,8 @@ public class RichStringFormatter {
   
   protected void _suppressLineWraps(final IHiddenRegionFormatting it) {
     String _space = it.getSpace();
-    boolean _equals = Objects.equal(_space, null);
-    if (_equals) {
+    boolean _tripleEquals = (_space == null);
+    if (_tripleEquals) {
       it.setSpace(" ");
     }
     it.setNewLinesMin(null);

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/RichStringToLineModel.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/RichStringToLineModel.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.formatting2;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import java.util.List;
 import java.util.Stack;
@@ -161,8 +160,7 @@ public class RichStringToLineModel extends AbstractRichStringPartAcceptor.ForLoo
       _feature=_regionFor.feature(XbasePackage.Literals.XSTRING_LITERAL__VALUE);
     }
     final ISemanticRegion node = _feature;
-    boolean _notEquals = (!Objects.equal(node, null));
-    if (_notEquals) {
+    if ((node != null)) {
       int _offset = node.getOffset();
       int _literalPrefixLenght = this.literalPrefixLenght(node);
       int _plus = (_offset + _literalPrefixLenght);

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/XtendFormatter.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/XtendFormatter.java
@@ -102,16 +102,14 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
     format.<XtendFile>prepend(xtendFile, _function);
     ISemanticRegionsFinder _regionFor = this.textRegionExtensions.regionFor(xtendFile);
     final ISemanticRegion pkg = _regionFor.feature(XtendPackage.Literals.XTEND_FILE__PACKAGE);
-    boolean _notEquals = (!Objects.equal(pkg, null));
-    if (_notEquals) {
+    if ((pkg != null)) {
       final Procedure1<IHiddenRegionFormatter> _function_1 = (IHiddenRegionFormatter it) -> {
         it.oneSpace();
       };
       format.prepend(pkg, _function_1);
       ISemanticRegionFinder _immediatelyFollowing = pkg.immediatelyFollowing();
       final ISemanticRegion pkgSemicolon = _immediatelyFollowing.keyword(";");
-      boolean _notEquals_1 = (!Objects.equal(pkgSemicolon, null));
-      if (_notEquals_1) {
+      if ((pkgSemicolon != null)) {
         final Procedure1<IHiddenRegionFormatter> _function_2 = (IHiddenRegionFormatter it) -> {
           it.noSpace();
         };
@@ -131,8 +129,8 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
         format.<XtendTypeDeclaration>format(clazz);
         EList<XtendTypeDeclaration> _xtendTypes_1 = xtendFile.getXtendTypes();
         XtendTypeDeclaration _last = IterableExtensions.<XtendTypeDeclaration>last(_xtendTypes_1);
-        boolean _notEquals_2 = (!Objects.equal(clazz, _last));
-        if (_notEquals_2) {
+        boolean _notEquals = (!Objects.equal(clazz, _last));
+        if (_notEquals) {
           format.<XtendTypeDeclaration>append(clazz, XtendFormatterPreferenceKeys.blankLinesBetweenClasses);
         }
       }
@@ -524,8 +522,8 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
     };
     format.prepend(open, _function_4);
     XExpression _expression = func.getExpression();
-    boolean _notEquals = (!Objects.equal(_expression, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_expression != null);
+    if (_tripleNotEquals) {
       format.append(close, XbaseFormatterPreferenceKeys.bracesInNewLine);
     }
     EList<XtendParameter> _parameters = func.getParameters();
@@ -540,8 +538,8 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
     this.formatAnnotations(field, document, XbaseFormatterPreferenceKeys.newLineAfterFieldAnnotations);
     this.formatModifiers(field, document);
     String _name = field.getName();
-    boolean _notEquals = (!Objects.equal(_name, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_name != null);
+    if (_tripleNotEquals) {
       JvmTypeReference _type = field.getType();
       final Procedure1<IHiddenRegionFormatter> _function = (IHiddenRegionFormatter it) -> {
         it.oneSpace();
@@ -618,8 +616,8 @@ public class XtendFormatter extends XbaseWithAnnotationsFormatter {
   protected XClosure builder(final List<XExpression> params) {
     XClosure _xifexpression = null;
     XExpression _last = IterableExtensions.<XExpression>last(params);
-    boolean _notEquals = (!Objects.equal(_last, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_last != null);
+    if (_tripleNotEquals) {
       XClosure _xblockexpression = null;
       {
         XExpression _last_1 = IterableExtensions.<XExpression>last(params);

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/javaconverter/ASTFlattenerUtils.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/javaconverter/ASTFlattenerUtils.java
@@ -83,11 +83,10 @@ public class ASTFlattenerUtils {
       return true;
     }
     final IMethodBinding iMethodBinding = declaration.resolveBinding();
-    boolean _notEquals = (!Objects.equal(iMethodBinding, null));
-    if (_notEquals) {
+    if ((iMethodBinding != null)) {
       ITypeBinding _declaringClass = iMethodBinding.getDeclaringClass();
       IMethodBinding _findOverride = this.findOverride(iMethodBinding, _declaringClass);
-      return (!Objects.equal(_findOverride, null));
+      return (_findOverride != null);
     }
     return false;
   }
@@ -99,20 +98,17 @@ public class ASTFlattenerUtils {
   public IMethodBinding findOverride(final IMethodBinding method, final ITypeBinding type, final boolean onlyPrimarylevel) {
     final ITypeBinding superclass = type.getSuperclass();
     IMethodBinding overridden = null;
-    boolean _notEquals = (!Objects.equal(superclass, null));
-    if (_notEquals) {
+    if ((superclass != null)) {
       IMethodBinding _internalFindOverride = this.internalFindOverride(method, superclass, onlyPrimarylevel);
       overridden = _internalFindOverride;
     }
-    boolean _equals = Objects.equal(overridden, null);
-    if (_equals) {
+    if ((overridden == null)) {
       ITypeBinding[] _interfaces = type.getInterfaces();
       for (final ITypeBinding interfaze : _interfaces) {
         {
           IMethodBinding _internalFindOverride_1 = this.internalFindOverride(method, interfaze, onlyPrimarylevel);
           overridden = _internalFindOverride_1;
-          boolean _notEquals_1 = (!Objects.equal(overridden, null));
-          if (_notEquals_1) {
+          if ((overridden != null)) {
             return overridden;
           }
         }
@@ -194,8 +190,7 @@ public class ASTFlattenerUtils {
   }
   
   private boolean isStaticBinding(final IBinding binding) {
-    boolean _notEquals = (!Objects.equal(binding, null));
-    if (_notEquals) {
+    if ((binding != null)) {
       int _modifiers = binding.getModifiers();
       return Modifier.isStatic(_modifiers);
     }
@@ -223,16 +218,15 @@ public class ASTFlattenerUtils {
   
   public boolean isLambdaCase(final ClassInstanceCreation creation) {
     final AnonymousClassDeclaration anonymousClazz = creation.getAnonymousClassDeclaration();
-    if (((!Objects.equal(anonymousClazz, null)) && (anonymousClazz.bodyDeclarations().size() == 1))) {
+    if (((anonymousClazz != null) && (anonymousClazz.bodyDeclarations().size() == 1))) {
       List _bodyDeclarations = anonymousClazz.bodyDeclarations();
       final Object declaredMethod = _bodyDeclarations.get(0);
-      if (((declaredMethod instanceof MethodDeclaration) && (!Objects.equal(creation.getType().resolveBinding(), null)))) {
+      if (((declaredMethod instanceof MethodDeclaration) && (creation.getType().resolveBinding() != null))) {
         final IMethodBinding methodBinding = ((MethodDeclaration) declaredMethod).resolveBinding();
-        boolean _notEquals = (!Objects.equal(methodBinding, null));
-        if (_notEquals) {
+        if ((methodBinding != null)) {
           ITypeBinding _declaringClass = methodBinding.getDeclaringClass();
           final IMethodBinding overrides = this.findOverride(methodBinding, _declaringClass, true);
-          return ((!Objects.equal(overrides, null)) && Modifier.isAbstract(overrides.getModifiers()));
+          return ((overrides != null) && Modifier.isAbstract(overrides.getModifiers()));
         }
       }
     }
@@ -240,7 +234,7 @@ public class ASTFlattenerUtils {
   }
   
   public boolean needsReturnValue(final ASTNode node) {
-    return ((!Objects.equal(node.getParent(), null)) && ((!(node.getParent() instanceof Statement)) || (node.getParent() instanceof ReturnStatement)));
+    return ((node.getParent() != null) && ((!(node.getParent() instanceof Statement)) || (node.getParent() instanceof ReturnStatement)));
   }
   
   public boolean isConstantArrayIndex(final Expression node) {
@@ -249,8 +243,7 @@ public class ASTFlattenerUtils {
   
   public boolean canConvertToRichText(final InfixExpression node) {
     final FieldDeclaration parentFieldDecl = this.<FieldDeclaration>findParentOfType(node, FieldDeclaration.class);
-    boolean _notEquals = (!Objects.equal(parentFieldDecl, null));
-    if (_notEquals) {
+    if ((parentFieldDecl != null)) {
       final TypeDeclaration typeDeclr = this.<TypeDeclaration>findParentOfType(parentFieldDecl, TypeDeclaration.class);
       if ((typeDeclr.isInterface() || (this.isFinal(parentFieldDecl.modifiers()) && this.isStatic(parentFieldDecl.modifiers())))) {
         return false;
@@ -264,8 +257,8 @@ public class ASTFlattenerUtils {
   
   public <T extends ASTNode> T findParentOfType(final ASTNode someNode, final Class<T> parentType) {
     ASTNode _parent = someNode.getParent();
-    boolean _equals = Objects.equal(_parent, null);
-    if (_equals) {
+    boolean _tripleEquals = (_parent == null);
+    if (_tripleEquals) {
       return null;
     } else {
       ASTNode _parent_1 = someNode.getParent();
@@ -318,11 +311,10 @@ public class ASTFlattenerUtils {
   
   public Type findDeclaredType(final SimpleName simpleName) {
     ASTNode scope = this.findDeclarationBlocks(simpleName);
-    while ((!Objects.equal(scope, null))) {
+    while ((scope != null)) {
       {
         final Type type = this.findDeclaredType(scope, simpleName);
-        boolean _notEquals = (!Objects.equal(type, null));
-        if (_notEquals) {
+        if ((type != null)) {
           return type;
         }
         ASTNode _findDeclarationBlocks = this.findDeclarationBlocks(scope);
@@ -403,8 +395,7 @@ public class ASTFlattenerUtils {
   
   public Iterable<Expression> findAssignmentsInBlock(final Block scope, final Function1<? super Expression, ? extends Boolean> constraint) {
     final HashSet<Expression> assigments = CollectionLiterals.<Expression>newHashSet();
-    boolean _notEquals = (!Objects.equal(scope, null));
-    if (_notEquals) {
+    if ((scope != null)) {
       scope.accept(new ASTVisitor() {
         @Override
         public boolean visit(final Assignment node) {
@@ -502,7 +493,7 @@ public class ASTFlattenerUtils {
         }
       }
       if ((simpleName instanceof SimpleName)) {
-        return Boolean.valueOf(((!Objects.equal(simpleName, null)) && nameToLookFor.getIdentifier().equals(((SimpleName)simpleName).getIdentifier())));
+        return Boolean.valueOf(((simpleName != null) && nameToLookFor.getIdentifier().equals(((SimpleName)simpleName).getIdentifier())));
       }
       return Boolean.valueOf(false);
     };
@@ -529,8 +520,7 @@ public class ASTFlattenerUtils {
     };
     Iterable<ChildListPropertyDescriptor> _filter_1 = IterableExtensions.<ChildListPropertyDescriptor>filter(_filter, _function);
     final ChildListPropertyDescriptor property = IterableExtensions.<ChildListPropertyDescriptor>head(_filter_1);
-    boolean _notEquals = (!Objects.equal(property, null));
-    if (_notEquals) {
+    if ((property != null)) {
       Object _structuralProperty = node.getStructuralProperty(property);
       return ((List<ASTNode>) _structuralProperty);
     }
@@ -554,8 +544,7 @@ public class ASTFlattenerUtils {
     };
     Iterable<ChildPropertyDescriptor> _filter_1 = IterableExtensions.<ChildPropertyDescriptor>filter(_filter, _function);
     final ChildPropertyDescriptor property = IterableExtensions.<ChildPropertyDescriptor>head(_filter_1);
-    boolean _notEquals = (!Objects.equal(property, null));
-    if (_notEquals) {
+    if ((property != null)) {
       Object _structuralProperty = node.getStructuralProperty(property);
       return ((ASTNode) _structuralProperty);
     }

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/javaconverter/JavaASTFlattener.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/javaconverter/JavaASTFlattener.java
@@ -231,8 +231,7 @@ public class JavaASTFlattener extends ASTVisitor {
     };
     Iterable<IExtendedModifier> _filter = IterableExtensions.<IExtendedModifier>filter(ext, _function_1);
     IterableExtensions.<IExtendedModifier>forEach(_filter, appender);
-    boolean _notEquals = (!Objects.equal(callBack, null));
-    if (_notEquals) {
+    if ((callBack != null)) {
       callBack.apply(node);
     }
     final Function1<IExtendedModifier, Boolean> _function_2 = (IExtendedModifier it) -> {
@@ -448,8 +447,8 @@ public class JavaASTFlattener extends ASTVisitor {
   @Override
   public boolean visit(final PackageDeclaration it) {
     Javadoc _javadoc = it.getJavadoc();
-    boolean _notEquals = (!Objects.equal(_javadoc, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_javadoc != null);
+    if (_tripleNotEquals) {
       Javadoc _javadoc_1 = it.getJavadoc();
       _javadoc_1.accept(this);
     }
@@ -515,8 +514,8 @@ public class JavaASTFlattener extends ASTVisitor {
   @Override
   public boolean visit(final Initializer it) {
     Javadoc _javadoc = it.getJavadoc();
-    boolean _notEquals = (!Objects.equal(_javadoc, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_javadoc != null);
+    if (_tripleNotEquals) {
       Javadoc _javadoc_1 = it.getJavadoc();
       _javadoc_1.accept(this);
     }
@@ -584,8 +583,8 @@ public class JavaASTFlattener extends ASTVisitor {
       this.addProblem(it, "Non-static inner classes are not supported.");
     }
     Javadoc _javadoc = it.getJavadoc();
-    boolean _notEquals = (!Objects.equal(_javadoc, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_javadoc != null);
+    if (_tripleNotEquals) {
       Javadoc _javadoc_1 = it.getJavadoc();
       _javadoc_1.accept(this);
     }
@@ -614,8 +613,8 @@ public class JavaASTFlattener extends ASTVisitor {
     }
     this.appendSpaceToBuffer();
     Type _superclassType = it.getSuperclassType();
-    boolean _notEquals_1 = (!Objects.equal(_superclassType, null));
-    if (_notEquals_1) {
+    boolean _tripleNotEquals_1 = (_superclassType != null);
+    if (_tripleNotEquals_1) {
       this.appendToBuffer("extends ");
       Type _superclassType_1 = it.getSuperclassType();
       _superclassType_1.accept(this);
@@ -672,7 +671,7 @@ public class JavaASTFlattener extends ASTVisitor {
   private Iterable<Comment> unAssignedComments(final CompilationUnit cu) {
     List _commentList = cu.getCommentList();
     final Function1<Comment, Boolean> _function = (Comment c) -> {
-      return Boolean.valueOf(((!(c.isDocComment() && (!Objects.equal(c.getParent(), null)))) && this.notAssigned(c)));
+      return Boolean.valueOf(((!(c.isDocComment() && (c.getParent() != null))) && this.notAssigned(c)));
     };
     return IterableExtensions.<Comment>filter(_commentList, _function);
   }
@@ -763,8 +762,8 @@ public class JavaASTFlattener extends ASTVisitor {
   @Override
   public boolean visit(final FieldDeclaration it) {
     Javadoc _javadoc = it.getJavadoc();
-    boolean _notEquals = (!Objects.equal(_javadoc, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_javadoc != null);
+    if (_tripleNotEquals) {
       Javadoc _javadoc_1 = it.getJavadoc();
       _javadoc_1.accept(this);
     }
@@ -829,8 +828,8 @@ public class JavaASTFlattener extends ASTVisitor {
     SimpleName _name = it.getName();
     _name.accept(this);
     Expression _initializer = it.getInitializer();
-    boolean _notEquals = (!Objects.equal(_initializer, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_initializer != null);
+    if (_tripleNotEquals) {
       this.appendToBuffer("=");
       SimpleName _name_1 = it.getName();
       final Type type = this._aSTFlattenerUtils.findDeclaredType(_name_1);
@@ -968,7 +967,7 @@ public class JavaASTFlattener extends ASTVisitor {
   public void visitAll(final Iterable<? extends ASTNode> iterable, final String separator) {
     final Procedure2<ASTNode, Integer> _function = (ASTNode node, Integer counter) -> {
       node.accept(this);
-      if (((!Objects.equal(separator, null)) && ((counter).intValue() < (IterableExtensions.size(iterable) - 1)))) {
+      if (((separator != null) && ((counter).intValue() < (IterableExtensions.size(iterable) - 1)))) {
         this.appendToBuffer(separator);
       }
     };
@@ -988,8 +987,8 @@ public class JavaASTFlattener extends ASTVisitor {
   @Override
   public boolean visit(final MethodDeclaration it) {
     Javadoc _javadoc = it.getJavadoc();
-    boolean _notEquals = (!Objects.equal(_javadoc, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_javadoc != null);
+    if (_tripleNotEquals) {
       Javadoc _javadoc_1 = it.getJavadoc();
       _javadoc_1.accept(this);
     }
@@ -1049,8 +1048,8 @@ public class JavaASTFlattener extends ASTVisitor {
     boolean _not_2 = (!_isConstructor_2);
     if (_not_2) {
       Type _returnType2 = it.getReturnType2();
-      boolean _notEquals_1 = (!Objects.equal(_returnType2, null));
-      if (_notEquals_1) {
+      boolean _tripleNotEquals_1 = (_returnType2 != null);
+      if (_tripleNotEquals_1) {
         Type _returnType2_1 = it.getReturnType2();
         _returnType2_1.accept(this);
       } else {
@@ -1074,13 +1073,13 @@ public class JavaASTFlattener extends ASTVisitor {
           final Expression firstInBody = IterableExtensions.<Expression>head(_findAssignmentsInBlock);
           if ((firstInBody != null)) {
             ConstructorInvocation _findParentOfType = this._aSTFlattenerUtils.<ConstructorInvocation>findParentOfType(firstInBody, ConstructorInvocation.class);
-            boolean _tripleNotEquals = (_findParentOfType != null);
-            if (_tripleNotEquals) {
+            boolean _tripleNotEquals_2 = (_findParentOfType != null);
+            if (_tripleNotEquals_2) {
               this.addProblem(p, "Final parameter modified in constructor call");
             } else {
               SuperConstructorInvocation _findParentOfType_1 = this._aSTFlattenerUtils.<SuperConstructorInvocation>findParentOfType(firstInBody, SuperConstructorInvocation.class);
-              boolean _tripleNotEquals_1 = (_findParentOfType_1 != null);
-              if (_tripleNotEquals_1) {
+              boolean _tripleNotEquals_3 = (_findParentOfType_1 != null);
+              if (_tripleNotEquals_3) {
                 this.addProblem(p, "Final parameter modified in super constructor call");
               }
             }
@@ -1138,8 +1137,8 @@ public class JavaASTFlattener extends ASTVisitor {
     }
     this.appendSpaceToBuffer();
     Block _body = it.getBody();
-    boolean _notEquals_2 = (!Objects.equal(_body, null));
-    if (_notEquals_2) {
+    boolean _tripleNotEquals_2 = (_body != null);
+    if (_tripleNotEquals_2) {
       Block _body_1 = it.getBody();
       _body_1.accept(this);
     } else {
@@ -1175,8 +1174,8 @@ public class JavaASTFlattener extends ASTVisitor {
     SimpleName _name = it.getName();
     _name.accept(this);
     Expression _initializer = it.getInitializer();
-    boolean _notEquals = (!Objects.equal(_initializer, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_initializer != null);
+    if (_tripleNotEquals) {
       this.appendToBuffer("=");
       Expression _initializer_1 = it.getInitializer();
       _initializer_1.accept(this);
@@ -1187,8 +1186,8 @@ public class JavaASTFlattener extends ASTVisitor {
   @Override
   public boolean visit(final ClassInstanceCreation node) {
     Expression _expression = node.getExpression();
-    boolean _notEquals = (!Objects.equal(_expression, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_expression != null);
+    if (_tripleNotEquals) {
       Expression _expression_1 = node.getExpression();
       _expression_1.accept(this);
       this.appendToBuffer(".");
@@ -1256,8 +1255,8 @@ public class JavaASTFlattener extends ASTVisitor {
       }
       this.appendToBuffer(")");
       AnonymousClassDeclaration _anonymousClassDeclaration_1 = node.getAnonymousClassDeclaration();
-      boolean _notEquals_1 = (!Objects.equal(_anonymousClassDeclaration_1, null));
-      if (_notEquals_1) {
+      boolean _tripleNotEquals_1 = (_anonymousClassDeclaration_1 != null);
+      if (_tripleNotEquals_1) {
         AnonymousClassDeclaration _anonymousClassDeclaration_2 = node.getAnonymousClassDeclaration();
         _anonymousClassDeclaration_2.accept(this);
       }
@@ -1337,8 +1336,8 @@ public class JavaASTFlattener extends ASTVisitor {
   @Override
   public boolean visit(final MethodInvocation it) {
     Expression _expression = it.getExpression();
-    boolean _notEquals = (!Objects.equal(_expression, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_expression != null);
+    if (_tripleNotEquals) {
       Expression _expression_1 = it.getExpression();
       _expression_1.accept(this);
       if ((this.fallBackStrategy && this._aSTFlattenerUtils.isStaticMemberCall(it))) {
@@ -1370,8 +1369,8 @@ public class JavaASTFlattener extends ASTVisitor {
     this.visitAll(_initializers);
     this.appendToBuffer("; ");
     Expression _expression = it.getExpression();
-    boolean _notEquals = (!Objects.equal(_expression, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_expression != null);
+    if (_tripleNotEquals) {
       Expression _expression_1 = it.getExpression();
       _expression_1.accept(this);
     }
@@ -1393,8 +1392,8 @@ public class JavaASTFlattener extends ASTVisitor {
   @Override
   public boolean visit(final ThisExpression it) {
     Name _qualifier = it.getQualifier();
-    boolean _notEquals = (!Objects.equal(_qualifier, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_qualifier != null);
+    if (_tripleNotEquals) {
       Name _qualifier_1 = it.getQualifier();
       _qualifier_1.accept(this);
       this.appendToBuffer(".");
@@ -1412,8 +1411,8 @@ public class JavaASTFlattener extends ASTVisitor {
     Statement _thenStatement = node.getThenStatement();
     _thenStatement.accept(this);
     Statement _elseStatement = node.getElseStatement();
-    boolean _notEquals = (!Objects.equal(_elseStatement, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_elseStatement != null);
+    if (_tripleNotEquals) {
       this.appendToBuffer(" else ");
       Statement _elseStatement_1 = node.getElseStatement();
       _elseStatement_1.accept(this);
@@ -1585,8 +1584,7 @@ public class JavaASTFlattener extends ASTVisitor {
     }
     if ((expression instanceof SimpleName)) {
       final Type declType = this._aSTFlattenerUtils.findDeclaredType(((SimpleName)expression));
-      boolean _notEquals = (!Objects.equal(declType, null));
-      if (_notEquals) {
+      if ((declType != null)) {
         boolean _matched = false;
         boolean _isPrimitiveType = declType.isPrimitiveType();
         if (_isPrimitiveType) {
@@ -1640,8 +1638,8 @@ public class JavaASTFlattener extends ASTVisitor {
   public boolean visit(final ReturnStatement node) {
     this.appendToBuffer("return");
     Expression _expression = node.getExpression();
-    boolean _notEquals = (!Objects.equal(_expression, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_expression != null);
+    if (_tripleNotEquals) {
       this.appendSpaceToBuffer();
       Expression _expression_1 = node.getExpression();
       _expression_1.accept(this);
@@ -1658,8 +1656,7 @@ public class JavaASTFlattener extends ASTVisitor {
   
   @Override
   public boolean visit(final BlockComment node) {
-    boolean _notEquals = (!Objects.equal(this.javaSources, null));
-    if (_notEquals) {
+    if ((this.javaSources != null)) {
       String _commentContent = this.commentContent(node);
       this.appendToBuffer(_commentContent);
       boolean _shouldWrap = this.shouldWrap(node);
@@ -1695,8 +1692,7 @@ public class JavaASTFlattener extends ASTVisitor {
   
   @Override
   public boolean visit(final LineComment node) {
-    boolean _notEquals = (!Objects.equal(this.javaSources, null));
-    if (_notEquals) {
+    if ((this.javaSources != null)) {
       String _commentContent = this.commentContent(node);
       this.appendToBuffer(_commentContent);
     }
@@ -1918,8 +1914,8 @@ public class JavaASTFlattener extends ASTVisitor {
   @Override
   public boolean visit(final SuperConstructorInvocation node) {
     Expression _expression = node.getExpression();
-    boolean _notEquals = (!Objects.equal(_expression, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_expression != null);
+    if (_tripleNotEquals) {
       Expression _expression_1 = node.getExpression();
       _expression_1.accept(this);
       this.appendToBuffer(".");
@@ -1941,8 +1937,8 @@ public class JavaASTFlattener extends ASTVisitor {
   @Override
   public boolean visit(final SuperFieldAccess node) {
     Name _qualifier = node.getQualifier();
-    boolean _notEquals = (!Objects.equal(_qualifier, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_qualifier != null);
+    if (_tripleNotEquals) {
       Name _qualifier_1 = node.getQualifier();
       _qualifier_1.accept(this);
       this.appendToBuffer(".");
@@ -1956,8 +1952,8 @@ public class JavaASTFlattener extends ASTVisitor {
   @Override
   public boolean visit(final SuperMethodInvocation node) {
     Name _qualifier = node.getQualifier();
-    boolean _notEquals = (!Objects.equal(_qualifier, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_qualifier != null);
+    if (_tripleNotEquals) {
       Name _qualifier_1 = node.getQualifier();
       _qualifier_1.accept(this);
       this.appendToBuffer(".");
@@ -1990,8 +1986,8 @@ public class JavaASTFlattener extends ASTVisitor {
     }
     boolean previousRequiresWhiteSpace = false;
     String _tagName = node.getTagName();
-    boolean _notEquals = (!Objects.equal(_tagName, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_tagName != null);
+    if (_tripleNotEquals) {
       String _tagName_1 = node.getTagName();
       this.appendToBuffer(_tagName_1);
       previousRequiresWhiteSpace = true;
@@ -2075,8 +2071,8 @@ public class JavaASTFlattener extends ASTVisitor {
     };
     _catchClauses.forEach(_function);
     Block _finally = node.getFinally();
-    boolean _notEquals = (!Objects.equal(_finally, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_finally != null);
+    if (_tripleNotEquals) {
       this.appendToBuffer(" finally ");
       Block _finally_1 = node.getFinally();
       _finally_1.accept(this);
@@ -2173,8 +2169,7 @@ public class JavaASTFlattener extends ASTVisitor {
   public boolean visit(final WildcardType node) {
     this.appendToBuffer("?");
     Type bound = node.getBound();
-    boolean _notEquals = (!Objects.equal(bound, null));
-    if (_notEquals) {
+    if ((bound != null)) {
       boolean _isUpperBound = node.isUpperBound();
       if (_isUpperBound) {
         this.appendToBuffer(" extends ");
@@ -2213,8 +2208,8 @@ public class JavaASTFlattener extends ASTVisitor {
   @Override
   public boolean visit(final AnnotationTypeDeclaration node) {
     Javadoc _javadoc = node.getJavadoc();
-    boolean _notEquals = (!Objects.equal(_javadoc, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_javadoc != null);
+    if (_tripleNotEquals) {
       Javadoc _javadoc_1 = node.getJavadoc();
       _javadoc_1.accept(this);
     }
@@ -2234,8 +2229,8 @@ public class JavaASTFlattener extends ASTVisitor {
   @Override
   public boolean visit(final AnnotationTypeMemberDeclaration node) {
     Javadoc _javadoc = node.getJavadoc();
-    boolean _notEquals = (!Objects.equal(_javadoc, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_javadoc != null);
+    if (_tripleNotEquals) {
       Javadoc _javadoc_1 = node.getJavadoc();
       _javadoc_1.accept(this);
     }
@@ -2247,8 +2242,8 @@ public class JavaASTFlattener extends ASTVisitor {
     SimpleName _name = node.getName();
     _name.accept(this);
     Expression _default = node.getDefault();
-    boolean _notEquals_1 = (!Objects.equal(_default, null));
-    if (_notEquals_1) {
+    boolean _tripleNotEquals_1 = (_default != null);
+    if (_tripleNotEquals_1) {
       this.appendToBuffer(" = ");
       Expression _default_1 = node.getDefault();
       _default_1.accept(this);
@@ -2343,8 +2338,8 @@ public class JavaASTFlattener extends ASTVisitor {
       return false;
     }
     ArrayInitializer _initializer = node.getInitializer();
-    boolean _notEquals = (!Objects.equal(_initializer, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_initializer != null);
+    if (_tripleNotEquals) {
       if (this.fallBackStrategy) {
         this.appendToBuffer("(");
       }
@@ -2427,8 +2422,8 @@ public class JavaASTFlattener extends ASTVisitor {
     this.appendToBuffer(")) {");
     this.appendToBuffer("throw new AssertionError(");
     Expression _message = node.getMessage();
-    boolean _notEquals = (!Objects.equal(_message, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_message != null);
+    if (_tripleNotEquals) {
       Expression _message_1 = node.getMessage();
       _message_1.accept(this);
     }
@@ -2443,8 +2438,8 @@ public class JavaASTFlattener extends ASTVisitor {
     this.appendToBuffer(_builder.toString());
     this.addProblem(node, "Break statement is not supported");
     SimpleName _label = node.getLabel();
-    boolean _notEquals = (!Objects.equal(_label, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_label != null);
+    if (_tripleNotEquals) {
       this.appendSpaceToBuffer();
       SimpleName _label_1 = node.getLabel();
       _label_1.accept(this);
@@ -2509,8 +2504,8 @@ public class JavaASTFlattener extends ASTVisitor {
     this.appendToBuffer("/* FIXME Unsupported continue statement */ continue");
     this.addProblem(node, "Continue statement is not supported");
     SimpleName _label = node.getLabel();
-    boolean _notEquals = (!Objects.equal(_label, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_label != null);
+    if (_tripleNotEquals) {
       this.appendSpaceToBuffer();
       SimpleName _label_1 = node.getLabel();
       _label_1.accept(this);
@@ -2555,8 +2550,8 @@ public class JavaASTFlattener extends ASTVisitor {
   @Override
   public boolean visit(final EnumConstantDeclaration node) {
     Javadoc _javadoc = node.getJavadoc();
-    boolean _notEquals = (!Objects.equal(_javadoc, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_javadoc != null);
+    if (_tripleNotEquals) {
       Javadoc _javadoc_1 = node.getJavadoc();
       _javadoc_1.accept(this);
     }
@@ -2575,8 +2570,8 @@ public class JavaASTFlattener extends ASTVisitor {
       this.appendToBuffer(")");
     }
     AnonymousClassDeclaration _anonymousClassDeclaration = node.getAnonymousClassDeclaration();
-    boolean _notEquals_1 = (!Objects.equal(_anonymousClassDeclaration, null));
-    if (_notEquals_1) {
+    boolean _tripleNotEquals_1 = (_anonymousClassDeclaration != null);
+    if (_tripleNotEquals_1) {
       this.addProblem(node, "Enum constant cannot have any anonymous class declarations");
       AnonymousClassDeclaration _anonymousClassDeclaration_1 = node.getAnonymousClassDeclaration();
       _anonymousClassDeclaration_1.accept(this);
@@ -2587,8 +2582,8 @@ public class JavaASTFlattener extends ASTVisitor {
   @Override
   public boolean visit(final EnumDeclaration node) {
     Javadoc _javadoc = node.getJavadoc();
-    boolean _notEquals = (!Objects.equal(_javadoc, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_javadoc != null);
+    if (_tripleNotEquals) {
       Javadoc _javadoc_1 = node.getJavadoc();
       _javadoc_1.accept(this);
     }
@@ -2649,8 +2644,8 @@ public class JavaASTFlattener extends ASTVisitor {
   @Override
   public boolean visit(final MemberRef node) {
     Name _qualifier = node.getQualifier();
-    boolean _notEquals = (!Objects.equal(_qualifier, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_qualifier != null);
+    if (_tripleNotEquals) {
       Name _qualifier_1 = node.getQualifier();
       _qualifier_1.accept(this);
     }
@@ -2663,8 +2658,8 @@ public class JavaASTFlattener extends ASTVisitor {
   @Override
   public boolean visit(final MethodRef node) {
     Name _qualifier = node.getQualifier();
-    boolean _notEquals = (!Objects.equal(_qualifier, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_qualifier != null);
+    if (_tripleNotEquals) {
       Name _qualifier_1 = node.getQualifier();
       _qualifier_1.accept(this);
     }
@@ -2687,8 +2682,8 @@ public class JavaASTFlattener extends ASTVisitor {
       this.appendToBuffer("...");
     }
     SimpleName _name = node.getName();
-    boolean _notEquals = (!Objects.equal(_name, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_name != null);
+    if (_tripleNotEquals) {
       this.appendSpaceToBuffer();
       SimpleName _name_1 = node.getName();
       _name_1.accept(this);

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/javaconverter/JavaConverter.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/javaconverter/JavaConverter.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.javaconverter;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import java.util.List;
@@ -48,8 +47,8 @@ public class JavaConverter {
       String _result = flattener.getResult();
       result.xtendCode = _result;
       List<String> _problems = flattener.getProblems();
-      boolean _notEquals = (!Objects.equal(_problems, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_problems != null);
+      if (_tripleNotEquals) {
         List<String> _problems_1 = flattener.getProblems();
         result.problems = _problems_1;
       }
@@ -107,8 +106,7 @@ public class JavaConverter {
   public JavaConverter.ConversionResult toXtend(final String unitName, final String javaSrc) {
     JavaConverter.ConversionResult _xblockexpression = null;
     {
-      boolean _equals = Objects.equal(unitName, null);
-      if (_equals) {
+      if ((unitName == null)) {
         throw new IllegalArgumentException();
       }
       ASTParserFactory.ASTParserWrapper _createJavaParser = this.astParserFactory.createJavaParser(null);
@@ -127,8 +125,7 @@ public class JavaConverter {
   public JavaConverter.ConversionResult toXtend(final String unitName, final String javaSrc, final Object classPathContext) {
     JavaConverter.ConversionResult _xblockexpression = null;
     {
-      boolean _equals = Objects.equal(unitName, null);
-      if (_equals) {
+      if ((unitName == null)) {
         throw new IllegalArgumentException();
       }
       ASTParserFactory.ASTParserWrapper _createJavaParser = this.astParserFactory.createJavaParser(classPathContext);
@@ -226,15 +223,13 @@ public class JavaConverter {
    */
   private JavaConverter.ConversionResult internalToXtend(final String unitName, final String javaSrc, final String[] imports, final ASTParserFactory.ASTParserWrapper parser) {
     final StringBuilder javaSrcBuilder = new StringBuilder();
-    boolean _notEquals = (!Objects.equal(imports, null));
-    if (_notEquals) {
+    if ((imports != null)) {
       final Consumer<String> _function = (String it) -> {
         javaSrcBuilder.append((("import " + it) + ";"));
       };
       ((List<String>)Conversions.doWrapArray(imports)).forEach(_function);
     }
-    boolean _equals = Objects.equal(unitName, null);
-    if (_equals) {
+    if ((unitName == null)) {
       parser.setUnitName("MISSING");
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("class MISSING { ");

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ActiveAnnotationContextProvider.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ActiveAnnotationContextProvider.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.macro;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import java.util.List;
@@ -92,8 +91,7 @@ public class ActiveAnnotationContextProvider {
           final JvmType processorType = this._xAnnotationExtensions.getProcessorType(_key_1);
           try {
             final Object processorInstance = this._processorInstanceForJvmTypeProvider.getProcessorInstance(processorType);
-            boolean _equals = Objects.equal(processorInstance, null);
-            if (_equals) {
+            if ((processorInstance == null)) {
               String _identifier = processorType.getIdentifier();
               String _plus = ("Couldn\'t instantiate the annotation processor of type \'" + _identifier);
               String _plus_1 = (_plus + "\'. This is usually the case when the processor resides in the same project as the annotated element.");
@@ -268,8 +266,7 @@ public class ActiveAnnotationContextProvider {
     for (final XAnnotation annotation : _filter) {
       {
         final JvmAnnotationType activeAnnotationDeclaration = this._xAnnotationExtensions.tryFindAnnotationType(annotation);
-        boolean _notEquals = (!Objects.equal(activeAnnotationDeclaration, null));
-        if (_notEquals) {
+        if ((activeAnnotationDeclaration != null)) {
           boolean _isValid = this.isValid(annotation, activeAnnotationDeclaration);
           if (_isValid) {
             Pair<JvmAnnotationType, XAnnotation> _mappedTo = Pair.<JvmAnnotationType, XAnnotation>of(activeAnnotationDeclaration, annotation);
@@ -281,6 +278,6 @@ public class ActiveAnnotationContextProvider {
   }
   
   private boolean isValid(final XAnnotation annotation, final JvmAnnotationType activeAnnotationDeclaration) {
-    return (!Objects.equal(annotation, null));
+    return (annotation != null);
   }
 }

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ActiveAnnotationContexts.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ActiveAnnotationContexts.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.macro;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import java.util.Map;
 import org.eclipse.emf.common.notify.Adapter;
@@ -56,8 +55,7 @@ public class ActiveAnnotationContexts extends AdapterImpl {
     EList<Adapter> _eAdapters = resource.eAdapters();
     Iterable<ActiveAnnotationContexts> _filter = Iterables.<ActiveAnnotationContexts>filter(_eAdapters, ActiveAnnotationContexts.class);
     ActiveAnnotationContexts result = IterableExtensions.<ActiveAnnotationContexts>head(_filter);
-    boolean _notEquals = (!Objects.equal(result, null));
-    if (_notEquals) {
+    if ((result != null)) {
       result.contexts.clear();
     } else {
       ActiveAnnotationContexts _activeAnnotationContexts = new ActiveAnnotationContexts();

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/CompilationContextImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/CompilationContextImpl.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.macro;
 
-import com.google.common.base.Objects;
 import org.eclipse.xtend.core.macro.declaration.CompilationUnitImpl;
 import org.eclipse.xtend.lib.macro.declaration.CompilationStrategy;
 import org.eclipse.xtend.lib.macro.declaration.TypeReference;
@@ -53,8 +52,7 @@ public class CompilationContextImpl implements CompilationStrategy.CompilationCo
   @Override
   public String toJavaCode(final TypeReference typeref) {
     StringBuilderBasedAppendable _xifexpression = null;
-    boolean _notEquals = (!Objects.equal(this.importManager, null));
-    if (_notEquals) {
+    if ((this.importManager != null)) {
       _xifexpression = new StringBuilderBasedAppendable(this.importManager);
     } else {
       _xifexpression = new StringBuilderBasedAppendable();

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ConditionUtils.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ConditionUtils.java
@@ -22,22 +22,21 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
 @SuppressWarnings("all")
 public class ConditionUtils {
   public static void notRemoved(final EObject object, final String name) {
-    boolean _notEquals = (!Objects.equal(object, null));
     StringConcatenation _builder = new StringConcatenation();
     _builder.append(name, "");
     _builder.append(" cannot be null");
-    Preconditions.checkArgument(_notEquals, _builder);
+    Preconditions.checkArgument((object != null), _builder);
     Resource _eResource = object.eResource();
-    boolean _notEquals_1 = (!Objects.equal(_eResource, null));
+    boolean _tripleNotEquals = (_eResource != null);
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append(name, "");
     _builder_1.append(" cannot be removed");
-    Preconditions.checkArgument(_notEquals_1, _builder_1);
+    Preconditions.checkArgument(_tripleNotEquals, _builder_1);
   }
   
   public static void checkInferredTypeReferences(final String typeName, final TypeReference... types) {
     for (final TypeReference type : types) {
-      if (((!Objects.equal(type, null)) && type.isInferred())) {
+      if (((type != null) && type.isInferred())) {
         StringConcatenation _builder = new StringConcatenation();
         _builder.append("Cannot use inferred type as ");
         _builder.append(typeName, "");
@@ -48,17 +47,15 @@ public class ConditionUtils {
   }
   
   public static void checkIterable(final Iterable<?> values, final String name) {
-    boolean _notEquals = (!Objects.equal(values, null));
     StringConcatenation _builder = new StringConcatenation();
     _builder.append(name, "");
     _builder.append(" cannot be null");
-    Preconditions.checkArgument(_notEquals, _builder);
+    Preconditions.checkArgument((values != null), _builder);
     for (final Object value : values) {
-      boolean _notEquals_1 = (!Objects.equal(value, null));
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append(name, "");
       _builder_1.append(" cannot contain null");
-      Preconditions.checkArgument(_notEquals_1, _builder_1);
+      Preconditions.checkArgument((value != null), _builder_1);
     }
   }
   
@@ -95,7 +92,7 @@ public class ConditionUtils {
   public static boolean isValidQualifiedName(final String string) {
     boolean _xblockexpression = false;
     {
-      if ((Objects.equal(string, null) || (string.length() == 0))) {
+      if (((string == null) || (string.length() == 0))) {
         return false;
       }
       String[] _split = string.split("\\.");
@@ -114,7 +111,7 @@ public class ConditionUtils {
   public static boolean isValidJavaIdentifier(final String string) {
     boolean _xblockexpression = false;
     {
-      if ((Objects.equal(string, null) || (string.length() == 0))) {
+      if (((string == null) || (string.length() == 0))) {
         return false;
       }
       final char[] charArray = string.toCharArray();

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ConstantExpressionsInterpreter.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ConstantExpressionsInterpreter.java
@@ -113,8 +113,7 @@ public class ConstantExpressionsInterpreter extends AbstractConstantExpressionsI
             if ((((JvmField)member).isFinal() && ((JvmField)member).isStatic())) {
               String _simpleName = ((JvmField)member).getSimpleName();
               final JvmIdentifiableElement existing = result.put(_simpleName, member);
-              boolean _notEquals = (!Objects.equal(existing, null));
-              if (_notEquals) {
+              if ((existing != null)) {
                 String _simpleName_1 = existing.getSimpleName();
                 result.put(_simpleName_1, existing);
               }
@@ -214,15 +213,13 @@ public class ConstantExpressionsInterpreter extends AbstractConstantExpressionsI
         final HashMap<String, JvmIdentifiableElement> result = CollectionLiterals.<String, JvmIdentifiableElement>newHashMap();
         Resource _eResource_2 = expression.eResource();
         final XImportSection section = this.importSectionLocator.getImportSection(((XtextResource) _eResource_2));
-        boolean _notEquals = (!Objects.equal(section, null));
-        if (_notEquals) {
+        if ((section != null)) {
           EList<XImportDeclaration> _importDeclarations = section.getImportDeclarations();
           for (final XImportDeclaration imp : _importDeclarations) {
             boolean _isStatic = imp.isStatic();
             if (_isStatic) {
               final String importedTypeName = imp.getImportedTypeName();
-              boolean _notEquals_1 = (!Objects.equal(importedTypeName, null));
-              if (_notEquals_1) {
+              if ((importedTypeName != null)) {
                 final JvmType type = this.findTypeByName(imp, importedTypeName);
                 boolean _matched_2 = false;
                 if (type instanceof JvmGenericType) {
@@ -252,8 +249,7 @@ public class ConstantExpressionsInterpreter extends AbstractConstantExpressionsI
   }
   
   protected void collectAllVisibleFields(final JvmDeclaredType type, final Map<String, JvmIdentifiableElement> result) {
-    boolean _equals = Objects.equal(type, null);
-    if (_equals) {
+    if ((type == null)) {
       return;
     }
     JvmDeclaredType _declaringType = type.getDeclaringType();
@@ -286,8 +282,8 @@ public class ConstantExpressionsInterpreter extends AbstractConstantExpressionsI
       {
         Class<? extends Number> _xifexpression = null;
         JvmTypeReference _expectedType = ctx.getExpectedType();
-        boolean _equals = Objects.equal(_expectedType, null);
-        if (_equals) {
+        boolean _tripleEquals = (_expectedType == null);
+        if (_tripleEquals) {
           _xifexpression = this.numberLiterals.getJavaType(it);
         } else {
           JvmTypeReference _expectedType_1 = ctx.getExpectedType();
@@ -323,8 +319,7 @@ public class ConstantExpressionsInterpreter extends AbstractConstantExpressionsI
       };
       final List<Object> elements = ListExtensions.<XExpression, Object>map(_elements, _function);
       Class<?> _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(expectedComponentType, null));
-      if (_notEquals) {
+      if ((expectedComponentType != null)) {
         JvmType _type = expectedComponentType.getType();
         ClassFinder _classFinder = ctx.getClassFinder();
         _xifexpression = this.getJavaType(_type, _classFinder);
@@ -453,8 +448,7 @@ public class ConstantExpressionsInterpreter extends AbstractConstantExpressionsI
         _matched_1=true;
       }
       if (!_matched_1) {
-        boolean _equals = Objects.equal(it_1, null);
-        if (_equals) {
+        if ((it_1 == null)) {
           _matched_1=true;
         }
       }
@@ -529,8 +523,7 @@ public class ConstantExpressionsInterpreter extends AbstractConstantExpressionsI
       return _switchResult_2;
     }
     final JvmType type = this.findTypeByName(it, featureName);
-    boolean _notEquals = (!Objects.equal(type, null));
-    if (_notEquals) {
+    if ((type != null)) {
       this.resolveType(it, type);
       return this.toTypeReference(type, 0);
     }
@@ -605,8 +598,7 @@ public class ConstantExpressionsInterpreter extends AbstractConstantExpressionsI
             return Boolean.valueOf(Objects.equal(_simpleName, featureName));
           };
           final JvmEnumerationLiteral enumValue = IterableExtensions.<JvmEnumerationLiteral>findFirst(_literals, _function);
-          boolean _equals = Objects.equal(enumValue, null);
-          if (_equals) {
+          if ((enumValue == null)) {
             String _simpleName = ((JvmTypeReference)receiver).getSimpleName();
             String _plus = ((("Couldn\'t find enum value " + featureName) + " on enum ") + _simpleName);
             throw new ConstantExpressionEvaluationException(_plus, it);
@@ -624,8 +616,7 @@ public class ConstantExpressionsInterpreter extends AbstractConstantExpressionsI
               return Boolean.valueOf(Objects.equal(_simpleName, featureName));
             };
             final JvmField field = IterableExtensions.<JvmField>findFirst(_filter, _function);
-            boolean _equals = Objects.equal(field, null);
-            if (_equals) {
+            if ((field == null)) {
               String _simpleName = ((JvmTypeReference)receiver).getSimpleName();
               String _plus = ((("Couldn\'t find field " + featureName) + " on type ") + _simpleName);
               throw new ConstantExpressionEvaluationException(_plus, it);
@@ -641,8 +632,7 @@ public class ConstantExpressionsInterpreter extends AbstractConstantExpressionsI
         final UnresolvableFeatureException e = (UnresolvableFeatureException)_t;
         final String typeName = this.getFullName(it);
         final JvmType type = this.findTypeByName(it, typeName);
-        boolean _notEquals = (!Objects.equal(type, null));
-        if (_notEquals) {
+        if ((type != null)) {
           this.resolveType(it, type);
           return this.toTypeReference(type, 0);
         } else {

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/FileLocationsImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/FileLocationsImpl.java
@@ -66,16 +66,14 @@ public class FileLocationsImpl implements FileLocations {
     Path _xblockexpression = null;
     {
       final Path projectFolder = this.getProjectFolder(path);
-      boolean _equals = Objects.equal(projectFolder, null);
-      if (_equals) {
+      if ((projectFolder == null)) {
         return null;
       }
       Set<OutputConfiguration> _outputConfigurations = this.outputConfigurationProvider.getOutputConfigurations(this.context);
       final OutputConfiguration outputConfiguration = IterableExtensions.<OutputConfiguration>head(_outputConfigurations);
       final Path sourceFolder = this.getSourceFolder(path);
       String _xifexpression = null;
-      boolean _equals_1 = Objects.equal(sourceFolder, null);
-      if (_equals_1) {
+      if ((sourceFolder == null)) {
         _xifexpression = outputConfiguration.getOutputDirectory();
       } else {
         String _xblockexpression_1 = null;

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ProcessorInstanceForJvmTypeProvider.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ProcessorInstanceForJvmTypeProvider.java
@@ -57,8 +57,7 @@ public class ProcessorInstanceForJvmTypeProvider {
     
     @Override
     public void setTarget(final Notifier newTarget) {
-      boolean _equals = Objects.equal(newTarget, null);
-      if (_equals) {
+      if ((newTarget == null)) {
         this.discard();
       }
     }
@@ -138,8 +137,7 @@ public class ProcessorInstanceForJvmTypeProvider {
     EList<Adapter> _eAdapters = resourceSet.eAdapters();
     Iterable<ProcessorInstanceForJvmTypeProvider.ProcessorClassloaderAdapter> _filter = Iterables.<ProcessorInstanceForJvmTypeProvider.ProcessorClassloaderAdapter>filter(_eAdapters, ProcessorInstanceForJvmTypeProvider.ProcessorClassloaderAdapter.class);
     final ProcessorInstanceForJvmTypeProvider.ProcessorClassloaderAdapter adapter = IterableExtensions.<ProcessorInstanceForJvmTypeProvider.ProcessorClassloaderAdapter>head(_filter);
-    boolean _notEquals = (!Objects.equal(adapter, null));
-    if (_notEquals) {
+    if ((adapter != null)) {
       return adapter.getClassLoader();
     }
     boolean _matched = false;
@@ -179,8 +177,7 @@ public class ProcessorInstanceForJvmTypeProvider {
         _xifexpression = jvmTypeLoader;
       }
       final ClassLoader processorClassLoader = _xifexpression;
-      boolean _notEquals_1 = (!Objects.equal(processorClassLoader, null));
-      if (_notEquals_1) {
+      if ((processorClassLoader != null)) {
         EList<Adapter> _eAdapters_1 = ((XtextResourceSet)resourceSet).eAdapters();
         ProcessorInstanceForJvmTypeProvider.ProcessorClassloaderAdapter _processorClassloaderAdapter = new ProcessorInstanceForJvmTypeProvider.ProcessorClassloaderAdapter(processorClassLoader);
         _eAdapters_1.add(_processorClassloaderAdapter);

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/RegisterGlobalsContextImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/RegisterGlobalsContextImpl.java
@@ -92,12 +92,12 @@ public class RegisterGlobalsContextImpl implements RegisterGlobalsContext {
   private void setNameAndAccept(final JvmDeclaredType newType, final String qualifiedName) {
     ConditionUtils.checkQualifiedName(qualifiedName, "qualifiedName");
     JvmDeclaredType _findType = this.findType(qualifiedName);
-    boolean _equals = Objects.equal(_findType, null);
+    boolean _tripleEquals = (_findType == null);
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("The type \'");
     _builder.append(qualifiedName, "");
     _builder.append("\' has already been registered.");
-    Preconditions.checkArgument(_equals, _builder);
+    Preconditions.checkArgument(_tripleEquals, _builder);
     this.compilationUnit.checkCanceled();
     final Pair<String, String> namespaceAndName = this.getNameParts(qualifiedName);
     IFileHeaderProvider _fileHeaderProvider = this.compilationUnit.getFileHeaderProvider();
@@ -107,12 +107,11 @@ public class RegisterGlobalsContextImpl implements RegisterGlobalsContext {
     JvmTypesBuilder _jvmTypesBuilder = this.compilationUnit.getJvmTypesBuilder();
     _jvmTypesBuilder.setFileHeader(newType, headerText);
     String _key = namespaceAndName.getKey();
-    boolean _notEquals = (!Objects.equal(_key, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_key != null);
+    if (_tripleNotEquals) {
       String _key_1 = namespaceAndName.getKey();
       final JvmDeclaredType parentType = this.findType(_key_1);
-      boolean _notEquals_1 = (!Objects.equal(parentType, null));
-      if (_notEquals_1) {
+      if ((parentType != null)) {
         EList<JvmMember> _members = parentType.getMembers();
         _members.add(newType);
         newType.setStatic(true);
@@ -149,8 +148,7 @@ public class RegisterGlobalsContextImpl implements RegisterGlobalsContext {
           EList<JvmMember> _members = type.getMembers();
           Iterable<JvmDeclaredType> _filter = Iterables.<JvmDeclaredType>filter(_members, JvmDeclaredType.class);
           final JvmDeclaredType result = this.findRecursively(string, _filter);
-          boolean _notEquals = (!Objects.equal(result, null));
-          if (_notEquals) {
+          if ((result != null)) {
             return result;
           }
         }

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/XAnnotationExtensions.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/XAnnotationExtensions.java
@@ -195,7 +195,7 @@ public class XAnnotationExtensions {
     final JvmAnnotationReference activeAnnotation = IterableExtensions.<JvmAnnotationReference>findFirst(_annotations, _function);
     EList<JvmAnnotationValue> _values = activeAnnotation.getValues();
     final Function1<JvmAnnotationValue, Boolean> _function_1 = (JvmAnnotationValue it_1) -> {
-      return Boolean.valueOf((Objects.equal(it_1.getOperation(), null) || Objects.equal(it_1.getOperation().getSimpleName(), "value")));
+      return Boolean.valueOf(((it_1.getOperation() == null) || Objects.equal(it_1.getOperation().getSimpleName(), "value")));
     };
     final JvmAnnotationValue annoVal = IterableExtensions.<JvmAnnotationValue>findFirst(_values, _function_1);
     boolean _matched = false;

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/AnnotationReferenceBuildContextImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/AnnotationReferenceBuildContextImpl.java
@@ -86,8 +86,7 @@ public class AnnotationReferenceBuildContextImpl implements AnnotationReferenceB
       return Boolean.valueOf(Objects.equal(_simpleName, name));
     };
     final JvmOperation jvmOperation = IterableExtensions.<JvmOperation>findFirst(_declaredOperations, _function);
-    boolean _equals = Objects.equal(jvmOperation, null);
-    if (_equals) {
+    if ((jvmOperation == null)) {
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("The annotation property \'");
       _builder.append(name, "");
@@ -109,7 +108,7 @@ public class AnnotationReferenceBuildContextImpl implements AnnotationReferenceB
     EList<JvmAnnotationValue> _explicitValues = this.delegate.getExplicitValues();
     Iterator<JvmAnnotationValue> _iterator = _explicitValues.iterator();
     final Predicate<JvmAnnotationValue> _function = (JvmAnnotationValue it) -> {
-      return (Objects.equal(op, it.getOperation()) || (Objects.equal(it.getOperation(), null) && Objects.equal(op.getSimpleName(), "value")));
+      return (Objects.equal(op, it.getOperation()) || ((it.getOperation() == null) && Objects.equal(op.getSimpleName(), "value")));
     };
     return Iterators.<JvmAnnotationValue>removeIf(_iterator, _function);
   }
@@ -505,8 +504,7 @@ public class AnnotationReferenceBuildContextImpl implements AnnotationReferenceB
   }
   
   protected void _setValue(final JvmAnnotationValue it, final Object value, final String componentType, final boolean mustBeArray) {
-    boolean _equals = Objects.equal(componentType, null);
-    if (_equals) {
+    if ((componentType == null)) {
       Class<?> _class = value.getClass();
       String _name = _class.getName();
       this.throwNotApplicable(it, _name);
@@ -525,8 +523,8 @@ public class AnnotationReferenceBuildContextImpl implements AnnotationReferenceB
       if (_type!=null) {
         _eClass=_type.eClass();
       }
-      boolean _equals_1 = Objects.equal(_eClass, TypesPackage.Literals.JVM_ARRAY_TYPE);
-      _or = _equals_1;
+      boolean _equals = Objects.equal(_eClass, TypesPackage.Literals.JVM_ARRAY_TYPE);
+      _or = _equals;
     }
     if (_or) {
       this.throwNotApplicable(it, (componentType + "[]"));
@@ -795,8 +793,7 @@ public class AnnotationReferenceBuildContextImpl implements AnnotationReferenceB
   }
   
   protected void checkType(final JvmAnnotationValue it, final String componentType, final boolean mustBeArray) {
-    boolean _equals = Objects.equal(componentType, null);
-    if (_equals) {
+    if ((componentType == null)) {
       return;
     }
     JvmOperation _operation = it.getOperation();
@@ -814,8 +811,8 @@ public class AnnotationReferenceBuildContextImpl implements AnnotationReferenceB
       if (returnType!=null) {
         _eClass=returnType.eClass();
       }
-      boolean _equals_1 = Objects.equal(_eClass, TypesPackage.Literals.JVM_ARRAY_TYPE);
-      _or = _equals_1;
+      boolean _equals = Objects.equal(_eClass, TypesPackage.Literals.JVM_ARRAY_TYPE);
+      _or = _equals;
     }
     if (_or) {
       String _annotationValueTypeName = this.getAnnotationValueTypeName(returnType);

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/AnnotationReferenceProviderImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/AnnotationReferenceProviderImpl.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.macro.declaration;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import org.eclipse.emf.common.util.EList;
@@ -86,20 +85,17 @@ public class AnnotationReferenceProviderImpl implements AnnotationReferenceProvi
     AnnotationReference _xblockexpression = null;
     {
       this.compilationUnit.checkCanceled();
-      boolean _notEquals = (!Objects.equal(annotationTypeName, null));
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("annotationTypeName cannot be null");
-      Preconditions.checkArgument(_notEquals, _builder);
-      boolean _notEquals_1 = (!Objects.equal(initializer, null));
+      Preconditions.checkArgument((annotationTypeName != null), _builder);
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append("initializer cannot be null");
-      Preconditions.checkArgument(_notEquals_1, _builder_1);
+      Preconditions.checkArgument((initializer != null), _builder_1);
       TypeReferences _typeReferences = this.compilationUnit.getTypeReferences();
       XtendFile _xtendFile = this.compilationUnit.getXtendFile();
       JvmType _findDeclaredType = _typeReferences.findDeclaredType(annotationTypeName, _xtendFile);
       final JvmAnnotationReference jvmAnnotationReference = this.createJvmAnnotationReference(_findDeclaredType);
-      boolean _equals = Objects.equal(jvmAnnotationReference, null);
-      if (_equals) {
+      if ((jvmAnnotationReference == null)) {
         return null;
       }
       AnnotationReferenceBuildContextImpl _annotationReferenceBuildContextImpl = new AnnotationReferenceBuildContextImpl();
@@ -119,14 +115,12 @@ public class AnnotationReferenceProviderImpl implements AnnotationReferenceProvi
     Object _xblockexpression = null;
     {
       this.compilationUnit.checkCanceled();
-      boolean _notEquals = (!Objects.equal(annotationTypeDelcaration, null));
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("annotationTypeDelcaration cannot be null");
-      Preconditions.checkArgument(_notEquals, _builder);
-      boolean _notEquals_1 = (!Objects.equal(initializer, null));
+      Preconditions.checkArgument((annotationTypeDelcaration != null), _builder);
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append("initializer cannot be null");
-      Preconditions.checkArgument(_notEquals_1, _builder_1);
+      Preconditions.checkArgument((initializer != null), _builder_1);
       JvmDeclaredType _switchResult = null;
       boolean _matched = false;
       if (annotationTypeDelcaration instanceof JvmAnnotationTypeDeclarationImpl) {
@@ -165,10 +159,9 @@ public class AnnotationReferenceProviderImpl implements AnnotationReferenceProvi
   public AnnotationReference newAnnotationReference(final Class<?> annotationClass, final Procedure1<AnnotationReferenceBuildContext> initializer) {
     AnnotationReference _xblockexpression = null;
     {
-      boolean _notEquals = (!Objects.equal(annotationClass, null));
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("annotationClass cannot be null");
-      Preconditions.checkArgument(_notEquals, _builder);
+      Preconditions.checkArgument((annotationClass != null), _builder);
       String _name = annotationClass.getName();
       _xblockexpression = this.newAnnotationReference(_name, initializer);
     }
@@ -180,14 +173,12 @@ public class AnnotationReferenceProviderImpl implements AnnotationReferenceProvi
     Object _xblockexpression = null;
     {
       this.compilationUnit.checkCanceled();
-      boolean _notEquals = (!Objects.equal(annotationReference, null));
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("annotationReference cannot be null");
-      Preconditions.checkArgument(_notEquals, _builder);
-      boolean _notEquals_1 = (!Objects.equal(initializer, null));
+      Preconditions.checkArgument((annotationReference != null), _builder);
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append("initializer cannot be null");
-      Preconditions.checkArgument(_notEquals_1, _builder_1);
+      Preconditions.checkArgument((initializer != null), _builder_1);
       if ((annotationReference instanceof JvmAnnotationReferenceImpl)) {
         final JvmAnnotationReference baseJvmAnnotationReference = ((JvmAnnotationReferenceImpl)annotationReference).getDelegate();
         ConditionUtils.notRemoved(baseJvmAnnotationReference, "annotationReference");

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/CompilationUnitImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/CompilationUnitImpl.java
@@ -373,15 +373,13 @@ public class CompilationUnitImpl implements CompilationUnit {
   public MutableFileSystemSupport getFileSystemSupport() {
     MutableFileSystemSupport _xblockexpression = null;
     {
-      boolean _equals = Objects.equal(this.decoratedFileSystemSupport, null);
-      if (_equals) {
+      if ((this.decoratedFileSystemSupport == null)) {
         Resource _eResource = this.xtendFile.eResource();
         ResourceSet _resourceSet = _eResource.getResourceSet();
         EList<Adapter> _eAdapters = _resourceSet.eAdapters();
         Iterable<FileSystemAccessQueue> _filter = Iterables.<FileSystemAccessQueue>filter(_eAdapters, FileSystemAccessQueue.class);
         final FileSystemAccessQueue fileSystemAccessQueue = IterableExtensions.<FileSystemAccessQueue>head(_filter);
-        boolean _equals_1 = Objects.equal(fileSystemAccessQueue, null);
-        if (_equals_1) {
+        if ((fileSystemAccessQueue == null)) {
           return this.createListeningFileSystemSupport();
         }
         Resource _eResource_1 = this.xtendFile.eResource();
@@ -455,8 +453,7 @@ public class CompilationUnitImpl implements CompilationUnit {
   
   private <IN extends Object, OUT extends Object> OUT getOrCreate(final IN in, final Function1<? super IN, ? extends OUT> provider) {
     this.checkCanceled();
-    boolean _equals = Objects.equal(in, null);
-    if (_equals) {
+    if ((in == null)) {
       return null;
     }
     boolean _containsKey = this.identityCache.containsKey(in);
@@ -907,8 +904,7 @@ public class CompilationUnitImpl implements CompilationUnit {
   public TypeReference toTypeReference(final JvmTypeReference delegate) {
     TypeReference _xblockexpression = null;
     {
-      boolean _equals = Objects.equal(delegate, null);
-      if (_equals) {
+      if ((delegate == null)) {
         return null;
       }
       TypeReference _switchResult = null;
@@ -943,8 +939,7 @@ public class CompilationUnitImpl implements CompilationUnit {
     TypeReferenceImpl _xblockexpression = null;
     {
       this.checkCanceled();
-      boolean _equals = Objects.equal(delegate, null);
-      if (_equals) {
+      if ((delegate == null)) {
         return null;
       }
       TypeReferenceImpl _typeReferenceImpl = new TypeReferenceImpl();
@@ -1404,8 +1399,7 @@ public class CompilationUnitImpl implements CompilationUnit {
   protected Object translateAnnotationValue(final Object value, final JvmTypeReference expectedType, final boolean isArray) {
     Object _xblockexpression = null;
     {
-      boolean _equals = Objects.equal(value, null);
-      if (_equals) {
+      if ((value == null)) {
         return null;
       }
       if (((!isArray) || value.getClass().isArray())) {
@@ -1483,8 +1477,8 @@ public class CompilationUnitImpl implements CompilationUnit {
   
   protected JvmTypeReference findExpectedType(final JvmAnnotationValue value) {
     JvmOperation _operation = value.getOperation();
-    boolean _notEquals = (!Objects.equal(_operation, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_operation != null);
+    if (_tripleNotEquals) {
       JvmOperation _operation_1 = value.getOperation();
       return _operation_1.getReturnType();
     }
@@ -1506,8 +1500,7 @@ public class CompilationUnitImpl implements CompilationUnit {
           Iterable<JvmOperation> _filter = Iterables.<JvmOperation>filter(_findAllFeaturesByName, JvmOperation.class);
           final JvmOperation defaultOp = IterableExtensions.<JvmOperation>head(_filter);
           JvmTypeReference _xifexpression = null;
-          boolean _notEquals_1 = (!Objects.equal(defaultOp, null));
-          if (_notEquals_1) {
+          if ((defaultOp != null)) {
             _xifexpression = defaultOp.getReturnType();
           }
           _xblockexpression = _xifexpression;
@@ -1667,8 +1660,7 @@ public class CompilationUnitImpl implements CompilationUnit {
       for (final XAnnotationElementValuePair valuePair : _elementValuePairs) {
         {
           final XExpression value = valuePair.getValue();
-          boolean _notEquals = (!Objects.equal(value, null));
-          if (_notEquals) {
+          if ((value != null)) {
             final JvmOperation operation = valuePair.getElement();
             JvmTypeReference _returnType = operation.getReturnType();
             final Object annotationValue = this.translateAnnotationValue(value, _returnType);
@@ -1678,8 +1670,8 @@ public class CompilationUnitImpl implements CompilationUnit {
         }
       }
       XExpression _value = annotation.getValue();
-      boolean _notEquals = (!Objects.equal(_value, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_value != null);
+      if (_tripleNotEquals) {
         XExpression _value_1 = annotation.getValue();
         final Object annotationValue = this.translateAnnotationValue(_value_1, null);
         buildContext.set("value", annotationValue);

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/JvmAnnotationReferenceImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/JvmAnnotationReferenceImpl.java
@@ -49,7 +49,7 @@ public class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationRefe
     JvmAnnotationReference _delegate = this.getDelegate();
     EList<JvmAnnotationValue> _values = _delegate.getValues();
     final Function1<JvmAnnotationValue, Boolean> _function = (JvmAnnotationValue it) -> {
-      return Boolean.valueOf((Objects.equal(it.getOperation(), op) || (Objects.equal(it.getOperation(), null) && Objects.equal(op.getSimpleName(), "value"))));
+      return Boolean.valueOf((Objects.equal(it.getOperation(), op) || ((it.getOperation() == null) && Objects.equal(op.getSimpleName(), "value"))));
     };
     final JvmAnnotationValue annotationValue = IterableExtensions.<JvmAnnotationValue>findFirst(_values, _function);
     boolean _matched = false;
@@ -73,12 +73,11 @@ public class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationRefe
       JvmAnnotationReference _delegate = this.getDelegate();
       EList<JvmAnnotationValue> _values = _delegate.getValues();
       final Function1<JvmAnnotationValue, Boolean> _function = (JvmAnnotationValue it) -> {
-        return Boolean.valueOf((Objects.equal(it.getOperation(), op) || (Objects.equal(it.getOperation(), null) && Objects.equal(op.getSimpleName(), "value"))));
+        return Boolean.valueOf((Objects.equal(it.getOperation(), op) || ((it.getOperation() == null) && Objects.equal(op.getSimpleName(), "value"))));
       };
       final JvmAnnotationValue annotationValue = IterableExtensions.<JvmAnnotationValue>findFirst(_values, _function);
-      final boolean isArrayType = ((!Objects.equal(op, null)) && this.getCompilationUnit().getTypeReferences().isArray(op.getReturnType()));
-      boolean _notEquals = (!Objects.equal(annotationValue, null));
-      if (_notEquals) {
+      final boolean isArrayType = ((op != null) && this.getCompilationUnit().getTypeReferences().isArray(op.getReturnType()));
+      if ((annotationValue != null)) {
         CompilationUnitImpl _compilationUnit = this.getCompilationUnit();
         return _compilationUnit.translateAnnotationValue(annotationValue, isArrayType);
       }
@@ -106,8 +105,7 @@ public class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationRefe
       return Boolean.valueOf(Objects.equal(_simpleName, name));
     };
     final JvmOperation jvmOperation = IterableExtensions.<JvmOperation>findFirst(_declaredOperations, _function);
-    boolean _equals = Objects.equal(jvmOperation, null);
-    if (_equals) {
+    if ((jvmOperation == null)) {
       String _identifier = jvmAnnoType.getIdentifier();
       String _plus = ((("The annotation property \'" + name) + "\' is not declared on the annotation type \'") + _identifier);
       String _plus_1 = (_plus + "\'.");
@@ -139,8 +137,7 @@ public class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationRefe
     Boolean _xblockexpression = null;
     {
       final Object value = this.getValue(name);
-      boolean _equals = Objects.equal(value, null);
-      if (_equals) {
+      if ((value == null)) {
         return false;
       }
       _xblockexpression = ((Boolean) value);
@@ -159,8 +156,7 @@ public class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationRefe
     Byte _xblockexpression = null;
     {
       final Object value = this.getValue(name);
-      boolean _equals = Objects.equal(value, null);
-      if (_equals) {
+      if ((value == null)) {
         return ((byte) 0);
       }
       _xblockexpression = ((Byte) value);
@@ -179,8 +175,7 @@ public class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationRefe
     Character _xblockexpression = null;
     {
       final Object value = this.getValue(name);
-      boolean _equals = Objects.equal(value, null);
-      if (_equals) {
+      if ((value == null)) {
         return ((char) 0);
       }
       Character _switchResult = null;
@@ -220,8 +215,7 @@ public class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationRefe
     Double _xblockexpression = null;
     {
       final Object value = this.getValue(name);
-      boolean _equals = Objects.equal(value, null);
-      if (_equals) {
+      if ((value == null)) {
         return 0;
       }
       Double _switchResult = null;
@@ -291,8 +285,7 @@ public class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationRefe
     Float _xblockexpression = null;
     {
       final Object value = this.getValue(name);
-      boolean _equals = Objects.equal(value, null);
-      if (_equals) {
+      if ((value == null)) {
         return 0;
       }
       Float _switchResult = null;
@@ -344,8 +337,7 @@ public class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationRefe
     Integer _xblockexpression = null;
     {
       final Object value = this.getValue(name);
-      boolean _equals = Objects.equal(value, null);
-      if (_equals) {
+      if ((value == null)) {
         return 0;
       }
       Integer _switchResult = null;
@@ -385,8 +377,7 @@ public class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationRefe
     Long _xblockexpression = null;
     {
       final Object value = this.getValue(name);
-      boolean _equals = Objects.equal(value, null);
-      if (_equals) {
+      if ((value == null)) {
         return 0;
       }
       Long _switchResult = null;
@@ -432,8 +423,7 @@ public class JvmAnnotationReferenceImpl extends JvmElementImpl<JvmAnnotationRefe
     Short _xblockexpression = null;
     {
       final Object value = this.getValue(name);
-      boolean _equals = Objects.equal(value, null);
-      if (_equals) {
+      if ((value == null)) {
         return ((short) 0);
       }
       Short _switchResult = null;

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/JvmAnnotationTargetImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/JvmAnnotationTargetImpl.java
@@ -43,8 +43,7 @@ public abstract class JvmAnnotationTargetImpl<T extends JvmAnnotationTarget> ext
     AnnotationReference _xblockexpression = null;
     {
       this.checkMutable();
-      boolean _notEquals = (!Objects.equal(annotationReference, null));
-      Preconditions.checkArgument(_notEquals, "annotationReference cannot be null");
+      Preconditions.checkArgument((annotationReference != null), "annotationReference cannot be null");
       AnnotationReference _xifexpression = null;
       if ((annotationReference instanceof JvmAnnotationReferenceImpl)) {
         AnnotationReference _xblockexpression_1 = null;

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/JvmElementImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/JvmElementImpl.java
@@ -24,12 +24,12 @@ public abstract class JvmElementImpl<T extends EObject> extends AbstractElementI
     this.checkMutable();
     T _delegate = this.getDelegate();
     Resource _eResource = _delegate.eResource();
-    boolean _notEquals = (!Objects.equal(_eResource, null));
+    boolean _tripleNotEquals = (_eResource != null);
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("This element has already been removed: ");
     T _delegate_1 = this.getDelegate();
     _builder.append(_delegate_1, "");
-    Preconditions.checkState(_notEquals, _builder);
+    Preconditions.checkState(_tripleNotEquals, _builder);
     CompilationUnitImpl _compilationUnit = this.getCompilationUnit();
     IJvmModelAssociator _jvmModelAssociator = _compilationUnit.getJvmModelAssociator();
     T _delegate_2 = this.getDelegate();
@@ -38,12 +38,12 @@ public abstract class JvmElementImpl<T extends EObject> extends AbstractElementI
     EcoreUtil.remove(_delegate_3);
     T _delegate_4 = this.getDelegate();
     Resource _eResource_1 = _delegate_4.eResource();
-    boolean _equals = Objects.equal(_eResource_1, null);
+    boolean _tripleEquals = (_eResource_1 == null);
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("Couldn\'t remove: ");
     T _delegate_5 = this.getDelegate();
     _builder_1.append(_delegate_5, "");
-    Preconditions.checkState(_equals, _builder_1);
+    Preconditions.checkState(_tripleEquals, _builder_1);
   }
   
   protected final void checkMutable() {

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/JvmExecutableDeclarationImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/JvmExecutableDeclarationImpl.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.macro.declaration;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import org.eclipse.emf.common.util.EList;
@@ -89,8 +88,7 @@ public abstract class JvmExecutableDeclarationImpl<T extends JvmExecutable> exte
   
   public void setBody(final Expression body) {
     this.checkMutable();
-    boolean _equals = Objects.equal(body, null);
-    if (_equals) {
+    if ((body == null)) {
       CompilationUnitImpl _compilationUnit = this.getCompilationUnit();
       JvmTypesBuilder _jvmTypesBuilder = _compilationUnit.getJvmTypesBuilder();
       T _delegate = this.getDelegate();
@@ -112,8 +110,7 @@ public abstract class JvmExecutableDeclarationImpl<T extends JvmExecutable> exte
     EList<JvmTypeReference> _exceptions = _delegate.getExceptions();
     _exceptions.clear();
     for (final TypeReference exceptionType : exceptions) {
-      boolean _notEquals = (!Objects.equal(exceptionType, null));
-      if (_notEquals) {
+      if ((exceptionType != null)) {
         T _delegate_1 = this.getDelegate();
         EList<JvmTypeReference> _exceptions_1 = _delegate_1.getExceptions();
         CompilationUnitImpl _compilationUnit = this.getCompilationUnit();
@@ -156,8 +153,7 @@ public abstract class JvmExecutableDeclarationImpl<T extends JvmExecutable> exte
   
   public void setBody(final CompilationStrategy compilationStrategy) {
     this.checkMutable();
-    boolean _notEquals = (!Objects.equal(compilationStrategy, null));
-    Preconditions.checkArgument(_notEquals, "compilationStrategy cannot be null");
+    Preconditions.checkArgument((compilationStrategy != null), "compilationStrategy cannot be null");
     CompilationUnitImpl _compilationUnit = this.getCompilationUnit();
     T _delegate = this.getDelegate();
     _compilationUnit.setCompilationStrategy(_delegate, compilationStrategy);
@@ -165,8 +161,7 @@ public abstract class JvmExecutableDeclarationImpl<T extends JvmExecutable> exte
   
   public void setBody(final StringConcatenationClient compilationTemplate) {
     this.checkMutable();
-    boolean _notEquals = (!Objects.equal(compilationTemplate, null));
-    Preconditions.checkArgument(_notEquals, "compilationTemplate cannot be null");
+    Preconditions.checkArgument((compilationTemplate != null), "compilationTemplate cannot be null");
     CompilationUnitImpl _compilationUnit = this.getCompilationUnit();
     T _delegate = this.getDelegate();
     _compilationUnit.setCompilationTemplate(_delegate, compilationTemplate);
@@ -175,8 +170,7 @@ public abstract class JvmExecutableDeclarationImpl<T extends JvmExecutable> exte
   public MutableParameterDeclaration addParameter(final String name, final TypeReference type) {
     this.checkMutable();
     ConditionUtils.checkJavaIdentifier(name, "name");
-    boolean _notEquals = (!Objects.equal(type, null));
-    Preconditions.checkArgument(_notEquals, "type cannot be null");
+    Preconditions.checkArgument((type != null), "type cannot be null");
     boolean _isInferred = type.isInferred();
     if (_isInferred) {
       throw new IllegalArgumentException("Cannot use inferred type as parameter type.");

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/JvmInterfaceDeclarationImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/JvmInterfaceDeclarationImpl.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.macro.declaration;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import org.eclipse.emf.common.util.EList;
@@ -78,8 +77,7 @@ public class JvmInterfaceDeclarationImpl extends JvmTypeDeclarationImpl<JvmGener
   public MutableMethodDeclaration addMethod(final String name, final Procedure1<MutableMethodDeclaration> initializer) {
     this.checkMutable();
     ConditionUtils.checkJavaIdentifier(name, "name");
-    boolean _notEquals = (!Objects.equal(initializer, null));
-    Preconditions.checkArgument(_notEquals, "initializer cannot be null");
+    Preconditions.checkArgument((initializer != null), "initializer cannot be null");
     final JvmOperation newMethod = TypesFactory.eINSTANCE.createJvmOperation();
     newMethod.setVisibility(JvmVisibility.PUBLIC);
     newMethod.setSimpleName(name);

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/JvmMemberDeclarationImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/JvmMemberDeclarationImpl.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.macro.declaration;
 
-import com.google.common.base.Objects;
 import java.util.Collections;
 import java.util.Set;
 import org.eclipse.emf.common.notify.Adapter;
@@ -53,8 +52,7 @@ public abstract class JvmMemberDeclarationImpl<T extends JvmMember> extends JvmA
     EList<Adapter> _eAdapters = _delegate.eAdapters();
     Adapter _adapter = EcoreUtil.getAdapter(_eAdapters, DocumentationAdapter.class);
     DocumentationAdapter adapter = ((DocumentationAdapter) _adapter);
-    boolean _equals = Objects.equal(adapter, null);
-    if (_equals) {
+    if ((adapter == null)) {
       DocumentationAdapter _documentationAdapter = new DocumentationAdapter();
       adapter = _documentationAdapter;
       T _delegate_1 = this.getDelegate();
@@ -146,8 +144,7 @@ public abstract class JvmMemberDeclarationImpl<T extends JvmMember> extends JvmA
       TypeLookupImpl _typeLookup = _compilationUnit_1.getTypeLookup();
       Type _findTypeGlobally = _typeLookup.findTypeGlobally(Deprecated.class);
       final AnnotationReference existingReference = this.findAnnotation(_findTypeGlobally);
-      boolean _notEquals = (!Objects.equal(existingReference, null));
-      if (_notEquals) {
+      if ((existingReference != null)) {
         this.removeAnnotation(existingReference);
       }
     }

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/JvmTypeDeclarationImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/JvmTypeDeclarationImpl.java
@@ -73,8 +73,7 @@ public abstract class JvmTypeDeclarationImpl<T extends JvmDeclaredType> extends 
   }
   
   public boolean isAssignableFrom(final Type otherType) {
-    boolean _equals = Objects.equal(otherType, null);
-    if (_equals) {
+    if ((otherType == null)) {
       return false;
     }
     CompilationUnitImpl _compilationUnit = this.getCompilationUnit();
@@ -88,8 +87,7 @@ public abstract class JvmTypeDeclarationImpl<T extends JvmDeclaredType> extends 
   
   public MutableConstructorDeclaration addConstructor(final Procedure1<MutableConstructorDeclaration> initializer) {
     this.checkMutable();
-    boolean _notEquals = (!Objects.equal(initializer, null));
-    Preconditions.checkArgument(_notEquals, "initializer cannot be null");
+    Preconditions.checkArgument((initializer != null), "initializer cannot be null");
     T _delegate = this.getDelegate();
     EList<JvmMember> _members = _delegate.getMembers();
     Iterable<JvmConstructor> _filter = Iterables.<JvmConstructor>filter(_members, JvmConstructor.class);
@@ -99,8 +97,7 @@ public abstract class JvmTypeDeclarationImpl<T extends JvmDeclaredType> extends 
       return Boolean.valueOf(_typeExtensions.isSingleSyntheticDefaultConstructor(it));
     };
     final JvmConstructor constructor = IterableExtensions.<JvmConstructor>findFirst(_filter, _function);
-    boolean _notEquals_1 = (!Objects.equal(constructor, null));
-    if (_notEquals_1) {
+    if ((constructor != null)) {
       EcoreUtil.remove(constructor);
     }
     final JvmConstructor newConstructor = TypesFactory.eINSTANCE.createJvmConstructor();
@@ -120,8 +117,7 @@ public abstract class JvmTypeDeclarationImpl<T extends JvmDeclaredType> extends 
   public MutableFieldDeclaration addField(final String name, final Procedure1<MutableFieldDeclaration> initializer) {
     this.checkMutable();
     ConditionUtils.checkJavaIdentifier(name, "name");
-    boolean _notEquals = (!Objects.equal(initializer, null));
-    Preconditions.checkArgument(_notEquals, "initializer cannot be null");
+    Preconditions.checkArgument((initializer != null), "initializer cannot be null");
     final JvmField newField = TypesFactory.eINSTANCE.createJvmField();
     newField.setSimpleName(name);
     newField.setVisibility(JvmVisibility.PRIVATE);
@@ -138,8 +134,7 @@ public abstract class JvmTypeDeclarationImpl<T extends JvmDeclaredType> extends 
   public MutableMethodDeclaration addMethod(final String name, final Procedure1<MutableMethodDeclaration> initializer) {
     this.checkMutable();
     ConditionUtils.checkJavaIdentifier(name, "name");
-    boolean _notEquals = (!Objects.equal(initializer, null));
-    Preconditions.checkArgument(_notEquals, "initializer cannot be null");
+    Preconditions.checkArgument((initializer != null), "initializer cannot be null");
     final JvmOperation newMethod = TypesFactory.eINSTANCE.createJvmOperation();
     newMethod.setVisibility(JvmVisibility.PUBLIC);
     newMethod.setSimpleName(name);

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/JvmTypeParameterDeclarationImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/JvmTypeParameterDeclarationImpl.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.macro.declaration;
 
-import com.google.common.base.Objects;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtend.core.macro.declaration.CompilationUnitImpl;
 import org.eclipse.xtend.core.macro.declaration.TypeParameterDeclarationImpl;
@@ -34,8 +33,7 @@ public class JvmTypeParameterDeclarationImpl extends TypeParameterDeclarationImp
   
   @Override
   public boolean isAssignableFrom(final Type otherType) {
-    boolean _equals = Objects.equal(otherType, null);
-    if (_equals) {
+    if ((otherType == null)) {
       return false;
     }
     CompilationUnitImpl _compilationUnit = this.getCompilationUnit();

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/MutableJvmAnnotationTypeDeclarationImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/MutableJvmAnnotationTypeDeclarationImpl.java
@@ -145,8 +145,7 @@ public class MutableJvmAnnotationTypeDeclarationImpl extends JvmAnnotationTypeDe
   public MutableAnnotationTypeElementDeclaration addAnnotationTypeElement(final String name, final Procedure1<MutableAnnotationTypeElementDeclaration> initializer) {
     this.checkMutable();
     ConditionUtils.checkJavaIdentifier(name, "name");
-    boolean _notEquals = (!Objects.equal(initializer, null));
-    Preconditions.checkArgument(_notEquals, "initializer cannot be null");
+    Preconditions.checkArgument((initializer != null), "initializer cannot be null");
     final JvmOperation newAnnotationElement = TypesFactory.eINSTANCE.createJvmOperation();
     newAnnotationElement.setSimpleName(name);
     newAnnotationElement.setVisibility(JvmVisibility.PUBLIC);

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/MutableJvmClassDeclarationImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/MutableJvmClassDeclarationImpl.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.macro.declaration;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.xtend.core.macro.ConditionUtils;
@@ -182,8 +181,7 @@ public class MutableJvmClassDeclarationImpl extends JvmClassDeclarationImpl impl
     this.checkMutable();
     ConditionUtils.checkInferredTypeReferences("extended class", superclass);
     JvmTypeReference _xifexpression = null;
-    boolean _notEquals = (!Objects.equal(superclass, null));
-    if (_notEquals) {
+    if ((superclass != null)) {
       CompilationUnitImpl _compilationUnit = this.getCompilationUnit();
       _xifexpression = _compilationUnit.toJvmTypeReference(superclass);
     } else {
@@ -200,8 +198,7 @@ public class MutableJvmClassDeclarationImpl extends JvmClassDeclarationImpl impl
       return Boolean.valueOf(((it.getType() instanceof JvmGenericType) && (!((JvmGenericType) it.getType()).isInterface())));
     };
     final JvmTypeReference oldType = IterableExtensions.<JvmTypeReference>findFirst(_superTypes, _function);
-    boolean _notEquals_1 = (!Objects.equal(oldType, null));
-    if (_notEquals_1) {
+    if ((oldType != null)) {
       JvmGenericType _delegate_1 = this.getDelegate();
       EList<JvmTypeReference> _superTypes_1 = _delegate_1.getSuperTypes();
       _superTypes_1.remove(oldType);

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/MutableJvmEnumerationTypeDeclarationImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/MutableJvmEnumerationTypeDeclarationImpl.java
@@ -159,8 +159,7 @@ public class MutableJvmEnumerationTypeDeclarationImpl extends JvmEnumerationType
   public MutableEnumerationValueDeclaration addValue(final String name, final Procedure1<MutableEnumerationValueDeclaration> initializer) {
     this.checkMutable();
     ConditionUtils.checkJavaIdentifier(name, "name");
-    boolean _notEquals = (!Objects.equal(initializer, null));
-    Preconditions.checkArgument(_notEquals, "initializer cannot be null");
+    Preconditions.checkArgument((initializer != null), "initializer cannot be null");
     final JvmEnumerationLiteral jvmLiteral = TypesFactory.eINSTANCE.createJvmEnumerationLiteral();
     jvmLiteral.setSimpleName(name);
     jvmLiteral.setVisibility(JvmVisibility.PUBLIC);

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/MutableJvmFieldDeclarationImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/MutableJvmFieldDeclarationImpl.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.macro.declaration;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtend.core.jvmmodel.IXtendJvmAssociations;
@@ -87,8 +86,7 @@ public class MutableJvmFieldDeclarationImpl extends JvmFieldDeclarationImpl impl
   @Override
   public void setInitializer(final Expression initializer) {
     this.checkMutable();
-    boolean _equals = Objects.equal(initializer, null);
-    if (_equals) {
+    if ((initializer == null)) {
       CompilationUnitImpl _compilationUnit = this.getCompilationUnit();
       JvmTypesBuilder _jvmTypesBuilder = _compilationUnit.getJvmTypesBuilder();
       JvmField _delegate = this.getDelegate();
@@ -105,8 +103,7 @@ public class MutableJvmFieldDeclarationImpl extends JvmFieldDeclarationImpl impl
   @Override
   public void setInitializer(final CompilationStrategy initializer) {
     this.checkMutable();
-    boolean _notEquals = (!Objects.equal(initializer, null));
-    Preconditions.checkArgument(_notEquals, "initializer cannot be null");
+    Preconditions.checkArgument((initializer != null), "initializer cannot be null");
     CompilationUnitImpl _compilationUnit = this.getCompilationUnit();
     JvmField _delegate = this.getDelegate();
     _compilationUnit.setCompilationStrategy(_delegate, initializer);
@@ -115,8 +112,7 @@ public class MutableJvmFieldDeclarationImpl extends JvmFieldDeclarationImpl impl
   @Override
   public void setInitializer(final StringConcatenationClient template) {
     this.checkMutable();
-    boolean _notEquals = (!Objects.equal(template, null));
-    Preconditions.checkArgument(_notEquals, "template cannot be null");
+    Preconditions.checkArgument((template != null), "template cannot be null");
     CompilationUnitImpl _compilationUnit = this.getCompilationUnit();
     JvmField _delegate = this.getDelegate();
     _compilationUnit.setCompilationTemplate(_delegate, template);
@@ -153,8 +149,7 @@ public class MutableJvmFieldDeclarationImpl extends JvmFieldDeclarationImpl impl
   @Override
   public void setType(final TypeReference type) {
     this.checkMutable();
-    boolean _notEquals = (!Objects.equal(type, null));
-    Preconditions.checkArgument(_notEquals, "type cannot be null");
+    Preconditions.checkArgument((type != null), "type cannot be null");
     JvmField _delegate = this.getDelegate();
     CompilationUnitImpl _compilationUnit = this.getCompilationUnit();
     JvmTypeReference _jvmTypeReference = _compilationUnit.toJvmTypeReference(type);
@@ -177,8 +172,7 @@ public class MutableJvmFieldDeclarationImpl extends JvmFieldDeclarationImpl impl
   
   private void internalGenericSetConstantValue(final Object value) {
     this.checkMutable();
-    boolean _notEquals = (!Objects.equal(value, null));
-    Preconditions.checkArgument(_notEquals, "value cannot be null");
+    Preconditions.checkArgument((value != null), "value cannot be null");
     JvmField _delegate = this.getDelegate();
     _delegate.setConstant(true);
     JvmField _delegate_1 = this.getDelegate();

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/MutableJvmMethodDeclarationImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/MutableJvmMethodDeclarationImpl.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.macro.declaration;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import org.eclipse.xtend.core.macro.declaration.CompilationUnitImpl;
 import org.eclipse.xtend.core.macro.declaration.JvmMethodDeclarationImpl;
@@ -69,8 +68,7 @@ public class MutableJvmMethodDeclarationImpl extends JvmMethodDeclarationImpl im
   @Override
   public void setReturnType(final TypeReference type) {
     this.checkMutable();
-    boolean _notEquals = (!Objects.equal(type, null));
-    Preconditions.checkArgument(_notEquals, "returnType cannot be null");
+    Preconditions.checkArgument((type != null), "returnType cannot be null");
     JvmOperation _delegate = this.getDelegate();
     CompilationUnitImpl _compilationUnit = this.getCompilationUnit();
     JvmTypeReference _jvmTypeReference = _compilationUnit.toJvmTypeReference(type);

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/MutableJvmTypeParameterDeclarationImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/MutableJvmTypeParameterDeclarationImpl.java
@@ -62,12 +62,12 @@ public class MutableJvmTypeParameterDeclarationImpl extends JvmTypeParameterDecl
     this.checkMutable();
     JvmTypeParameter _delegate = this.getDelegate();
     Resource _eResource = _delegate.eResource();
-    boolean _notEquals = (!Objects.equal(_eResource, null));
+    boolean _tripleNotEquals = (_eResource != null);
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("This element has already been removed: ");
     JvmTypeParameter _delegate_1 = this.getDelegate();
     _builder.append(_delegate_1, "");
-    Preconditions.checkState(_notEquals, _builder);
+    Preconditions.checkState(_tripleNotEquals, _builder);
     CompilationUnitImpl _compilationUnit = this.getCompilationUnit();
     IJvmModelAssociator _jvmModelAssociator = _compilationUnit.getJvmModelAssociator();
     JvmTypeParameter _delegate_2 = this.getDelegate();
@@ -76,12 +76,12 @@ public class MutableJvmTypeParameterDeclarationImpl extends JvmTypeParameterDecl
     EcoreUtil.remove(_delegate_3);
     JvmTypeParameter _delegate_4 = this.getDelegate();
     Resource _eResource_1 = _delegate_4.eResource();
-    boolean _equals = Objects.equal(_eResource_1, null);
+    boolean _tripleEquals = (_eResource_1 == null);
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("Couldn\'t remove: ");
     JvmTypeParameter _delegate_5 = this.getDelegate();
     _builder_1.append(_delegate_5, "");
-    Preconditions.checkState(_equals, _builder_1);
+    Preconditions.checkState(_tripleEquals, _builder_1);
   }
   
   @Override

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/ProblemSupportImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/ProblemSupportImpl.java
@@ -212,8 +212,7 @@ public class ProblemSupportImpl implements ProblemSupport {
           IXtendJvmAssociations _jvmModelAssociations = this.compilationUnit.getJvmModelAssociations();
           EObject _delegate_1 = ((AbstractElementImpl<? extends EObject>)element).getDelegate();
           final EObject eobject = _jvmModelAssociations.getPrimarySourceElement(_delegate_1);
-          boolean _equals_1 = Objects.equal(eobject, null);
-          if (_equals_1) {
+          if ((eobject == null)) {
             EObject _delegate_2 = ((AbstractElementImpl<? extends EObject>)element).getDelegate();
             return Pair.<Resource, EObject>of(resource, _delegate_2);
           }

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/TypeLookupImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/TypeLookupImpl.java
@@ -108,8 +108,7 @@ public class TypeLookupImpl implements TypeLookup, SourceTypeLookup, UpstreamTyp
     };
     final JvmDeclaredType result = this.<JvmDeclaredType>recursiveFindType(qualifiedName, _filter, _function, _function_1);
     Type _xifexpression = null;
-    boolean _notEquals = (!Objects.equal(result, null));
-    if (_notEquals) {
+    if ((result != null)) {
       _xifexpression = this.compilationUnit.toType(result);
     }
     return _xifexpression;
@@ -181,8 +180,7 @@ public class TypeLookupImpl implements TypeLookup, SourceTypeLookup, UpstreamTyp
     };
     final XtendTypeDeclaration result = this.<XtendTypeDeclaration>recursiveFindType(qualifiedName, _xtendTypes, _function, _function_1);
     XtendTypeDeclarationImpl<? extends XtendTypeDeclaration> _xifexpression = null;
-    boolean _notEquals = (!Objects.equal(result, null));
-    if (_notEquals) {
+    if ((result != null)) {
       _xifexpression = this.compilationUnit.toXtendTypeDeclaration(result);
     }
     return _xifexpression;

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/XtendAnnotationReferenceImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/XtendAnnotationReferenceImpl.java
@@ -99,8 +99,7 @@ public class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotatio
   @Override
   public Expression getExpression(final String property) {
     final XExpression value = this.findValue(property);
-    boolean _notEquals = (!Objects.equal(value, null));
-    if (_notEquals) {
+    if ((value != null)) {
       CompilationUnitImpl _compilationUnit = this.getCompilationUnit();
       return _compilationUnit.toExpression(value);
     }
@@ -110,8 +109,7 @@ public class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotatio
   @Override
   public Object getValue(final String property) {
     final XExpression value = this.findValue(property);
-    boolean _notEquals = (!Objects.equal(value, null));
-    if (_notEquals) {
+    if ((value != null)) {
       return this.translateAnnotationValue(value, property);
     }
     AnnotationTypeDeclaration _annotationTypeDeclaration = this.getAnnotationTypeDeclaration();
@@ -122,7 +120,7 @@ public class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotatio
   protected XExpression findValue(final String property) {
     XExpression _xblockexpression = null;
     {
-      if ((Objects.equal(property, "value") && (!Objects.equal(this.getDelegate().getValue(), null)))) {
+      if ((Objects.equal(property, "value") && (this.getDelegate().getValue() != null))) {
         XAnnotation _delegate = this.getDelegate();
         return _delegate.getValue();
       }
@@ -154,8 +152,7 @@ public class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotatio
         return Boolean.valueOf(Objects.equal(_simpleName, property));
       };
       final JvmOperation operation = IterableExtensions.<JvmOperation>findFirst(_filter, _function);
-      boolean _notEquals = (!Objects.equal(operation, null));
-      if (_notEquals) {
+      if ((operation != null)) {
         CompilationUnitImpl _compilationUnit = this.getCompilationUnit();
         TypeReferences _typeReferences = _compilationUnit.getTypeReferences();
         JvmTypeReference _returnType = operation.getReturnType();
@@ -192,8 +189,7 @@ public class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotatio
     Boolean _xblockexpression = null;
     {
       final Object value = this.getValue(name);
-      boolean _equals = Objects.equal(value, null);
-      if (_equals) {
+      if ((value == null)) {
         return false;
       }
       _xblockexpression = ((Boolean) value);
@@ -212,8 +208,7 @@ public class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotatio
     Byte _xblockexpression = null;
     {
       final Object value = this.getValue(name);
-      boolean _equals = Objects.equal(value, null);
-      if (_equals) {
+      if ((value == null)) {
         return ((byte) 0);
       }
       _xblockexpression = ((Byte) value);
@@ -232,8 +227,7 @@ public class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotatio
     Character _xblockexpression = null;
     {
       final Object value = this.getValue(name);
-      boolean _equals = Objects.equal(value, null);
-      if (_equals) {
+      if ((value == null)) {
         return ((char) 0);
       }
       Character _switchResult = null;
@@ -273,8 +267,7 @@ public class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotatio
     Double _xblockexpression = null;
     {
       final Object value = this.getValue(name);
-      boolean _equals = Objects.equal(value, null);
-      if (_equals) {
+      if ((value == null)) {
         return 0;
       }
       Double _switchResult = null;
@@ -344,8 +337,7 @@ public class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotatio
     Float _xblockexpression = null;
     {
       final Object value = this.getValue(name);
-      boolean _equals = Objects.equal(value, null);
-      if (_equals) {
+      if ((value == null)) {
         return 0;
       }
       Float _switchResult = null;
@@ -397,8 +389,7 @@ public class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotatio
     Integer _xblockexpression = null;
     {
       final Object value = this.getValue(name);
-      boolean _equals = Objects.equal(value, null);
-      if (_equals) {
+      if ((value == null)) {
         return 0;
       }
       Integer _switchResult = null;
@@ -438,8 +429,7 @@ public class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotatio
     Long _xblockexpression = null;
     {
       final Object value = this.getValue(name);
-      boolean _equals = Objects.equal(value, null);
-      if (_equals) {
+      if ((value == null)) {
         return 0;
       }
       Long _switchResult = null;
@@ -485,8 +475,7 @@ public class XtendAnnotationReferenceImpl extends AbstractElementImpl<XAnnotatio
     Short _xblockexpression = null;
     {
       final Object value = this.getValue(name);
-      boolean _equals = Objects.equal(value, null);
-      if (_equals) {
+      if ((value == null)) {
         return ((short) 0);
       }
       Short _switchResult = null;

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/XtendAnnotationTypeElementDeclarationImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/XtendAnnotationTypeElementDeclarationImpl.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.macro.declaration;
 
-import com.google.common.base.Objects;
 import org.eclipse.xtend.core.macro.declaration.CompilationUnitImpl;
 import org.eclipse.xtend.core.macro.declaration.XtendMemberDeclarationImpl;
 import org.eclipse.xtend.core.xtend.XtendField;
@@ -31,8 +30,8 @@ public class XtendAnnotationTypeElementDeclarationImpl extends XtendMemberDeclar
     {
       XtendField _delegate = this.getDelegate();
       XExpression _initialValue = _delegate.getInitialValue();
-      boolean _equals = Objects.equal(_initialValue, null);
-      if (_equals) {
+      boolean _tripleEquals = (_initialValue == null);
+      if (_tripleEquals) {
         return null;
       }
       CompilationUnitImpl _compilationUnit = this.getCompilationUnit();
@@ -51,8 +50,8 @@ public class XtendAnnotationTypeElementDeclarationImpl extends XtendMemberDeclar
     {
       XtendField _delegate = this.getDelegate();
       XExpression _initialValue = _delegate.getInitialValue();
-      boolean _equals = Objects.equal(_initialValue, null);
-      if (_equals) {
+      boolean _tripleEquals = (_initialValue == null);
+      if (_tripleEquals) {
         return null;
       }
       CompilationUnitImpl _compilationUnit = this.getCompilationUnit();

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/XtendConstructorDeclarationImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/XtendConstructorDeclarationImpl.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.macro.declaration;
 
-import com.google.common.base.Objects;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.xtend.core.macro.declaration.CompilationUnitImpl;
 import org.eclipse.xtend.core.macro.declaration.XtendMemberDeclarationImpl;
@@ -35,8 +34,8 @@ public class XtendConstructorDeclarationImpl extends XtendMemberDeclarationImpl<
   public Expression getBody() {
     XtendConstructor _delegate = this.getDelegate();
     XExpression _expression = _delegate.getExpression();
-    boolean _equals = Objects.equal(_expression, null);
-    if (_equals) {
+    boolean _tripleEquals = (_expression == null);
+    if (_tripleEquals) {
       return null;
     }
     CompilationUnitImpl _compilationUnit = this.getCompilationUnit();

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/XtendFieldDeclarationImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/XtendFieldDeclarationImpl.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.macro.declaration;
 
-import com.google.common.base.Objects;
 import org.eclipse.xtend.core.macro.declaration.CompilationUnitImpl;
 import org.eclipse.xtend.core.macro.declaration.XtendMemberDeclarationImpl;
 import org.eclipse.xtend.core.xtend.XtendField;
@@ -41,8 +40,8 @@ public class XtendFieldDeclarationImpl extends XtendMemberDeclarationImpl<XtendF
   public Expression getInitializer() {
     XtendField _delegate = this.getDelegate();
     XExpression _initialValue = _delegate.getInitialValue();
-    boolean _equals = Objects.equal(_initialValue, null);
-    if (_equals) {
+    boolean _tripleEquals = (_initialValue == null);
+    if (_tripleEquals) {
       return null;
     }
     CompilationUnitImpl _compilationUnit = this.getCompilationUnit();

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/XtendMethodDeclarationImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/XtendMethodDeclarationImpl.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.macro.declaration;
 
-import com.google.common.base.Objects;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.xtend.core.macro.declaration.CompilationUnitImpl;
 import org.eclipse.xtend.core.macro.declaration.XtendMemberDeclarationImpl;
@@ -35,7 +34,7 @@ public class XtendMethodDeclarationImpl extends XtendMemberDeclarationImpl<Xtend
   public boolean isAbstract() {
     XtendFunction _delegate = this.getDelegate();
     XExpression _expression = _delegate.getExpression();
-    return Objects.equal(_expression, null);
+    return (_expression == null);
   }
   
   @Override
@@ -101,8 +100,8 @@ public class XtendMethodDeclarationImpl extends XtendMemberDeclarationImpl<Xtend
   public Expression getBody() {
     XtendFunction _delegate = this.getDelegate();
     XExpression _expression = _delegate.getExpression();
-    boolean _equals = Objects.equal(_expression, null);
-    if (_equals) {
+    boolean _tripleEquals = (_expression == null);
+    if (_tripleEquals) {
       return null;
     }
     CompilationUnitImpl _compilationUnit = this.getCompilationUnit();

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/XtendTypeDeclarationImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/XtendTypeDeclarationImpl.java
@@ -66,8 +66,7 @@ public abstract class XtendTypeDeclarationImpl<T extends XtendTypeDeclaration> e
     final EObject container = decl.eContainer();
     if ((container instanceof XtendFile)) {
       final String package_ = ((XtendFile)container).getPackage();
-      boolean _equals = Objects.equal(package_, null);
-      if (_equals) {
+      if ((package_ == null)) {
         return decl.getName();
       }
       String _name = decl.getName();
@@ -75,8 +74,7 @@ public abstract class XtendTypeDeclarationImpl<T extends XtendTypeDeclaration> e
     }
     if ((container instanceof XtendTypeDeclaration)) {
       final String containerName = this.getQualifiedName(((XtendTypeDeclaration)container));
-      boolean _equals_1 = Objects.equal(containerName, null);
-      if (_equals_1) {
+      if ((containerName == null)) {
         return null;
       }
       String _name_1 = decl.getName();
@@ -106,8 +104,7 @@ public abstract class XtendTypeDeclarationImpl<T extends XtendTypeDeclaration> e
   
   @Override
   public boolean isAssignableFrom(final Type otherType) {
-    boolean _equals = Objects.equal(otherType, null);
-    if (_equals) {
+    if ((otherType == null)) {
       return false;
     }
     CompilationUnitImpl _compilationUnit = this.getCompilationUnit();

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/XtendTypeParameterDeclarationImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/XtendTypeParameterDeclarationImpl.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.macro.declaration;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
@@ -81,8 +80,7 @@ public class XtendTypeParameterDeclarationImpl extends AbstractElementImpl<JvmTy
   
   @Override
   public boolean isAssignableFrom(final Type otherType) {
-    boolean _equals = Objects.equal(otherType, null);
-    if (_equals) {
+    if ((otherType == null)) {
       return false;
     }
     CompilationUnitImpl _compilationUnit = this.getCompilationUnit();

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/resource/XtendResourceDescription.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/resource/XtendResourceDescription.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtend.core.resource;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import java.util.Collections;
@@ -56,8 +55,7 @@ public class XtendResourceDescription extends DefaultResourceDescription {
   
   @Override
   protected EObjectDescriptionLookUp getLookUp() {
-    boolean _equals = Objects.equal(this.lookup, null);
-    if (_equals) {
+    if ((this.lookup == null)) {
       List<IEObjectDescription> _computeExportedObjects = this.computeExportedObjects();
       EObjectDescriptionLookUp _eObjectDescriptionLookUp = new EObjectDescriptionLookUp(_computeExportedObjects);
       this.lookup = _eObjectDescriptionLookUp;
@@ -72,16 +70,14 @@ public class XtendResourceDescription extends DefaultResourceDescription {
   
   @Override
   public Iterable<QualifiedName> getImportedNames() {
-    boolean _notEquals = (!Objects.equal(this.importedNames, null));
-    if (_notEquals) {
+    if ((this.importedNames != null)) {
       return this.importedNames;
     }
     final HashSet<QualifiedName> result = CollectionLiterals.<QualifiedName>newHashSet();
     Resource _resource = this.getResource();
     EList<EObject> _contents = _resource.getContents();
     final EObject astRoot = IterableExtensions.<EObject>head(_contents);
-    boolean _notEquals_1 = (!Objects.equal(astRoot, null));
-    if (_notEquals_1) {
+    if ((astRoot != null)) {
       final IResolvedTypes types = this.typeResolver.resolveTypes(astRoot);
       TreeIterator<Object> _allContents = EcoreUtil.<Object>getAllContents(astRoot, true);
       Iterable<Object> _iterable = IteratorExtensions.<Object>toIterable(_allContents);
@@ -90,7 +86,7 @@ public class XtendResourceDescription extends DefaultResourceDescription {
         {
           boolean _matched = false;
           if (expression instanceof XMemberFeatureCall) {
-            if ((((!Objects.equal(((XMemberFeatureCall)expression).getFeature(), null)) && ((XMemberFeatureCall)expression).getFeature().eIsProxy()) && (!((XMemberFeatureCall)expression).isExplicitOperationCallOrBuilderSyntax()))) {
+            if ((((((XMemberFeatureCall)expression).getFeature() != null) && ((XMemberFeatureCall)expression).getFeature().eIsProxy()) && (!((XMemberFeatureCall)expression).isExplicitOperationCallOrBuilderSyntax()))) {
               _matched=true;
               final XExpression receiver = ((XMemberFeatureCall)expression).getActualReceiver();
               boolean _matched_1 = false;
@@ -128,8 +124,7 @@ public class XtendResourceDescription extends DefaultResourceDescription {
             }
           }
           final LightweightTypeReference typeRef = types.getActualType(expression);
-          boolean _notEquals_2 = (!Objects.equal(typeRef, null));
-          if (_notEquals_2) {
+          if ((typeRef != null)) {
             JvmType _type = typeRef.getType();
             final Function1<String, Boolean> _function = (String it) -> {
               QualifiedName _qualifiedName = this.nameConverter.toQualifiedName(it);
@@ -156,8 +151,7 @@ public class XtendResourceDescription extends DefaultResourceDescription {
           Iterator<LightweightTypeReference> _map = IteratorExtensions.<JvmIdentifiableElement, LightweightTypeReference>map(_filter_1, _function);
           final Iterable<LightweightTypeReference> typesOfIdentifiables = IteratorExtensions.<LightweightTypeReference>toIterable(_map);
           for (final LightweightTypeReference typeRef : typesOfIdentifiables) {
-            boolean _notEquals_2 = (!Objects.equal(typeRef, null));
-            if (_notEquals_2) {
+            if ((typeRef != null)) {
               JvmType _type = typeRef.getType();
               final Function1<String, Boolean> _function_1 = (String it) -> {
                 QualifiedName _qualifiedName = this.nameConverter.toQualifiedName(it);
@@ -184,7 +178,7 @@ public class XtendResourceDescription extends DefaultResourceDescription {
   }
   
   public void registerAllTypes(final JvmType type, final Function1<? super String, ? extends Boolean> acceptor) {
-    if ((Objects.equal(type, null) || type.eIsProxy())) {
+    if (((type == null) || type.eIsProxy())) {
       return;
     }
     if (((!this.isLocal(type)) && (acceptor.apply(type.getIdentifier())).booleanValue())) {

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/validation/AnnotationValidation.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/validation/AnnotationValidation.java
@@ -70,8 +70,8 @@ public class AnnotationValidation extends AbstractDeclarativeValidator {
             IssueCodes.INVALID_ANNOTATION_VALUE_TYPE);
         }
         XExpression _initialValue = it_1.getInitialValue();
-        boolean _notEquals = (!Objects.equal(_initialValue, null));
-        if (_notEquals) {
+        boolean _tripleNotEquals = (_initialValue != null);
+        if (_tripleNotEquals) {
           XExpression _initialValue_1 = it_1.getInitialValue();
           this.annotationValueValidator.validateAnnotationValue(_initialValue_1, this);
         }
@@ -90,8 +90,7 @@ public class AnnotationValidation extends AbstractDeclarativeValidator {
       _switchResult = reference;
     }
     final JvmTypeReference toCheck = _switchResult;
-    boolean _equals = Objects.equal(toCheck, null);
-    if (_equals) {
+    if ((toCheck == null)) {
       return true;
     }
     JvmType _type = toCheck.getType();

--- a/org.eclipse.xtend.examples/projects/xtend-annotation-examples/src/i18n/Externalized.xtend
+++ b/org.eclipse.xtend.examples/projects/xtend-annotation-examples/src/i18n/Externalized.xtend
@@ -91,7 +91,7 @@ class ExternalizedProcessor extends AbstractClassProcessor implements CodeGenera
 
 	def getInitializerAsString(FieldDeclaration f) {
 		val string = f.initializer?.toString
-		if(string == null)
+		if(string === null)
 			return "empty string"
 		return string.substring(1, string.length - 1)
 	}

--- a/org.eclipse.xtend.examples/projects/xtend-annotation-examples/src/lazy/Lazy.xtend
+++ b/org.eclipse.xtend.examples/projects/xtend-annotation-examples/src/lazy/Lazy.xtend
@@ -29,7 +29,7 @@ class LazyProcessor extends AbstractFieldProcessor {
 		if (field.type.primitive)
 			field.addError("Fields with primitives are not supported by @Lazy")
 			
-		if (field.initializer == null)
+		if (field.initializer === null)
 			field.addError("A lazy field must have an initializer.")
 		
 		field.declaringType.addMethod('_init' + field.simpleName) [

--- a/org.eclipse.xtend.ide.common/src/org/eclipse/xtend/ide/common/outline/AbstractXtendOutlineTreeBuilder.xtend
+++ b/org.eclipse.xtend.ide.common/src/org/eclipse/xtend/ide/common/outline/AbstractXtendOutlineTreeBuilder.xtend
@@ -46,10 +46,10 @@ abstract class AbstractXtendOutlineTreeBuilder implements IXtendOutlineTreeBuild
 	}
 
 	protected def void buildPackageAndImportSection(XtendFile xtendFile, IXtendOutlineContext context) {
-		if (xtendFile.package != null) {
+		if (xtendFile.package !== null) {
 			xtendFile.buildPackageNode(context)
 		}
-		if (xtendFile.importSection != null && !xtendFile.importSection.importDeclarations.empty) {
+		if (xtendFile.importSection !== null && !xtendFile.importSection.importDeclarations.empty) {
 			xtendFile.buildImportSectionNode(context)
 		}
 	}

--- a/org.eclipse.xtend.ide.common/src/org/eclipse/xtend/ide/common/outline/XtendOutlineSourceTreeBuilder.xtend
+++ b/org.eclipse.xtend.ide.common/src/org/eclipse/xtend/ide/common/outline/XtendOutlineSourceTreeBuilder.xtend
@@ -45,7 +45,7 @@ class XtendOutlineSourceTreeBuilder extends AbstractXtendOutlineTreeBuilder impl
 		JvmDeclaredType inferredType,
 		IXtendOutlineContext context
 	) {
-		if (inferredType != null) {
+		if (inferredType !== null) {
 			val membersContext = context.newContext
 			xtendType.buildMembers(inferredType, inferredType, membersContext)
 		} else {
@@ -59,7 +59,7 @@ class XtendOutlineSourceTreeBuilder extends AbstractXtendOutlineTreeBuilder impl
 		JvmDeclaredType baseType,
 		extension IXtendOutlineContext context
 	) {
-		if (xtendType != null) {
+		if (xtendType !== null) {
 			for (member : xtendType.members) {
 				val jvmElement = member.getPrimaryJvmElement
 				if (jvmElement instanceof JvmMember) {

--- a/org.eclipse.xtend.ide.common/xtend-gen/org/eclipse/xtend/ide/common/outline/AbstractXtendOutlineTreeBuilder.java
+++ b/org.eclipse.xtend.ide.common/xtend-gen/org/eclipse/xtend/ide/common/outline/AbstractXtendOutlineTreeBuilder.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.common.outline;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import java.util.Arrays;
@@ -75,11 +74,11 @@ public abstract class AbstractXtendOutlineTreeBuilder implements IXtendOutlineTr
   
   protected void buildPackageAndImportSection(final XtendFile xtendFile, final IXtendOutlineContext context) {
     String _package = xtendFile.getPackage();
-    boolean _notEquals = (!Objects.equal(_package, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_package != null);
+    if (_tripleNotEquals) {
       this.xtendOutlineNodeBuilder.buildPackageNode(xtendFile, context);
     }
-    if (((!Objects.equal(xtendFile.getImportSection(), null)) && (!xtendFile.getImportSection().getImportDeclarations().isEmpty()))) {
+    if (((xtendFile.getImportSection() != null) && (!xtendFile.getImportSection().getImportDeclarations().isEmpty()))) {
       this.xtendOutlineNodeBuilder.buildImportSectionNode(xtendFile, context);
     }
   }

--- a/org.eclipse.xtend.ide.common/xtend-gen/org/eclipse/xtend/ide/common/outline/XtendOutlineSourceTreeBuilder.java
+++ b/org.eclipse.xtend.ide.common/xtend-gen/org/eclipse/xtend/ide/common/outline/XtendOutlineSourceTreeBuilder.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.common.outline;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -64,8 +63,7 @@ public class XtendOutlineSourceTreeBuilder extends AbstractXtendOutlineTreeBuild
   }
   
   protected void buildMembers(final XtendTypeDeclaration xtendType, final JvmDeclaredType inferredType, final IXtendOutlineContext context) {
-    boolean _notEquals = (!Objects.equal(inferredType, null));
-    if (_notEquals) {
+    if ((inferredType != null)) {
       final IXtendOutlineContext membersContext = context.newContext();
       this.buildMembers(xtendType, inferredType, inferredType, membersContext);
     } else {
@@ -78,8 +76,7 @@ public class XtendOutlineSourceTreeBuilder extends AbstractXtendOutlineTreeBuild
   }
   
   protected void buildMembers(final XtendTypeDeclaration xtendType, final JvmDeclaredType inferredType, final JvmDeclaredType baseType, @Extension final IXtendOutlineContext context) {
-    boolean _notEquals = (!Objects.equal(xtendType, null));
-    if (_notEquals) {
+    if ((xtendType != null)) {
       EList<XtendMember> _members = xtendType.getMembers();
       for (final XtendMember member : _members) {
         {

--- a/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/tests/AbstractRefactoringSwtBotTest.xtend
+++ b/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/tests/AbstractRefactoringSwtBotTest.xtend
@@ -186,7 +186,7 @@ class WaitForLinkedModeCondition extends DefaultCondition {
 	}
 
 	override test() throws Exception {
-		controller.activeLinkedMode != null
+		controller.activeLinkedMode !== null
 	}
 }
 

--- a/org.eclipse.xtend.ide.swtbot.tests/swtbot/xtend-gen/org/eclipse/xtend/ide/tests/WaitForLinkedModeCondition.java
+++ b/org.eclipse.xtend.ide.swtbot.tests/swtbot/xtend-gen/org/eclipse/xtend/ide/tests/WaitForLinkedModeCondition.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.tests;
 
-import com.google.common.base.Objects;
 import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
 import org.eclipse.xtext.ui.refactoring.ui.RenameLinkedMode;
 import org.eclipse.xtext.ui.refactoring.ui.RenameRefactoringController;
@@ -28,6 +27,6 @@ public class WaitForLinkedModeCondition extends DefaultCondition {
   @Override
   public boolean test() throws Exception {
     RenameLinkedMode _activeLinkedMode = this.controller.getActiveLinkedMode();
-    return (!Objects.equal(_activeLinkedMode, null));
+    return (_activeLinkedMode != null);
   }
 }

--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/builder/BuildAffectionTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/builder/BuildAffectionTest.xtend
@@ -78,7 +78,7 @@ class BuildAffectionTest {
 	 
 	@After
 	def tearDown() {
-		if(clientProject != null) 
+		if(clientProject !== null) 
 			WorkbenchTestHelper.deleteProject(clientProject)
 		workbenchTestHelper.tearDown
 		autoBuild

--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/contentassist/DirtyEditorFilteringContentAssistTests.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/contentassist/DirtyEditorFilteringContentAssistTests.xtend
@@ -91,7 +91,7 @@ class DirtyEditorFilteringContentAssistTests extends AbstractXtendUITestCase{
 		val contentAssistant = editorForCompletion.getXtextSourceViewerConfiguration().getContentAssistant(sourceViewer);
 		val contentType = editorForCompletion.document.getContentType(cursorPosition);
 		val processor = contentAssistant.getContentAssistProcessor(contentType);
-		if (processor != null) {
+		if (processor !== null) {
 			return processor.computeCompletionProposals(sourceViewer, cursorPosition);
 		}
 		return null;

--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTestBuilder.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTestBuilder.xtend
@@ -49,7 +49,7 @@ class QuickfixTestBuilder {
 	}
 	
 	def setSeverity(String issueCode, String severity) {
-		if (modifiedIssueCodes == null)
+		if (modifiedIssueCodes === null)
 			modifiedIssueCodes = newHashSet
 		modifiedIssueCodes.add(issueCode)
 		preferenceStore.setValue(issueCode, "error")
@@ -180,7 +180,7 @@ class QuickfixTestBuilder {
 		closeAllEditors(false)
 		files.forEach[ delete(true, new NullProgressMonitor) ]
 		files.clear
-		if (modifiedIssueCodes != null) {
+		if (modifiedIssueCodes !== null) {
 			preferenceStore => [
 				modifiedIssueCodes.forEach [ code |
 					setToDefault(code)

--- a/org.eclipse.xtend.ide.tests/longrunning/xtend-gen/org/eclipse/xtend/ide/tests/builder/BuildAffectionTest.java
+++ b/org.eclipse.xtend.ide.tests/longrunning/xtend-gen/org/eclipse/xtend/ide/tests/builder/BuildAffectionTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.tests.builder;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import org.eclipse.core.resources.IFile;
@@ -89,8 +88,7 @@ public class BuildAffectionTest {
   @After
   public void tearDown() {
     try {
-      boolean _notEquals = (!Objects.equal(this.clientProject, null));
-      if (_notEquals) {
+      if ((this.clientProject != null)) {
         WorkbenchTestHelper.deleteProject(this.clientProject);
       }
       this.workbenchTestHelper.tearDown();

--- a/org.eclipse.xtend.ide.tests/longrunning/xtend-gen/org/eclipse/xtend/ide/tests/contentassist/DirtyEditorFilteringContentAssistTests.java
+++ b/org.eclipse.xtend.ide.tests/longrunning/xtend-gen/org/eclipse/xtend/ide/tests/contentassist/DirtyEditorFilteringContentAssistTests.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.tests.contentassist;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.List;
 import org.eclipse.jface.text.BadLocationException;
@@ -174,8 +173,7 @@ public class DirtyEditorFilteringContentAssistTests extends AbstractXtendUITestC
     IXtextDocument _document = editorForCompletion.getDocument();
     final String contentType = _document.getContentType(cursorPosition);
     final IContentAssistProcessor processor = contentAssistant.getContentAssistProcessor(contentType);
-    boolean _notEquals = (!Objects.equal(processor, null));
-    if (_notEquals) {
+    if ((processor != null)) {
       return processor.computeCompletionProposals(sourceViewer, cursorPosition);
     }
     return null;

--- a/org.eclipse.xtend.ide.tests/longrunning/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTestBuilder.java
+++ b/org.eclipse.xtend.ide.tests/longrunning/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTestBuilder.java
@@ -81,8 +81,7 @@ public class QuickfixTestBuilder {
   }
   
   public void setSeverity(final String issueCode, final String severity) {
-    boolean _equals = Objects.equal(this.modifiedIssueCodes, null);
-    if (_equals) {
+    if ((this.modifiedIssueCodes == null)) {
       HashSet<String> _newHashSet = CollectionLiterals.<String>newHashSet();
       this.modifiedIssueCodes = _newHashSet;
     }
@@ -383,8 +382,7 @@ public class QuickfixTestBuilder {
     _files.forEach(_function);
     Set<IFile> _files_1 = this._workbenchTestHelper.getFiles();
     _files_1.clear();
-    boolean _notEquals = (!Objects.equal(this.modifiedIssueCodes, null));
-    if (_notEquals) {
+    if ((this.modifiedIssueCodes != null)) {
       IPersistentPreferenceStore _preferenceStore = this.getPreferenceStore();
       final Procedure1<IPersistentPreferenceStore> _function_1 = (IPersistentPreferenceStore it) -> {
         final Consumer<String> _function_2 = (String code) -> {

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/builder/AbstractQueuedBuildDataTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/builder/AbstractQueuedBuildDataTest.xtend
@@ -75,7 +75,7 @@ abstract class AbstractQueuedBuildDataTest extends AbstractXtendUITestCase {
 			val unexpectedExportedNames = <String>newHashSet
 			for (exportedName : deltas.exportedNames) {
 				val qualifiedName = expectedExportedNames.findFirst[exportedName == it]
-				if (qualifiedName == null) {
+				if (qualifiedName === null) {
 					unexpectedExportedNames.add(exportedName)
 				} else {
 					remainingExportedNames.remove(qualifiedName)

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/builder/JavaEditorExtension.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/builder/JavaEditorExtension.xtend
@@ -36,7 +36,7 @@ class JavaEditorExtension {
 	}
 
 	def ITextEditor reconcile(ITextEditor editor, (ITextEditor)=>ITextEditor consumer) {
-		if (consumer == null) {
+		if (consumer === null) {
 			return editor
 		}
 		waitForPostReconcileEvent [ |
@@ -51,7 +51,7 @@ class JavaEditorExtension {
 
 	def save(ITextEditor editor, (ITextEditor)=>ITextEditor consumer) {
 		waitForPostChangeEvent [ |
-			if (consumer != null) {
+			if (consumer !== null) {
 				consumer.apply(editor)
 			}
 			assertTrue(editor.saveEditor(false))
@@ -65,7 +65,7 @@ class JavaEditorExtension {
 
 	def close(ITextEditor editor, (ITextEditor)=>ITextEditor consumer) {
 		waitForPostChangeEvent [ |
-			if (consumer != null) {
+			if (consumer !== null) {
 				consumer.apply(editor)
 			}
 			assertTrue(editor.closeEditor(false))

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/codebuilder/AbstractBuilderTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/codebuilder/AbstractBuilderTest.xtend
@@ -41,7 +41,7 @@ class AbstractBuilderTest extends AbstractXtendUITestCase {
 	}
 	
 	def protected getXtendClass() {
-		if(xtendClass == null) {
+		if(xtendClass === null) {
 			xtendClass = (xtendFile('Foo', '''
 				class Foo {
 				}
@@ -51,7 +51,7 @@ class AbstractBuilderTest extends AbstractXtendUITestCase {
 	}
 	
 	def protected getJavaClass() {
-		if(javaClass == null) {	
+		if(javaClass === null) {	
 			createFile('Bar.java', '''
 				public class Bar {
 				}

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/editor/XbaseEditorOpenClassFileTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/editor/XbaseEditorOpenClassFileTest.xtend
@@ -291,7 +291,7 @@ import org.junit.Before
 		val jarFile = jp.project.getFile(new Path(fileName))
 		jarFile.create(class.getResourceAsStream(fileName), true, null)
 
-		val sourceFile = if (fileNameOfSource != null) {
+		val sourceFile = if (fileNameOfSource !== null) {
 				val source = jp.project.getFile(new Path(fileNameOfSource))
 				source.create(class.getResourceAsStream(fileNameOfSource), true, null)
 				source
@@ -310,7 +310,7 @@ import org.junit.Before
 
 	def supportsEditorOverride() {
 		try {
-			if (Class.forName("org.eclipse.ui.ide.IEditorAssociationOverride") != null) {
+			if (Class.forName("org.eclipse.ui.ide.IEditorAssociationOverride") !== null) {
 				return true;
 			}
 		} catch (ClassNotFoundException e) {

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/findrefs/JdtFindReferencesTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/findrefs/JdtFindReferencesTest.xtend
@@ -68,11 +68,11 @@ class JdtFindReferencesTest extends AbstractXtendUITestCase {
 		assertNotNull("Couldn't find 'src/Xtend.xtend'.", project.findMember("/src/Xtend.xtend"))
 		assertNotNull("Couldn't find 'src/JavaRef.java'.", project.findMember("/src/JavaRef.java"))
 		val member = project.findMember("/xtend-gen/Xtend.java")
-		if (member == null) {
+		if (member === null) {
 			assertNotNull("Couldn't find 'xtend-gen/Xtend.java'.", member)
 		}
 		var IType type = JavaCore.create(project).findType("Xtend")
-		if (type == null) {
+		if (type === null) {
 			assertNotNull("Couldn't find type 'Xtend'.", type)
 		}
 		val constructor = type.getMethod("Xtend", newArrayList)

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/resource/ResourceStorageTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/resource/ResourceStorageTest.xtend
@@ -157,7 +157,7 @@ class ResourceStorageTest extends AbstractXtendUITestCase {
 		testShouldLoadFromStorageJob.schedule
 		testShouldLoadFromStorageJob.join
 		val t = throwables.head
-		if (t != null) {
+		if (t !== null) {
 			Throwables.propagate(t)
 		}
 	}

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/builder/AbstractQueuedBuildDataTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/builder/AbstractQueuedBuildDataTest.java
@@ -112,8 +112,7 @@ public abstract class AbstractQueuedBuildDataTest extends AbstractXtendUITestCas
               return Boolean.valueOf(Objects.equal(exportedName, it));
             };
             final String qualifiedName = IterableExtensions.<String>findFirst(((Iterable<String>)Conversions.doWrapArray(expectedExportedNames)), _function);
-            boolean _equals = Objects.equal(qualifiedName, null);
-            if (_equals) {
+            if ((qualifiedName == null)) {
               unexpectedExportedNames.add(exportedName);
             } else {
               remainingExportedNames.remove(qualifiedName);

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/builder/JavaEditorExtension.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/builder/JavaEditorExtension.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.tests.builder;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.ArrayList;
 import org.eclipse.core.resources.IFile;
@@ -55,8 +54,7 @@ public class JavaEditorExtension {
   public ITextEditor reconcile(final ITextEditor editor, final Function1<? super ITextEditor, ? extends ITextEditor> consumer) {
     ITextEditor _xblockexpression = null;
     {
-      boolean _equals = Objects.equal(consumer, null);
-      if (_equals) {
+      if ((consumer == null)) {
         return editor;
       }
       final Procedure0 _function = () -> {
@@ -76,8 +74,7 @@ public class JavaEditorExtension {
     ITextEditor _xblockexpression = null;
     {
       final Procedure0 _function = () -> {
-        boolean _notEquals = (!Objects.equal(consumer, null));
-        if (_notEquals) {
+        if ((consumer != null)) {
           consumer.apply(editor);
         }
         boolean _saveEditor = this._workbenchTestHelper.saveEditor(editor, false);
@@ -97,8 +94,7 @@ public class JavaEditorExtension {
     ITextEditor _xblockexpression = null;
     {
       final Procedure0 _function = () -> {
-        boolean _notEquals = (!Objects.equal(consumer, null));
-        if (_notEquals) {
+        if ((consumer != null)) {
           consumer.apply(editor);
         }
         boolean _closeEditor = this._workbenchTestHelper.closeEditor(editor, false);

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/codebuilder/AbstractBuilderTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/codebuilder/AbstractBuilderTest.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtend.ide.tests.codebuilder;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
@@ -62,8 +61,7 @@ public class AbstractBuilderTest extends AbstractXtendUITestCase {
     try {
       JvmDeclaredType _xblockexpression = null;
       {
-        boolean _equals = Objects.equal(AbstractBuilderTest.xtendClass, null);
-        if (_equals) {
+        if ((AbstractBuilderTest.xtendClass == null)) {
           StringConcatenation _builder = new StringConcatenation();
           _builder.append("class Foo {");
           _builder.newLine();
@@ -87,8 +85,7 @@ public class AbstractBuilderTest extends AbstractXtendUITestCase {
     try {
       JvmDeclaredType _xblockexpression = null;
       {
-        boolean _equals = Objects.equal(AbstractBuilderTest.javaClass, null);
-        if (_equals) {
+        if ((AbstractBuilderTest.javaClass == null)) {
           StringConcatenation _builder = new StringConcatenation();
           _builder.append("public class Bar {");
           _builder.newLine();

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/editor/XbaseEditorOpenClassFileTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/editor/XbaseEditorOpenClassFileTest.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtend.ide.tests.editor;
 
-import com.google.common.base.Objects;
 import com.google.common.io.ByteStreams;
 import com.google.inject.Inject;
 import java.io.ByteArrayInputStream;
@@ -513,8 +512,7 @@ public class XbaseEditorOpenClassFileTest extends AbstractXtendUITestCase {
       InputStream _resourceAsStream = _class.getResourceAsStream(fileName);
       jarFile.create(_resourceAsStream, true, null);
       IFile _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(fileNameOfSource, null));
-      if (_notEquals) {
+      if ((fileNameOfSource != null)) {
         IFile _xblockexpression = null;
         {
           IProject _project_1 = jp.getProject();
@@ -557,8 +555,8 @@ public class XbaseEditorOpenClassFileTest extends AbstractXtendUITestCase {
   public boolean supportsEditorOverride() {
     try {
       Class<?> _forName = Class.forName("org.eclipse.ui.ide.IEditorAssociationOverride");
-      boolean _notEquals = (!Objects.equal(_forName, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_forName != null);
+      if (_tripleNotEquals) {
         return true;
       }
     } catch (final Throwable _t) {

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/findrefs/JdtFindReferencesTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/findrefs/JdtFindReferencesTest.java
@@ -142,15 +142,13 @@ public class JdtFindReferencesTest extends AbstractXtendUITestCase {
       Assert.assertNotNull("Couldn\'t find \'src/JavaRef.java\'.", _findMember_1);
       IProject _project_2 = this._workbenchTestHelper.getProject();
       final IResource member = _project_2.findMember("/xtend-gen/Xtend.java");
-      boolean _equals = Objects.equal(member, null);
-      if (_equals) {
+      if ((member == null)) {
         Assert.assertNotNull("Couldn\'t find \'xtend-gen/Xtend.java\'.", member);
       }
       IProject _project_3 = this._workbenchTestHelper.getProject();
       IJavaProject _create = JavaCore.create(_project_3);
       IType type = _create.findType("Xtend");
-      boolean _equals_1 = Objects.equal(type, null);
-      if (_equals_1) {
+      if ((type == null)) {
         Assert.assertNotNull("Couldn\'t find type \'Xtend\'.", type);
       }
       ArrayList<String> _newArrayList = CollectionLiterals.<String>newArrayList();

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/resource/ResourceStorageTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/resource/ResourceStorageTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.tests.resource;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
@@ -302,8 +301,7 @@ public class ResourceStorageTest extends AbstractXtendUITestCase {
       testShouldLoadFromStorageJob.schedule();
       testShouldLoadFromStorageJob.join();
       final Throwable t = IterableExtensions.<Throwable>head(throwables);
-      boolean _notEquals = (!Objects.equal(t, null));
-      if (_notEquals) {
+      if ((t != null)) {
         Throwables.propagate(t);
       }
     } catch (Throwable _e) {

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/AbstractCodeBuilder.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/AbstractCodeBuilder.xtend
@@ -43,8 +43,8 @@ abstract class AbstractCodeBuilder implements ICodeBuilder {
 	
 	override isValid() {
 		val javaElement = owner.findElementFor
-		return (javaElement == null || !javaElement.readOnly) 
-			&& ownerSource != null && owner != null && context != null
+		return (javaElement === null || !javaElement.readOnly) 
+			&& ownerSource !== null && owner !== null && context !== null
 	}
 	
 	override getPreview() {
@@ -75,7 +75,7 @@ abstract class AbstractCodeBuilder implements ICodeBuilder {
 	}
 
 	def protected appendType(ISourceAppender appendable, LightweightTypeReference typeRef, String surrogate) {
-		if (typeRef == null) {
+		if (typeRef === null) {
 			appendable.append(surrogate)
 		} else {
 			appendable.append(typeRef)

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/AbstractExecutableBuilder.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/AbstractExecutableBuilder.xtend
@@ -39,7 +39,7 @@ abstract class AbstractExecutableBuilder extends AbstractCodeBuilder {
 
 	def appendBody(ISourceAppender appendable, String statementSeparator) {
 		appendable.append(' {').increaseIndentation.newLine
-		if (bodyGenerator != null)
+		if (bodyGenerator !== null)
 			bodyGenerator.apply(appendable)
 		else
 			appendable.append(defaultBody)
@@ -72,7 +72,7 @@ abstract class AbstractExecutableBuilder extends AbstractCodeBuilder {
 		for (i : 0 ..< parameterBuilders.size) {
 			val parameterBuilder = parameterBuilders.get(i)
 			val acceptor = new VariableNameAcceptor(notAllowed)
-			if(parameterBuilder.name == null) {
+			if(parameterBuilder.name === null) {
 				getVariableProposals(parameterBuilder.type.identifier, context,
 					JdtVariableCompletions.VariableType.PARAMETER, notAllowed, acceptor)
 				parameterBuilder.name = acceptor.variableName
@@ -90,7 +90,7 @@ abstract class AbstractExecutableBuilder extends AbstractCodeBuilder {
 			appendable.append(" throws ")
 			do {
 				val typeRef = iterator.next()
-				if (typeRef != null) {
+				if (typeRef !== null) {
 					appendable.appendType(typeRef, "Exception")
 				}
 				if (iterator.hasNext())

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/AnnotationBuilders.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/AnnotationBuilders.xtend
@@ -36,7 +36,7 @@ class XtendAnnotationBuilder extends AbstractAnnotationBuilder implements ICodeB
 	@Inject extension InsertionOffsets
 	
 	override isValid() {
-		super.valid && annotationName != null && visibility == JvmVisibility.PUBLIC  
+		super.valid && annotationName !== null && visibility == JvmVisibility.PUBLIC  
 	}	
 
 	override build(ISourceAppender appendable) {
@@ -63,7 +63,7 @@ class XtendAnnotationBuilder extends AbstractAnnotationBuilder implements ICodeB
 class JavaAnnotationBuilder extends AbstractAnnotationBuilder implements ICodeBuilder.Java {
 	
 	override isValid() {
-		super.valid && annotationName != null  
+		super.valid && annotationName !== null  
 	}	
 
 	override build(ISourceAppender appendable) {

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/ClassBuilders.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/ClassBuilders.xtend
@@ -36,7 +36,7 @@ class XtendClassBuilder extends AbstractClassBuilder implements ICodeBuilder.Xte
 	@Inject extension InsertionOffsets
 	
 	override isValid() {
-		super.valid && className != null && visibility == JvmVisibility.PUBLIC  
+		super.valid && className !== null && visibility == JvmVisibility.PUBLIC  
 	}	
 
 	override build(ISourceAppender appendable) {
@@ -63,7 +63,7 @@ class XtendClassBuilder extends AbstractClassBuilder implements ICodeBuilder.Xte
 class JavaClassBuilder extends AbstractClassBuilder implements ICodeBuilder.Java {
 	
 	override isValid() {
-		super.valid && className != null  
+		super.valid && className !== null  
 	}	
 
 	override build(ISourceAppender appendable) {

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/FieldBuilders.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/FieldBuilders.xtend
@@ -44,7 +44,7 @@ class XtendFieldBuilder extends AbstractFieldBuilder implements ICodeBuilder.Xte
 	@Inject extension InsertionOffsets
 	
 	override isValid() {
-		super.isValid() && fieldName != null
+		super.isValid() && fieldName !== null
 	}
 	
 	override build(ISourceAppender appendable) {
@@ -73,7 +73,7 @@ class XtendFieldBuilder extends AbstractFieldBuilder implements ICodeBuilder.Xte
 class JavaFieldBuilder extends AbstractFieldBuilder implements ICodeBuilder.Java {
 	
 	override isValid() {
-		super.isValid() && fieldName != null && fieldType != null
+		super.isValid() && fieldName !== null && fieldType !== null
 	}
 	
 	override build(ISourceAppender appendable) {

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/InsertionOffsets.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/InsertionOffsets.xtend
@@ -30,10 +30,10 @@ class InsertionOffsets {
 		if (ownerType.members.empty)
 			return inEmpty(ownerType)
 		val callingMember = EcoreUtil2.getContainerOfType(call, XtendField)
-		if (callingMember != null && ownerType.members.contains(callingMember))
+		if (callingMember !== null && ownerType.members.contains(callingMember))
 			return before(callingMember)
 		val lastDefinedField = ownerType.members.filter(XtendField).last
-		if (lastDefinedField == null)
+		if (lastDefinedField === null)
 			return before(ownerType.members.head)
 		else
 			return after(lastDefinedField)
@@ -41,7 +41,7 @@ class InsertionOffsets {
 
 	def getNewMethodInsertOffset(/* @Nullable */ EObject call, XtendTypeDeclaration ownerType) {
 		val callingMember = EcoreUtil2.getContainerOfType(call, XtendMember)
-		if (callingMember != null && ownerType.members.contains(callingMember))
+		if (callingMember !== null && ownerType.members.contains(callingMember))
 			return after(callingMember)
 		else if (ownerType.members.empty)
 			return inEmpty(ownerType)
@@ -51,7 +51,7 @@ class InsertionOffsets {
 
 	def getNewConstructorInsertOffset(/* @Nullable */ EObject call, XtendTypeDeclaration ownerType) {
 		val lastDefinedConstructor = ownerType.members.filter(XtendConstructor).last
-		if(lastDefinedConstructor == null)
+		if(lastDefinedConstructor === null)
 			return getNewFieldInsertOffset(call, ownerType)		
 		else	
 			return after(lastDefinedConstructor)
@@ -69,7 +69,7 @@ class InsertionOffsets {
 	def protected inEmpty(XtendTypeDeclaration ownerType) {
 		val classNode = NodeModelUtils.findActualNodeFor(ownerType)
 		val openingBraceNode = classNode.leafNodes.findFirst[text == "{"]
-		if(openingBraceNode != null)
+		if(openingBraceNode !== null)
 			openingBraceNode.offset + 1
 		else 
 			classNode.endOffset

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/InterfaceBuilders.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/InterfaceBuilders.xtend
@@ -36,7 +36,7 @@ class XtendInterfaceBuilder extends AbstractInterfaceBuilder implements ICodeBui
 	@Inject extension InsertionOffsets
 	
 	override isValid() {
-		super.valid && interfaceName != null && visibility == JvmVisibility.PUBLIC  
+		super.valid && interfaceName !== null && visibility == JvmVisibility.PUBLIC  
 	}	
 
 	override build(ISourceAppender appendable) {
@@ -63,7 +63,7 @@ class XtendInterfaceBuilder extends AbstractInterfaceBuilder implements ICodeBui
 class JavaInterfaceBuilder extends AbstractInterfaceBuilder implements ICodeBuilder.Java {
 	
 	override isValid() {
-		super.valid && interfaceName != null  
+		super.valid && interfaceName !== null  
 	}	
 
 	override build(ISourceAppender appendable) {

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/MemberFromSuperImplementor.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/MemberFromSuperImplementor.xtend
@@ -77,8 +77,8 @@ class MemberFromSuperImplementor {
 				return [append(superInterface).append('.')]
 			}
 			val interfaze = subType.superTypes.filter[type.isInterface].map[type as JvmDeclaredType]
-				.findFirst[getImplementedInterface(superInterface) != null]
-			if (interfaze != null) {
+				.findFirst[getImplementedInterface(superInterface) !== null]
+			if (interfaze !== null) {
 				return [append(interfaze).append('.')]
 			}
 		}
@@ -110,7 +110,7 @@ class MemberFromSuperImplementor {
 			val parameterBuilder = builder.newParameterBuilder
 			parameterBuilder.name = declaredParameter.simpleName
 			parameterBuilder.type = it
-			parameterBuilder.extensionFlag = annotationLookup.findAnnotation(declaredParameter, Extension) != null
+			parameterBuilder.extensionFlag = annotationLookup.findAnnotation(declaredParameter, Extension) !== null
 		]
 		builder.varArgsFlag = executable.varArgs
 		builder.exceptions = overridden.resolvedExceptions

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/MethodBuilders.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/MethodBuilders.xtend
@@ -37,7 +37,7 @@ class XtendMethodBuilder extends AbstractMethodBuilder implements ICodeBuilder.X
 	@Inject extension InsertionOffsets
 
 	override isValid() {
-		super.isValid() && methodName != null
+		super.isValid() && methodName !== null
 	}
 	
 	override build(ISourceAppender appendable) {
@@ -75,7 +75,7 @@ class XtendMethodBuilder extends AbstractMethodBuilder implements ICodeBuilder.X
 class JavaMethodBuilder extends AbstractMethodBuilder implements ICodeBuilder.Java {
 	
 	override isValid() {
-		super.isValid() && methodName != null
+		super.isValid() && methodName !== null
 	}
 	
 	override build(ISourceAppender appendable) {

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/ParameterBuilders.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/codebuilder/ParameterBuilders.xtend
@@ -34,7 +34,7 @@ abstract class AbstractParameterBuilder extends AbstractCodeBuilder {
 	protected def ISourceAppender appendModifiers(ISourceAppender appendable)
 
 	override isValid() {
-		type != null 
+		type !== null 
 		&& (!varArgsFlag || type instanceof ArrayTypeReference)
 		&& super.isValid()
 	}

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/hyperlinking/ConsoleHyperlinking.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/hyperlinking/ConsoleHyperlinking.xtend
@@ -87,7 +87,7 @@ class XtendFileHyperlink implements IHyperlink {
 	
 	def private ILaunch getLaunch() {
 		val process = console.getAttribute(IDebugUIConstants.ATTR_CONSOLE_PROCESS) as IProcess
-		if (process != null) {
+		if (process !== null) {
 		    return process.getLaunch();
 		}
 		return null;

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/hyperlinking/HyperLinkingLabelProvider.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/hyperlinking/HyperLinkingLabelProvider.xtend
@@ -23,7 +23,7 @@ class HyperLinkingLabelProvider extends XtendLabelProvider {
 	
 	override getText(Object element) {
 		val result = super.getText(element)
-		if (result != null) {
+		if (result !== null) {
 			return 'Open Declaration - '+result
 		}
 		return null;

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/javaconverter/EclipseASTParserFactory.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/javaconverter/EclipseASTParserFactory.xtend
@@ -38,7 +38,7 @@ class EclipseASTParserFactory extends org.eclipse.xtend.core.javaconverter.ASTPa
 	}
 
 	def tweakOptions(ASTParser parser, IJavaProject project) {
-		if (project != null) {
+		if (project !== null) {
 			val options = project.getOptions(true);
 			options.remove(JavaCore.COMPILER_TASK_TAGS);
 			options.put(JavaCore.COMPILER_DOC_COMMENT_SUPPORT, JavaCore.ENABLED)

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/labeling/XtendLabelProvider.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/labeling/XtendLabelProvider.xtend
@@ -69,7 +69,7 @@ public class XtendLabelProvider extends XtendJvmLabelProvider {
 
 	protected def dispatch imageDescriptor(XtendFunction element) {
 		val operation = element.directlyInferredOperation
-		if (operation != null)
+		if (operation !== null)
 			images.forOperation(element.visibility, adornments.get(operation))
 	}
 
@@ -124,10 +124,10 @@ public class XtendLabelProvider extends XtendJvmLabelProvider {
 
 	protected def text(XtendFunction element) {
 		val simpleName = element.name
-		if (simpleName != null) {
+		if (simpleName !== null) {
 			val qnName = QualifiedName.create(simpleName)
 			val operator = operatorMapping.getOperator(qnName)
-			if (operator != null) {
+			if (operator !== null) {
 				val result = signature(operator.firstSegment, element.directlyInferredOperation)
 				result.append(' (' + simpleName + ')', StyledString.COUNTER_STYLER)
 				return result
@@ -137,11 +137,11 @@ public class XtendLabelProvider extends XtendJvmLabelProvider {
 	}
 
 	protected def text(XtendField element) {
-		if (element.name == null && element.extension)
+		if (element.name === null && element.extension)
 			return new StyledString(uiStrings.referenceToString(element.type, "extension"),
 				StyledString.DECORATIONS_STYLER)
 		val fieldType = element.displayedType
-		if (fieldType != null) {
+		if (fieldType !== null) {
 			val type = uiStrings.referenceToString(fieldType, "")
 			if (type.length != 0) {
 				return new StyledString(element.name).append(
@@ -161,7 +161,7 @@ public class XtendLabelProvider extends XtendJvmLabelProvider {
 
 	protected def JvmTypeReference getDisplayedType(XtendField field) {
 		val jvmField = field.jvmField
-		if (jvmField != null) {
+		if (jvmField !== null) {
 			return jvmField.getType
 		} else {
 			val i = field.jvmElements.iterator

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/macro/EclipseFileSystemSupportImpl.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/macro/EclipseFileSystemSupportImpl.xtend
@@ -46,7 +46,7 @@ class EclipseFileSystemSupportImpl extends AbstractFileSystemSupport {
 
 	protected def java.net.URI toURI(URI uri, List<String> trailingSegments) {
 		val resource = uri.findMember
-		if (resource == null) {
+		if (resource === null) {
 			trailingSegments += uri.lastSegment
 			return toURI(uri.trimSegments(1), trailingSegments)
 		}

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/macro/JdtBasedProcessorProvider.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/macro/JdtBasedProcessorProvider.xtend
@@ -47,13 +47,13 @@ class JdtBasedProcessorProvider extends ProcessorInstanceForJvmTypeProvider {
 		val isEditor = ResourceSetContext.get(rs).isEditor
 		if (isBuilder) {
 			val adapter = rs.eAdapters.filter(ProcessorClassloaderAdapter).head
-			if (adapter != null)
+			if (adapter !== null)
 				return adapter.classLoader
 		}
 		if (isEditor) {
 			val adapter = ctx.editorResource.eAdapters.filter(ProcessorClassloaderAdapter).head
-			if (adapter != null) {
-				if (adapter.classLoader == null) {
+			if (adapter !== null) {
+				if (adapter.classLoader === null) {
 					// old adapter without classLoader (already closed)
 					// remove
 					ctx.editorResource.eAdapters.remove(adapter)				
@@ -114,7 +114,7 @@ class JdtBasedProcessorProvider extends ProcessorInstanceForJvmTypeProvider {
 				case IClasspathEntry.CPE_SOURCE: {
 					if (includeOutputFolder) {
 						val path = entry.getOutputLocation();
-						if (path != null)
+						if (path !== null)
 							url = new URL(
 								URI.createPlatformResourceURI(path.addTrailingSeparator().toString(), true).toString());
 					}
@@ -130,7 +130,7 @@ class JdtBasedProcessorProvider extends ProcessorInstanceForJvmTypeProvider {
 					// if the library is in the workspace, the entry path is relative to the workspace root
 					// thus we load it as a resource and take the raw path to find the location in the file system
 					val IResource library = projectToUse.workspaceRoot.findMember(path)
-					url = if (library != null) {
+					url = if (library !== null) {
 						library.rawLocationURI.toURL
 					} else {
 						// otherwise we use the path itself
@@ -142,7 +142,7 @@ class JdtBasedProcessorProvider extends ProcessorInstanceForJvmTypeProvider {
 					url = path.toFile().toURI().toURL();
 				}
 			}
-			if (url != null) {
+			if (url !== null) {
 				result.add(url);
 			}
 		}

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/outline/EclipseXtendOutlineSourceContext.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/outline/EclipseXtendOutlineSourceContext.xtend
@@ -36,7 +36,7 @@ class EclipseXtendOutlineSourceContext extends EclipseXtendOutlineContext {
 	protected def markCreateExtensionJvmFeaturesAsProcessed(JvmMember member) {
 		val function = member.primarySourceElement
 		if (function instanceof XtendFunction) {
-			if (function.createExtensionInfo != null) {
+			if (function.createExtensionInfo !== null) {
 				for (jvmFeature : function.jvmElements.filter(JvmFeature).filter[it != member].filter [
 					simpleName.startsWith(CREATE_CHACHE_VARIABLE_PREFIX) ||
 						simpleName.startsWith(CREATE_INITIALIZER_PREFIX)

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/outline/XtendOutlineWithEditorLinker.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/outline/XtendOutlineWithEditorLinker.xtend
@@ -41,7 +41,7 @@ class XtendOutlineWithEditorLinker extends OutlineWithEditorLinker {
 	
 	def protected void findNodesInRange(IOutlineNode input, ITextRegion selectedTextRegion, List<IOutlineNode> nodes) {
 		val ITextRegion textRegion = input.getFullTextRegion();
-		if (textRegion == null || textRegion.contains(selectedTextRegion)) {
+		if (textRegion === null || textRegion.contains(selectedTextRegion)) {
 			nodes.add(input)
 		}
 		for (IOutlineNode child : input.getChildren()) {

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/CodeBuilderQuickfix.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/CodeBuilderQuickfix.xtend
@@ -104,7 +104,7 @@ class CodeBuilderQuickfix {
 					JavaMethodBuilder: type.createMethod(content.toString, null, true, new NullProgressMonitor)
 					default: null
 				}
-			if(element != null)
+			if(element !== null)
 				new JdtHyperlink => [
 					javaElement = element
 					open

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/AbstractCodeBuilder.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/AbstractCodeBuilder.java
@@ -67,7 +67,7 @@ public abstract class AbstractCodeBuilder implements ICodeBuilder {
   @Override
   public boolean isValid() {
     final IJavaElement javaElement = this._iJavaElementFinder.findElementFor(this.owner);
-    return ((((Objects.equal(javaElement, null) || (!javaElement.isReadOnly())) && (!Objects.equal(this.ownerSource, null))) && (!Objects.equal(this.owner, null))) && (!Objects.equal(this.context, null)));
+    return (((((javaElement == null) || (!javaElement.isReadOnly())) && (this.ownerSource != null)) && (this.owner != null)) && (this.context != null));
   }
   
   @Override
@@ -131,8 +131,7 @@ public abstract class AbstractCodeBuilder implements ICodeBuilder {
   protected ISourceAppender appendType(final ISourceAppender appendable, final LightweightTypeReference typeRef, final String surrogate) {
     ISourceAppender _xblockexpression = null;
     {
-      boolean _equals = Objects.equal(typeRef, null);
-      if (_equals) {
+      if ((typeRef == null)) {
         appendable.append(surrogate);
       } else {
         appendable.append(typeRef);

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/AbstractExecutableBuilder.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/AbstractExecutableBuilder.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.codebuilder;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -70,8 +69,7 @@ public abstract class AbstractExecutableBuilder extends AbstractCodeBuilder {
       ISourceAppender _append = appendable.append(" {");
       ISourceAppender _increaseIndentation = _append.increaseIndentation();
       _increaseIndentation.newLine();
-      boolean _notEquals = (!Objects.equal(this.bodyGenerator, null));
-      if (_notEquals) {
+      if ((this.bodyGenerator != null)) {
         this.bodyGenerator.apply(appendable);
       } else {
         String _defaultBody = this.defaultBody();
@@ -134,8 +132,8 @@ public abstract class AbstractExecutableBuilder extends AbstractCodeBuilder {
           final AbstractParameterBuilder parameterBuilder = this.parameterBuilders.get((i).intValue());
           final VariableNameAcceptor acceptor = new VariableNameAcceptor(notAllowed);
           String _name = parameterBuilder.getName();
-          boolean _equals = Objects.equal(_name, null);
-          if (_equals) {
+          boolean _tripleEquals = (_name == null);
+          if (_tripleEquals) {
             LightweightTypeReference _type = parameterBuilder.getType();
             String _identifier = _type.getIdentifier();
             EObject _context = this.getContext();
@@ -168,8 +166,7 @@ public abstract class AbstractExecutableBuilder extends AbstractCodeBuilder {
         do {
           {
             final LightweightTypeReference typeRef = iterator.next();
-            boolean _notEquals = (!Objects.equal(typeRef, null));
-            if (_notEquals) {
+            if ((typeRef != null)) {
               this.appendType(appendable, typeRef, "Exception");
             }
             boolean _hasNext_1 = iterator.hasNext();

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/AbstractParameterBuilder.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/AbstractParameterBuilder.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.codebuilder;
 
-import com.google.common.base.Objects;
 import org.eclipse.xtend.ide.codebuilder.AbstractCodeBuilder;
 import org.eclipse.xtend.lib.annotations.Accessors;
 import org.eclipse.xtext.xbase.compiler.ISourceAppender;
@@ -57,7 +56,7 @@ public abstract class AbstractParameterBuilder extends AbstractCodeBuilder {
   
   @Override
   public boolean isValid() {
-    return (((!Objects.equal(this.type, null)) && ((!this.varArgsFlag) || (this.type instanceof ArrayTypeReference))) && super.isValid());
+    return (((this.type != null) && ((!this.varArgsFlag) || (this.type instanceof ArrayTypeReference))) && super.isValid());
   }
   
   @Override

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/InsertionOffsets.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/InsertionOffsets.java
@@ -40,14 +40,13 @@ public class InsertionOffsets {
       return this.inEmpty(ownerType);
     }
     final XtendField callingMember = EcoreUtil2.<XtendField>getContainerOfType(call, XtendField.class);
-    if (((!Objects.equal(callingMember, null)) && ownerType.getMembers().contains(callingMember))) {
+    if (((callingMember != null) && ownerType.getMembers().contains(callingMember))) {
       return this.before(callingMember);
     }
     EList<XtendMember> _members_1 = ownerType.getMembers();
     Iterable<XtendField> _filter = Iterables.<XtendField>filter(_members_1, XtendField.class);
     final XtendField lastDefinedField = IterableExtensions.<XtendField>last(_filter);
-    boolean _equals = Objects.equal(lastDefinedField, null);
-    if (_equals) {
+    if ((lastDefinedField == null)) {
       EList<XtendMember> _members_2 = ownerType.getMembers();
       XtendMember _head = IterableExtensions.<XtendMember>head(_members_2);
       return this.before(_head);
@@ -58,7 +57,7 @@ public class InsertionOffsets {
   
   public int getNewMethodInsertOffset(final EObject call, final XtendTypeDeclaration ownerType) {
     final XtendMember callingMember = EcoreUtil2.<XtendMember>getContainerOfType(call, XtendMember.class);
-    if (((!Objects.equal(callingMember, null)) && ownerType.getMembers().contains(callingMember))) {
+    if (((callingMember != null) && ownerType.getMembers().contains(callingMember))) {
       return this.after(callingMember);
     } else {
       EList<XtendMember> _members = ownerType.getMembers();
@@ -77,8 +76,7 @@ public class InsertionOffsets {
     EList<XtendMember> _members = ownerType.getMembers();
     Iterable<XtendConstructor> _filter = Iterables.<XtendConstructor>filter(_members, XtendConstructor.class);
     final XtendConstructor lastDefinedConstructor = IterableExtensions.<XtendConstructor>last(_filter);
-    boolean _equals = Objects.equal(lastDefinedConstructor, null);
-    if (_equals) {
+    if ((lastDefinedConstructor == null)) {
       return this.getNewFieldInsertOffset(call, ownerType);
     } else {
       return this.after(lastDefinedConstructor);
@@ -110,8 +108,7 @@ public class InsertionOffsets {
       };
       final ILeafNode openingBraceNode = IterableExtensions.<ILeafNode>findFirst(_leafNodes, _function);
       int _xifexpression = (int) 0;
-      boolean _notEquals = (!Objects.equal(openingBraceNode, null));
-      if (_notEquals) {
+      if ((openingBraceNode != null)) {
         int _offset = openingBraceNode.getOffset();
         _xifexpression = (_offset + 1);
       } else {

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/JavaAnnotationBuilder.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/JavaAnnotationBuilder.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.codebuilder;
 
-import com.google.common.base.Objects;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.xtend.ide.codebuilder.AbstractAnnotationBuilder;
 import org.eclipse.xtend.ide.codebuilder.ICodeBuilder;
@@ -21,7 +20,7 @@ import org.eclipse.xtext.xbase.compiler.ISourceAppender;
 public class JavaAnnotationBuilder extends AbstractAnnotationBuilder implements ICodeBuilder.Java {
   @Override
   public boolean isValid() {
-    return (super.isValid() && (!Objects.equal(this.getAnnotationName(), null)));
+    return (super.isValid() && (this.getAnnotationName() != null));
   }
   
   @Override

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/JavaClassBuilder.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/JavaClassBuilder.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.codebuilder;
 
-import com.google.common.base.Objects;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.xtend.ide.codebuilder.AbstractClassBuilder;
 import org.eclipse.xtend.ide.codebuilder.ICodeBuilder;
@@ -21,7 +20,7 @@ import org.eclipse.xtext.xbase.compiler.ISourceAppender;
 public class JavaClassBuilder extends AbstractClassBuilder implements ICodeBuilder.Java {
   @Override
   public boolean isValid() {
-    return (super.isValid() && (!Objects.equal(this.getClassName(), null)));
+    return (super.isValid() && (this.getClassName() != null));
   }
   
   @Override

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/JavaFieldBuilder.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/JavaFieldBuilder.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.codebuilder;
 
-import com.google.common.base.Objects;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.xtend.ide.codebuilder.AbstractFieldBuilder;
 import org.eclipse.xtend.ide.codebuilder.ICodeBuilder;
@@ -22,7 +21,7 @@ import org.eclipse.xtext.xbase.typesystem.references.LightweightTypeReference;
 public class JavaFieldBuilder extends AbstractFieldBuilder implements ICodeBuilder.Java {
   @Override
   public boolean isValid() {
-    return ((super.isValid() && (!Objects.equal(this.getFieldName(), null))) && (!Objects.equal(this.getFieldType(), null)));
+    return ((super.isValid() && (this.getFieldName() != null)) && (this.getFieldType() != null));
   }
   
   @Override

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/JavaInterfaceBuilder.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/JavaInterfaceBuilder.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.codebuilder;
 
-import com.google.common.base.Objects;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.xtend.ide.codebuilder.AbstractInterfaceBuilder;
 import org.eclipse.xtend.ide.codebuilder.ICodeBuilder;
@@ -21,7 +20,7 @@ import org.eclipse.xtext.xbase.compiler.ISourceAppender;
 public class JavaInterfaceBuilder extends AbstractInterfaceBuilder implements ICodeBuilder.Java {
   @Override
   public boolean isValid() {
-    return (super.isValid() && (!Objects.equal(this.getInterfaceName(), null)));
+    return (super.isValid() && (this.getInterfaceName() != null));
   }
   
   @Override

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/JavaMethodBuilder.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/JavaMethodBuilder.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.codebuilder;
 
-import com.google.common.base.Objects;
 import java.util.List;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.xtend.ide.codebuilder.AbstractMethodBuilder;
@@ -24,7 +23,7 @@ import org.eclipse.xtext.xbase.typesystem.references.LightweightTypeReference;
 public class JavaMethodBuilder extends AbstractMethodBuilder implements ICodeBuilder.Java {
   @Override
   public boolean isValid() {
-    return (super.isValid() && (!Objects.equal(this.getMethodName(), null)));
+    return (super.isValid() && (this.getMethodName() != null));
   }
   
   @Override

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/MemberFromSuperImplementor.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/MemberFromSuperImplementor.java
@@ -184,11 +184,10 @@ public class MemberFromSuperImplementor {
       Iterable<JvmDeclaredType> _map = IterableExtensions.<JvmTypeReference, JvmDeclaredType>map(_filter, _function_3);
       final Function1<JvmDeclaredType, Boolean> _function_4 = (JvmDeclaredType it) -> {
         Procedure1<? super ISourceAppender> _implementedInterface = this.getImplementedInterface(it, superInterface);
-        return Boolean.valueOf((!Objects.equal(_implementedInterface, null)));
+        return Boolean.valueOf((_implementedInterface != null));
       };
       final JvmDeclaredType interfaze = IterableExtensions.<JvmDeclaredType>findFirst(_map, _function_4);
-      boolean _notEquals = (!Objects.equal(interfaze, null));
-      if (_notEquals) {
+      if ((interfaze != null)) {
         final Procedure1<ISourceAppender> _function_5 = (ISourceAppender it) -> {
           ISourceAppender _append = it.append(interfaze);
           _append.append(".");
@@ -248,8 +247,8 @@ public class MemberFromSuperImplementor {
       parameterBuilder.setName(_simpleName);
       parameterBuilder.setType(it);
       JvmAnnotationReference _findAnnotation = this.annotationLookup.findAnnotation(declaredParameter, Extension.class);
-      boolean _notEquals = (!Objects.equal(_findAnnotation, null));
-      parameterBuilder.setExtensionFlag(_notEquals);
+      boolean _tripleNotEquals = (_findAnnotation != null);
+      parameterBuilder.setExtensionFlag(_tripleNotEquals);
     };
     IterableExtensions.<LightweightTypeReference>forEach(_resolvedParameterTypes, _function);
     boolean _isVarArgs = executable.isVarArgs();

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/XtendAnnotationBuilder.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/XtendAnnotationBuilder.java
@@ -30,7 +30,7 @@ public class XtendAnnotationBuilder extends AbstractAnnotationBuilder implements
   
   @Override
   public boolean isValid() {
-    return ((super.isValid() && (!Objects.equal(this.getAnnotationName(), null))) && Objects.equal(this.getVisibility(), JvmVisibility.PUBLIC));
+    return ((super.isValid() && (this.getAnnotationName() != null)) && Objects.equal(this.getVisibility(), JvmVisibility.PUBLIC));
   }
   
   @Override

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/XtendClassBuilder.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/XtendClassBuilder.java
@@ -30,7 +30,7 @@ public class XtendClassBuilder extends AbstractClassBuilder implements ICodeBuil
   
   @Override
   public boolean isValid() {
-    return ((super.isValid() && (!Objects.equal(this.getClassName(), null))) && Objects.equal(this.getVisibility(), JvmVisibility.PUBLIC));
+    return ((super.isValid() && (this.getClassName() != null)) && Objects.equal(this.getVisibility(), JvmVisibility.PUBLIC));
   }
   
   @Override

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/XtendFieldBuilder.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/XtendFieldBuilder.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.codebuilder;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtend.core.xtend.XtendTypeDeclaration;
@@ -31,7 +30,7 @@ public class XtendFieldBuilder extends AbstractFieldBuilder implements ICodeBuil
   
   @Override
   public boolean isValid() {
-    return (super.isValid() && (!Objects.equal(this.getFieldName(), null)));
+    return (super.isValid() && (this.getFieldName() != null));
   }
   
   @Override

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/XtendInterfaceBuilder.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/XtendInterfaceBuilder.java
@@ -30,7 +30,7 @@ public class XtendInterfaceBuilder extends AbstractInterfaceBuilder implements I
   
   @Override
   public boolean isValid() {
-    return ((super.isValid() && (!Objects.equal(this.getInterfaceName(), null))) && Objects.equal(this.getVisibility(), JvmVisibility.PUBLIC));
+    return ((super.isValid() && (this.getInterfaceName() != null)) && Objects.equal(this.getVisibility(), JvmVisibility.PUBLIC));
   }
   
   @Override

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/XtendMethodBuilder.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/XtendMethodBuilder.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.codebuilder;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.List;
 import org.eclipse.emf.ecore.EObject;
@@ -33,7 +32,7 @@ public class XtendMethodBuilder extends AbstractMethodBuilder implements ICodeBu
   
   @Override
   public boolean isValid() {
-    return (super.isValid() && (!Objects.equal(this.getMethodName(), null)));
+    return (super.isValid() && (this.getMethodName() != null));
   }
   
   @Override

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/hyperlinking/HyperLinkingLabelProvider.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/hyperlinking/HyperLinkingLabelProvider.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.hyperlinking;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider;
 import org.eclipse.xtend.ide.labeling.XtendLabelProvider;
@@ -25,8 +24,7 @@ public class HyperLinkingLabelProvider extends XtendLabelProvider {
   @Override
   public String getText(final Object element) {
     final String result = super.getText(element);
-    boolean _notEquals = (!Objects.equal(result, null));
-    if (_notEquals) {
+    if ((result != null)) {
       return ("Open Declaration - " + result);
     }
     return null;

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/hyperlinking/XtendFileHyperlink.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/hyperlinking/XtendFileHyperlink.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtend.ide.hyperlinking;
 
-import com.google.common.base.Objects;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.model.IProcess;
@@ -95,8 +94,7 @@ public class XtendFileHyperlink implements IHyperlink {
   private ILaunch getLaunch() {
     Object _attribute = this.console.getAttribute(IDebugUIConstants.ATTR_CONSOLE_PROCESS);
     final IProcess process = ((IProcess) _attribute);
-    boolean _notEquals = (!Objects.equal(process, null));
-    if (_notEquals) {
+    if ((process != null)) {
       return process.getLaunch();
     }
     return null;

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/javaconverter/EclipseASTParserFactory.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/javaconverter/EclipseASTParserFactory.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.javaconverter;
 
-import com.google.common.base.Objects;
 import java.util.Map;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
@@ -43,8 +42,7 @@ public class EclipseASTParserFactory extends ASTParserFactory {
   }
   
   public void tweakOptions(final ASTParser parser, final IJavaProject project) {
-    boolean _notEquals = (!Objects.equal(project, null));
-    if (_notEquals) {
+    if ((project != null)) {
       final Map options = project.getOptions(true);
       options.remove(JavaCore.COMPILER_TASK_TAGS);
       options.put(JavaCore.COMPILER_DOC_COMMENT_SUPPORT, JavaCore.ENABLED);

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/labeling/XtendLabelProvider.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/labeling/XtendLabelProvider.java
@@ -1,6 +1,5 @@
 package org.eclipse.xtend.ide.labeling;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -119,8 +118,7 @@ public class XtendLabelProvider extends XtendJvmLabelProvider {
     {
       final JvmOperation operation = this._iXtendJvmAssociations.getDirectlyInferredOperation(element);
       ImageDescriptor _xifexpression = null;
-      boolean _notEquals = (!Objects.equal(operation, null));
-      if (_notEquals) {
+      if ((operation != null)) {
         JvmVisibility _visibility = element.getVisibility();
         int _get = this.adornments.get(operation);
         _xifexpression = this.images.forOperation(_visibility, _get);
@@ -223,12 +221,10 @@ public class XtendLabelProvider extends XtendJvmLabelProvider {
   
   protected StyledString text(final XtendFunction element) {
     final String simpleName = element.getName();
-    boolean _notEquals = (!Objects.equal(simpleName, null));
-    if (_notEquals) {
+    if ((simpleName != null)) {
       final QualifiedName qnName = QualifiedName.create(simpleName);
       final QualifiedName operator = this.operatorMapping.getOperator(qnName);
-      boolean _notEquals_1 = (!Objects.equal(operator, null));
-      if (_notEquals_1) {
+      if ((operator != null)) {
         String _firstSegment = operator.getFirstSegment();
         JvmOperation _directlyInferredOperation = this._iXtendJvmAssociations.getDirectlyInferredOperation(element);
         final StyledString result = this.signature(_firstSegment, _directlyInferredOperation);
@@ -244,19 +240,18 @@ public class XtendLabelProvider extends XtendJvmLabelProvider {
   protected StyledString text(final XtendField element) {
     StyledString _xblockexpression = null;
     {
-      if ((Objects.equal(element.getName(), null) && element.isExtension())) {
+      if (((element.getName() == null) && element.isExtension())) {
         JvmTypeReference _type = element.getType();
         String _referenceToString = this.uiStrings.referenceToString(_type, "extension");
         return new StyledString(_referenceToString, 
           StyledString.DECORATIONS_STYLER);
       }
       final JvmTypeReference fieldType = this.getDisplayedType(element);
-      boolean _notEquals = (!Objects.equal(fieldType, null));
-      if (_notEquals) {
+      if ((fieldType != null)) {
         final String type = this.uiStrings.referenceToString(fieldType, "");
         int _length = type.length();
-        boolean _notEquals_1 = (_length != 0);
-        if (_notEquals_1) {
+        boolean _notEquals = (_length != 0);
+        if (_notEquals) {
           String _name = element.getName();
           StyledString _styledString = new StyledString(_name);
           StyledString _styledString_1 = new StyledString((" : " + type), StyledString.DECORATIONS_STYLER);
@@ -285,8 +280,7 @@ public class XtendLabelProvider extends XtendJvmLabelProvider {
     Object _xblockexpression = null;
     {
       final JvmField jvmField = this._iXtendJvmAssociations.getJvmField(field);
-      boolean _notEquals = (!Objects.equal(jvmField, null));
-      if (_notEquals) {
+      if ((jvmField != null)) {
         return jvmField.getType();
       } else {
         Set<EObject> _jvmElements = this._iXtendJvmAssociations.getJvmElements(field);

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/macro/EclipseFileSystemSupportImpl.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/macro/EclipseFileSystemSupportImpl.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.macro;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
@@ -76,8 +75,7 @@ public class EclipseFileSystemSupportImpl extends AbstractFileSystemSupport {
     java.net.URI _xblockexpression = null;
     {
       final IResource resource = this.findMember(uri);
-      boolean _equals = Objects.equal(resource, null);
-      if (_equals) {
+      if ((resource == null)) {
         String _lastSegment = uri.lastSegment();
         trailingSegments.add(_lastSegment);
         URI _trimSegments = uri.trimSegments(1);

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/macro/JdtBasedProcessorProvider.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/macro/JdtBasedProcessorProvider.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.macro;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import java.io.File;
 import java.net.URL;
@@ -80,8 +79,7 @@ public class JdtBasedProcessorProvider extends ProcessorInstanceForJvmTypeProvid
       EList<Adapter> _eAdapters = rs.eAdapters();
       Iterable<ProcessorInstanceForJvmTypeProvider.ProcessorClassloaderAdapter> _filter = Iterables.<ProcessorInstanceForJvmTypeProvider.ProcessorClassloaderAdapter>filter(_eAdapters, ProcessorInstanceForJvmTypeProvider.ProcessorClassloaderAdapter.class);
       final ProcessorInstanceForJvmTypeProvider.ProcessorClassloaderAdapter adapter = IterableExtensions.<ProcessorInstanceForJvmTypeProvider.ProcessorClassloaderAdapter>head(_filter);
-      boolean _notEquals = (!Objects.equal(adapter, null));
-      if (_notEquals) {
+      if ((adapter != null)) {
         return adapter.getClassLoader();
       }
     }
@@ -90,11 +88,10 @@ public class JdtBasedProcessorProvider extends ProcessorInstanceForJvmTypeProvid
       EList<Adapter> _eAdapters_1 = _editorResource.eAdapters();
       Iterable<ProcessorInstanceForJvmTypeProvider.ProcessorClassloaderAdapter> _filter_1 = Iterables.<ProcessorInstanceForJvmTypeProvider.ProcessorClassloaderAdapter>filter(_eAdapters_1, ProcessorInstanceForJvmTypeProvider.ProcessorClassloaderAdapter.class);
       final ProcessorInstanceForJvmTypeProvider.ProcessorClassloaderAdapter adapter_1 = IterableExtensions.<ProcessorInstanceForJvmTypeProvider.ProcessorClassloaderAdapter>head(_filter_1);
-      boolean _notEquals_1 = (!Objects.equal(adapter_1, null));
-      if (_notEquals_1) {
+      if ((adapter_1 != null)) {
         ClassLoader _classLoader = adapter_1.getClassLoader();
-        boolean _equals = Objects.equal(_classLoader, null);
-        if (_equals) {
+        boolean _tripleEquals = (_classLoader == null);
+        if (_tripleEquals) {
           Resource _editorResource_1 = this.getEditorResource(ctx);
           EList<Adapter> _eAdapters_2 = _editorResource_1.eAdapters();
           _eAdapters_2.remove(adapter_1);
@@ -181,8 +178,7 @@ public class JdtBasedProcessorProvider extends ProcessorInstanceForJvmTypeProvid
             case IClasspathEntry.CPE_SOURCE:
               if (includeOutputFolder) {
                 final IPath path_1 = entry.getOutputLocation();
-                boolean _notEquals = (!Objects.equal(path_1, null));
-                if (_notEquals) {
+                if ((path_1 != null)) {
                   IPath _addTrailingSeparator = path_1.addTrailingSeparator();
                   String _string_2 = _addTrailingSeparator.toString();
                   URI _createPlatformResourceURI_1 = URI.createPlatformResourceURI(_string_2, true);
@@ -205,8 +201,7 @@ public class JdtBasedProcessorProvider extends ProcessorInstanceForJvmTypeProvid
               IWorkspaceRoot _workspaceRoot_1 = this.getWorkspaceRoot(projectToUse);
               final IResource library = _workspaceRoot_1.findMember(path_3);
               URL _xifexpression = null;
-              boolean _notEquals_1 = (!Objects.equal(library, null));
-              if (_notEquals_1) {
+              if ((library != null)) {
                 java.net.URI _rawLocationURI = library.getRawLocationURI();
                 _xifexpression = _rawLocationURI.toURL();
               } else {
@@ -226,8 +221,7 @@ public class JdtBasedProcessorProvider extends ProcessorInstanceForJvmTypeProvid
               }
               break;
           }
-          boolean _notEquals_2 = (!Objects.equal(url_1, null));
-          if (_notEquals_2) {
+          if ((url_1 != null)) {
             result.add(url_1);
           }
         }

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/outline/EclipseXtendOutlineSourceContext.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/outline/EclipseXtendOutlineSourceContext.java
@@ -52,8 +52,8 @@ public class EclipseXtendOutlineSourceContext extends EclipseXtendOutlineContext
     final EObject function = this._iXtendJvmAssociations.getPrimarySourceElement(member);
     if ((function instanceof XtendFunction)) {
       CreateExtensionInfo _createExtensionInfo = ((XtendFunction)function).getCreateExtensionInfo();
-      boolean _notEquals = (!Objects.equal(_createExtensionInfo, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_createExtensionInfo != null);
+      if (_tripleNotEquals) {
         Set<EObject> _jvmElements = this._iXtendJvmAssociations.getJvmElements(function);
         Iterable<JvmFeature> _filter = Iterables.<JvmFeature>filter(_jvmElements, JvmFeature.class);
         final Function1<JvmFeature, Boolean> _function = (JvmFeature it) -> {

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/outline/XtendOutlineWithEditorLinker.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/outline/XtendOutlineWithEditorLinker.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.outline;
 
-import com.google.common.base.Objects;
 import java.util.List;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.viewers.ISelection;
@@ -67,7 +66,7 @@ public class XtendOutlineWithEditorLinker extends OutlineWithEditorLinker {
   
   protected void findNodesInRange(final IOutlineNode input, final ITextRegion selectedTextRegion, final List<IOutlineNode> nodes) {
     final ITextRegion textRegion = input.getFullTextRegion();
-    if ((Objects.equal(textRegion, null) || textRegion.contains(selectedTextRegion))) {
+    if (((textRegion == null) || textRegion.contains(selectedTextRegion))) {
       nodes.add(input);
     }
     List<IOutlineNode> _children = input.getChildren();

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/quickfix/CodeBuilderQuickfix.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/quickfix/CodeBuilderQuickfix.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.ide.quickfix;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import java.util.List;
 import java.util.function.Consumer;
@@ -192,8 +191,7 @@ public class CodeBuilderQuickfix {
         _switchResult = null;
       }
       final Object element = ((Object)_switchResult);
-      boolean _notEquals = (!Objects.equal(element, null));
-      if (_notEquals) {
+      if ((element != null)) {
         JdtHyperlink _jdtHyperlink = new JdtHyperlink();
         final Procedure1<JdtHyperlink> _function_2 = (JdtHyperlink it_1) -> {
           it_1.setJavaElement(((IMember)element));

--- a/org.eclipse.xtend.idea.tests/src/org/eclipse/xtend/idea/completion/XtendCodeContextTypeTest.xtend
+++ b/org.eclipse.xtend.idea.tests/src/org/eclipse/xtend/idea/completion/XtendCodeContextTypeTest.xtend
@@ -128,7 +128,7 @@ class XtendCodeContextTypeTest extends LightXtendTest {
 		val result = TemplateManagerImpl.allContextTypes.findFirst[
 			clazz.isInstance(it)
 		]
-		if (result == null) {
+		if (result === null) {
 			throw new AssertionError("The context type "+clazz.name+" wasn't registered.")
 		}
 		return result

--- a/org.eclipse.xtend.idea.tests/src/org/eclipse/xtend/idea/execution/TraceBasedConfigurationProducerTest.xtend
+++ b/org.eclipse.xtend.idea.tests/src/org/eclipse/xtend/idea/execution/TraceBasedConfigurationProducerTest.xtend
@@ -238,7 +238,7 @@ class TraceBasedConfigurationProducerTest extends XtendIdeaTestCase {
 
 	def private ConfigurationContext createContext(@NotNull PsiElement psiClass, @NotNull MapDataContext dataContext) {
 		dataContext.put(CommonDataKeys.PROJECT, myProject);
-		if (LangDataKeys.MODULE.getData(dataContext) == null) {
+		if (LangDataKeys.MODULE.getData(dataContext) === null) {
 			dataContext.put(LangDataKeys.MODULE, ModuleUtilCore.findModuleForPsiElement(psiClass));
 		}
 		dataContext.put(Location.DATA_KEY, PsiLocation.fromPsiElement(psiClass));

--- a/org.eclipse.xtend.idea.tests/src/org/eclipse/xtend/idea/navigation/XtendNavigationTest.xtend
+++ b/org.eclipse.xtend.idea.tests/src/org/eclipse/xtend/idea/navigation/XtendNavigationTest.xtend
@@ -499,7 +499,7 @@ class XtendNavigationTest extends LightXtendTest {
 		assertNotNull(element)
 
 		val namedEObject = element.findPsiNamedEObject(range)
-		if (namedEObject != null) {
+		if (namedEObject !== null) {
 			assertEquals(namedEObject, namedEObject.navigationElement)
 			return namedEObject
 		}
@@ -513,12 +513,12 @@ class XtendNavigationTest extends LightXtendTest {
 	}
 
 	protected def PsiElement findPsiNamedEObject(PsiElement element, TextRange identifierRange) {
-		if (element == null) {
+		if (element === null) {
 			return null
 		}
 		if (element instanceof PsiNamedEObject) {
 			val nameIdentifier = element.nameIdentifier
-			if (nameIdentifier != null) {
+			if (nameIdentifier !== null) {
 				return if (nameIdentifier.textRange == identifierRange)
 					element
 				else

--- a/org.eclipse.xtend.idea.tests/src/org/eclipse/xtend/idea/structureview/AbstractOutlineTests.xtend
+++ b/org.eclipse.xtend.idea.tests/src/org/eclipse/xtend/idea/structureview/AbstractOutlineTests.xtend
@@ -292,15 +292,15 @@ abstract class AbstractOutlineTests extends LightToolingTest {
 
 	override void testStructureView(Consumer<StructureViewComponent> consumer) {
 		val myFile = myFixture.file.virtualFile
-		if (!(myFile != null)) {
+		if (!(myFile !== null)) {
 			throw new AssertionError("configure first")
 		}
 		val fileEditor = FileEditorManager.getInstance(project).getSelectedEditor(myFile)
-		if (fileEditor == null) {
+		if (fileEditor === null) {
 			throw new AssertionError('''editor not opened for «myFile»''')
 		}
 		val builder = LanguageStructureViewBuilder.INSTANCE.getStructureViewBuilder(myFixture.file)
-		if (builder == null) {
+		if (builder === null) {
 			throw new AssertionError('''no builder for «myFile»''')
 		}
 		var StructureView view = null
@@ -309,7 +309,7 @@ abstract class AbstractOutlineTests extends LightToolingTest {
 			val component = view.structureViewComponent
 			consumer.consume(component)
 		} finally {
-			if(view != null) Disposer.dispose(view)
+			if(view !== null) Disposer.dispose(view)
 		}
 	}
 

--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/autobuild/IdeaIntegrationTest.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/autobuild/IdeaIntegrationTest.java
@@ -37,7 +37,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.Collections;
-import junit.framework.Assert;
+import junit.framework.TestCase;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtend.core.idea.facet.XtendFacetType;
 import org.eclipse.xtend.core.idea.lang.XtendLanguage;
@@ -69,7 +69,7 @@ public class IdeaIntegrationTest extends LightXtendTest {
     this.myFixture.addFileToProject("otherPackage/Foo.xtend", _builder.toString());
     final VirtualFile file = this.myFixture.findFileInTempDir("xtend-gen/otherPackage/Foo.java");
     boolean _exists = file.exists();
-    Assert.assertTrue(_exists);
+    TestCase.assertTrue(_exists);
     Application _application = ApplicationManager.getApplication();
     final Runnable _function = () -> {
       try {
@@ -81,7 +81,7 @@ public class IdeaIntegrationTest extends LightXtendTest {
     _application.runWriteAction(_function);
     final VirtualFile regenerated = this.myFixture.findFileInTempDir("xtend-gen/otherPackage/Foo.java");
     boolean _exists_1 = regenerated.exists();
-    Assert.assertTrue(_exists_1);
+    TestCase.assertTrue(_exists_1);
   }
   
   public void testNoChangeDoesntTouch() {
@@ -95,7 +95,7 @@ public class IdeaIntegrationTest extends LightXtendTest {
     final PsiFile xtendFile = this.myFixture.addFileToProject("otherPackage/Foo.xtend", _builder.toString());
     final VirtualFile file = this.myFixture.findFileInTempDir("xtend-gen/otherPackage/Foo.java");
     boolean _exists = file.exists();
-    Assert.assertTrue(_exists);
+    TestCase.assertTrue(_exists);
     final long stamp = file.getModificationStamp();
     Project _project = this.getProject();
     PsiDocumentManager _instance = PsiDocumentManager.getInstance(_project);
@@ -117,7 +117,7 @@ public class IdeaIntegrationTest extends LightXtendTest {
     _application.runWriteAction(_function);
     final VirtualFile regenerated = this.myFixture.findFileInTempDir("xtend-gen/otherPackage/Foo.java");
     long _modificationStamp = regenerated.getModificationStamp();
-    Assert.assertEquals(stamp, _modificationStamp);
+    TestCase.assertEquals(stamp, _modificationStamp);
   }
   
   public void testRemoveAndAddFacet() {
@@ -131,7 +131,7 @@ public class IdeaIntegrationTest extends LightXtendTest {
     final PsiFile source = this.myFixture.addFileToProject("otherPackage/Foo.xtend", _builder.toString());
     VirtualFile file = this.myFixture.findFileInTempDir("xtend-gen/otherPackage/Foo.java");
     boolean _exists = file.exists();
-    Assert.assertTrue(_exists);
+    TestCase.assertTrue(_exists);
     Application _application = ApplicationManager.getApplication();
     final Runnable _function = () -> {
       final FacetManager mnr = FacetManager.getInstance(this.myModule);
@@ -153,14 +153,14 @@ public class IdeaIntegrationTest extends LightXtendTest {
     URI _uRI = VirtualFileURIUtil.getURI(_virtualFile);
     Iterable<URI> _generatedSources = autoBuilder.getGeneratedSources(_uRI);
     boolean _isEmpty = IterableExtensions.isEmpty(_generatedSources);
-    Assert.assertTrue(_isEmpty);
+    TestCase.assertTrue(_isEmpty);
     ChunkedResourceDescriptions _indexState = autoBuilder.getIndexState();
     Iterable<IResourceDescription> _allResourceDescriptions = _indexState.getAllResourceDescriptions();
     boolean _isEmpty_1 = IterableExtensions.isEmpty(_allResourceDescriptions);
-    Assert.assertTrue(_isEmpty_1);
+    TestCase.assertTrue(_isEmpty_1);
     VirtualFile _findFileInTempDir = this.myFixture.findFileInTempDir("xtend-gen/otherPackage/Foo.java");
     file = _findFileInTempDir;
-    Assert.assertNull(file);
+    TestCase.assertNull(file);
     String _iD = XtendLanguage.INSTANCE.getID();
     LightToolingTest.addFacetToModule(this.myModule, _iD);
     VirtualFile _virtualFile_1 = source.getVirtualFile();
@@ -169,7 +169,7 @@ public class IdeaIntegrationTest extends LightXtendTest {
     Iterable<IResourceDescription> _allResourceDescriptions_1 = _indexState_1.getAllResourceDescriptions();
     IResourceDescription _head = IterableExtensions.<IResourceDescription>head(_allResourceDescriptions_1);
     URI _uRI_2 = _head.getURI();
-    Assert.assertEquals(_uRI_1, _uRI_2);
+    TestCase.assertEquals(_uRI_1, _uRI_2);
     VirtualFile _virtualFile_2 = source.getVirtualFile();
     URI _uRI_3 = VirtualFileURIUtil.getURI(_virtualFile_2);
     Iterable<URI> _generatedSources_1 = autoBuilder.getGeneratedSources(_uRI_3);
@@ -178,11 +178,11 @@ public class IdeaIntegrationTest extends LightXtendTest {
       return Boolean.valueOf(_string.endsWith("xtend-gen/otherPackage/Foo.java"));
     };
     boolean _exists_1 = IterableExtensions.<URI>exists(_generatedSources_1, _function_1);
-    Assert.assertTrue(_exists_1);
+    TestCase.assertTrue(_exists_1);
     VirtualFile _findFileInTempDir_1 = this.myFixture.findFileInTempDir("xtend-gen/otherPackage/Foo.java");
     file = _findFileInTempDir_1;
     boolean _exists_2 = file.exists();
-    Assert.assertTrue(_exists_2);
+    TestCase.assertTrue(_exists_2);
   }
   
   public void testJavaDeletionTriggersError() {
@@ -241,7 +241,7 @@ public class IdeaIntegrationTest extends LightXtendTest {
     try {
       VirtualFile _virtualFile_1 = xtendFile.getVirtualFile();
       this.myFixture.testHighlighting(true, true, true, _virtualFile_1);
-      Assert.fail("expecting errors");
+      TestCase.fail("expecting errors");
     } catch (final Throwable _t) {
       if (_t instanceof ComparisonFailure) {
         final ComparisonFailure e = (ComparisonFailure)_t;
@@ -278,7 +278,7 @@ public class IdeaIntegrationTest extends LightXtendTest {
     try {
       VirtualFile _virtualFile = xtendFile.getVirtualFile();
       this.myFixture.testHighlighting(true, true, true, _virtualFile);
-      Assert.fail("expecting errors");
+      TestCase.fail("expecting errors");
     } catch (final Throwable _t) {
       if (_t instanceof ComparisonFailure) {
         final ComparisonFailure e = (ComparisonFailure)_t;
@@ -587,10 +587,10 @@ public class IdeaIntegrationTest extends LightXtendTest {
         _instance.processEvents(Collections.<VFileEvent>unmodifiableList(CollectionLiterals.<VFileEvent>newArrayList(_vFileDeleteEvent)));
         File _parentFile = f.getParentFile();
         boolean _sweepFolder = org.eclipse.xtext.util.Files.sweepFolder(_parentFile);
-        Assert.assertTrue(_sweepFolder);
+        TestCase.assertTrue(_sweepFolder);
         File _parentFile_1 = f.getParentFile();
         boolean _delete = _parentFile_1.delete();
-        Assert.assertTrue(_delete);
+        TestCase.assertTrue(_delete);
         return;
       } catch (Throwable _e) {
         throw Exceptions.sneakyThrow(_e);
@@ -598,7 +598,7 @@ public class IdeaIntegrationTest extends LightXtendTest {
     };
     _application.runWriteAction(_function);
     boolean _exists = vFile.exists();
-    Assert.assertFalse(_exists);
+    TestCase.assertFalse(_exists);
   }
   
   public void testAffectedUpdated() {
@@ -726,10 +726,10 @@ public class IdeaIntegrationTest extends LightXtendTest {
     this.myFixture.addFileToProject("otherPackage/Foo.xtend", _builder.toString());
     VirtualFile _findFileInTempDir = this.myFixture.findFileInTempDir("xtend-gen/otherPackage/Foo.java");
     boolean _exists = _findFileInTempDir.exists();
-    Assert.assertTrue(_exists);
+    TestCase.assertTrue(_exists);
     VirtualFile _findFileInTempDir_1 = this.myFixture.findFileInTempDir("xtend-gen/otherPackage/.Foo.java._trace");
     boolean _exists_1 = _findFileInTempDir_1.exists();
-    Assert.assertTrue(_exists_1);
+    TestCase.assertTrue(_exists_1);
     VirtualFile _findFileInTempDir_2 = this.myFixture.findFileInTempDir("otherPackage/Foo.xtend");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("package otherPackage;");
@@ -740,15 +740,15 @@ public class IdeaIntegrationTest extends LightXtendTest {
     _builder_1.newLine();
     this.myFixture.saveText(_findFileInTempDir_2, _builder_1.toString());
     VirtualFile _findFileInTempDir_3 = this.myFixture.findFileInTempDir("xtend-gen/otherPackage/Foo.java");
-    Assert.assertNull(_findFileInTempDir_3);
+    TestCase.assertNull(_findFileInTempDir_3);
     VirtualFile _findFileInTempDir_4 = this.myFixture.findFileInTempDir("xtend-gen/otherPackage/.Foo.java._trace");
-    Assert.assertNull(_findFileInTempDir_4);
+    TestCase.assertNull(_findFileInTempDir_4);
     VirtualFile _findFileInTempDir_5 = this.myFixture.findFileInTempDir("xtend-gen/otherPackage/OtherClass.java");
     boolean _exists_2 = _findFileInTempDir_5.exists();
-    Assert.assertTrue(_exists_2);
+    TestCase.assertTrue(_exists_2);
     VirtualFile _findFileInTempDir_6 = this.myFixture.findFileInTempDir("xtend-gen/otherPackage/.OtherClass.java._trace");
     boolean _exists_3 = _findFileInTempDir_6.exists();
-    Assert.assertTrue(_exists_3);
+    TestCase.assertTrue(_exists_3);
   }
   
   public void testActiveAnnotation() {
@@ -952,10 +952,10 @@ public class IdeaIntegrationTest extends LightXtendTest {
     final URI after = URI.createURI("temp:///src/Foo.xtend");
     ChunkedResourceDescriptions _index = this.getIndex();
     IResourceDescription _resourceDescription = _index.getResourceDescription(after);
-    Assert.assertNull(_resourceDescription);
+    TestCase.assertNull(_resourceDescription);
     ChunkedResourceDescriptions _index_1 = this.getIndex();
     IResourceDescription _resourceDescription_1 = _index_1.getResourceDescription(before);
-    Assert.assertNotNull(_resourceDescription_1);
+    TestCase.assertNotNull(_resourceDescription_1);
     XtextAutoBuilderComponent _builder_1 = this.getBuilder();
     final Procedure0 _function = () -> {
       Application _application = ApplicationManager.getApplication();
@@ -973,10 +973,10 @@ public class IdeaIntegrationTest extends LightXtendTest {
     _builder_1.runOperation(_function);
     ChunkedResourceDescriptions _index_2 = this.getIndex();
     IResourceDescription _resourceDescription_2 = _index_2.getResourceDescription(after);
-    Assert.assertNotNull(_resourceDescription_2);
+    TestCase.assertNotNull(_resourceDescription_2);
     ChunkedResourceDescriptions _index_3 = this.getIndex();
     IResourceDescription _resourceDescription_3 = _index_3.getResourceDescription(before);
-    Assert.assertNull(_resourceDescription_3);
+    TestCase.assertNull(_resourceDescription_3);
   }
   
   public void testRenameFile() {
@@ -995,10 +995,10 @@ public class IdeaIntegrationTest extends LightXtendTest {
     final URI after = URI.createURI("temp:///src/mypackage/Bar.xtend");
     ChunkedResourceDescriptions _index = this.getIndex();
     IResourceDescription _resourceDescription = _index.getResourceDescription(after);
-    Assert.assertNull(_resourceDescription);
+    TestCase.assertNull(_resourceDescription);
     ChunkedResourceDescriptions _index_1 = this.getIndex();
     IResourceDescription _resourceDescription_1 = _index_1.getResourceDescription(before);
-    Assert.assertNotNull(_resourceDescription_1);
+    TestCase.assertNotNull(_resourceDescription_1);
     XtextAutoBuilderComponent _builder_1 = this.getBuilder();
     final Procedure0 _function = () -> {
       this.myFixture.renameElement(xtendFile, "Bar.xtend");
@@ -1006,10 +1006,10 @@ public class IdeaIntegrationTest extends LightXtendTest {
     _builder_1.runOperation(_function);
     ChunkedResourceDescriptions _index_2 = this.getIndex();
     IResourceDescription _resourceDescription_2 = _index_2.getResourceDescription(after);
-    Assert.assertNotNull(_resourceDescription_2);
+    TestCase.assertNotNull(_resourceDescription_2);
     ChunkedResourceDescriptions _index_3 = this.getIndex();
     IResourceDescription _resourceDescription_3 = _index_3.getResourceDescription(before);
-    Assert.assertNull(_resourceDescription_3);
+    TestCase.assertNull(_resourceDescription_3);
   }
   
   public void testRenameReference() {
@@ -1070,7 +1070,7 @@ public class IdeaIntegrationTest extends LightXtendTest {
     ChunkedResourceDescriptions _index = this.getIndex();
     URI _createURI = URI.createURI("temp:///src/otherPackage/Foo.xtend");
     IResourceDescription _resourceDescription = _index.getResourceDescription(_createURI);
-    Assert.assertNull(_resourceDescription);
+    TestCase.assertNull(_resourceDescription);
   }
   
   public void testExcludedFile() {
@@ -1102,21 +1102,21 @@ public class IdeaIntegrationTest extends LightXtendTest {
     ChunkedResourceDescriptions _index = this.getIndex();
     URI _createURI = URI.createURI("temp:///src/excluded/Foo.xtend");
     IResourceDescription _resourceDescription = _index.getResourceDescription(_createURI);
-    Assert.assertNull(_resourceDescription);
+    TestCase.assertNull(_resourceDescription);
   }
   
   public void assertFileContents(final String path, final CharSequence sequence) {
     try {
       final VirtualFile file = this.myFixture.findFileInTempDir(path);
       if ((file == null)) {
-        Assert.fail(("Expected a file for " + path));
+        TestCase.fail(("Expected a file for " + path));
       }
       String _string = sequence.toString();
       InputStream _inputStream = file.getInputStream();
       Charset _charset = file.getCharset();
       InputStreamReader _inputStreamReader = new InputStreamReader(_inputStream, _charset);
       String _string_1 = CharStreams.toString(_inputStreamReader);
-      Assert.assertEquals(_string, _string_1);
+      TestCase.assertEquals(_string, _string_1);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/completion/XtendCodeContextTypeTest.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/completion/XtendCodeContextTypeTest.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.idea.completion;
 
-import com.google.common.base.Objects;
 import com.intellij.codeInsight.template.TemplateContextType;
 import com.intellij.codeInsight.template.impl.TemplateManagerImpl;
 import com.intellij.openapi.editor.CaretModel;
@@ -256,8 +255,7 @@ public class XtendCodeContextTypeTest extends LightXtendTest {
       return Boolean.valueOf(clazz.isInstance(it));
     };
     final TemplateContextType result = IterableExtensions.<TemplateContextType>findFirst(((Iterable<TemplateContextType>)Conversions.doWrapArray(_allContextTypes)), _function);
-    boolean _equals = Objects.equal(result, null);
-    if (_equals) {
+    if ((result == null)) {
       String _name = clazz.getName();
       String _plus = ("The context type " + _name);
       String _plus_1 = (_plus + " wasn\'t registered.");

--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/structureview/AbstractOutlineTests.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/structureview/AbstractOutlineTests.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.idea.structureview;
 
-import com.google.common.base.Objects;
 import com.intellij.ide.structureView.StructureView;
 import com.intellij.ide.structureView.StructureViewBuilder;
 import com.intellij.ide.structureView.newStructureView.StructureViewComponent;
@@ -487,16 +486,13 @@ public abstract class AbstractOutlineTests extends LightToolingTest {
   public void testStructureView(final Consumer<StructureViewComponent> consumer) {
     PsiFile _file = this.myFixture.getFile();
     final VirtualFile myFile = _file.getVirtualFile();
-    boolean _notEquals = (!Objects.equal(myFile, null));
-    boolean _not = (!_notEquals);
-    if (_not) {
+    if ((!(myFile != null))) {
       throw new AssertionError("configure first");
     }
     Project _project = this.getProject();
     FileEditorManager _instance = FileEditorManager.getInstance(_project);
     final FileEditor fileEditor = _instance.getSelectedEditor(myFile);
-    boolean _equals = Objects.equal(fileEditor, null);
-    if (_equals) {
+    if ((fileEditor == null)) {
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("editor not opened for ");
       _builder.append(myFile, "");
@@ -504,8 +500,7 @@ public abstract class AbstractOutlineTests extends LightToolingTest {
     }
     PsiFile _file_1 = this.myFixture.getFile();
     final StructureViewBuilder builder = LanguageStructureViewBuilder.INSTANCE.getStructureViewBuilder(_file_1);
-    boolean _equals_1 = Objects.equal(builder, null);
-    if (_equals_1) {
+    if ((builder == null)) {
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append("no builder for ");
       _builder_1.append(myFile, "");
@@ -519,8 +514,7 @@ public abstract class AbstractOutlineTests extends LightToolingTest {
       final StructureViewComponent component = this.getStructureViewComponent(view);
       consumer.consume(component);
     } finally {
-      boolean _notEquals_1 = (!Objects.equal(view, null));
-      if (_notEquals_1) {
+      if ((view != null)) {
         Disposer.dispose(view);
       }
     }

--- a/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/completion/XtendCodeContextType.xtend
+++ b/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/completion/XtendCodeContextType.xtend
@@ -87,11 +87,11 @@ abstract class XtendCodeContextType extends TemplateContextType {
 	protected def getTokenSet(PsiFile file, int offset) {
 		val lexer = parserDefinition.createLexer(file.project)
 		lexer.start(file.text)
-		while (lexer.tokenType != null && lexer.tokenEnd <= offset)
+		while (lexer.tokenType !== null && lexer.tokenEnd <= offset)
 			lexer.advance
 
 		val tokenType = lexer.tokenType
-		if (tokenType == null)
+		if (tokenType === null)
 			return false
 
 		tokenSetProvider.getTokenSet(tokenType)

--- a/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/completion/XtendCompletionContributor.xtend
+++ b/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/completion/XtendCompletionContributor.xtend
@@ -74,7 +74,7 @@ class XtendCompletionContributor extends AbstractXtendCompletionContributor {
 		) [
 			val psiElement = $0.position
 			val clazz = psiElement.findEObject?.getContainerOfType(XtendTypeDeclaration)
-			if (clazz == null) {
+			if (clazz === null) {
 				return
 			}
 			val jvmType = jvmModelAssociations.getPrimaryJvmElement(clazz)

--- a/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/config/XtendLibraryConfigurator.xtend
+++ b/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/config/XtendLibraryConfigurator.xtend
@@ -52,7 +52,7 @@ class XtendLibraryConfigurator {
 		val module = rootModel.module
 		val scope = GlobalSearchScope.moduleWithDependenciesAndLibrariesScope(module)
 		val psiClass = JavaPsiFacade.getInstance(rootModel.project).findClass(Data.name, scope)
-		if (psiClass == null) {
+		if (psiClass === null) {
 			val testScope = isTestScope(context)
 			if (isMavenInstalled && module.isMavenizedModule) {
 				module.addXtendLibMavenDependency(testScope)
@@ -75,7 +75,7 @@ class XtendLibraryConfigurator {
 
 	def void addJavaRuntimeLibrary(Module module, ModifiableRootModel rootModel) {
 		val library = createOrGetXtendJavaLibrary(rootModel, module)
-		if (library != null && rootModel.findLibraryOrderEntry(library) === null) {
+		if (library !== null && rootModel.findLibraryOrderEntry(library) === null) {
 			if (rootModel.isWritable)
 				rootModel.addLibraryEntry(library)
 		}

--- a/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/config/XtendProjectConfigurator.xtend
+++ b/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/config/XtendProjectConfigurator.xtend
@@ -94,12 +94,12 @@ class XtendProjectConfigurator extends XtextProjectConfigurator {
 
 	def void createOutputFolders(ModifiableRootModel rootModel, XbaseGeneratorConfigurationState state) {
 		var xtendGenMain = VfsUtil.createDirectoryIfMissing(state.outputDirectory)
-		if (xtendGenMain != null) {
+		if (xtendGenMain !== null) {
 			rootModel.addAsSourceFolder(xtendGenMain, JavaSourceRootType.SOURCE)
 		}
 		if (state.outputDirectory != state.testOutputDirectory) {
 			var xtendGenTest = VfsUtil.createDirectoryIfMissing(state.testOutputDirectory)
-			if (xtendGenTest != null) {
+			if (xtendGenTest !== null) {
 				rootModel.addAsSourceFolder(xtendGenTest, JavaSourceRootType.TEST_SOURCE)
 			}
 		}

--- a/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/debug/XtendSourcePositionProvider.xtend
+++ b/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/debug/XtendSourcePositionProvider.xtend
@@ -39,14 +39,14 @@ class XtendSourcePositionProvider extends SourcePositionProvider {
 		val ele = context.contextElement
 		if (ele instanceof LeafXtextPsiElement) {
 			val eobj = ele.INode.semanticElement
-			if (eobj == null) {
+			if (eobj === null) {
 				return null;
 			}
 			val scope = scopeProvider.getScope(eobj, XbasePackage.Literals.XABSTRACT_FEATURE_CALL__FEATURE)
 			val element = scope.getSingleElement(QualifiedName.create(name))
-			if (element != null && element.EObjectOrProxy.eResource == eobj.eResource) {
+			if (element !== null && element.EObjectOrProxy.eResource == eobj.eResource) {
 				val node = NodeModelUtils.getNode(element.EObjectOrProxy)
-				if (node != null) {
+				if (node !== null) {
 					val offset = node.offset
 					return SourcePosition.createFromOffset(ele.xtextFile, offset)
 				}

--- a/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/editorActions/AutoEditMultiLineBlockInRichString.xtend
+++ b/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/editorActions/AutoEditMultiLineBlockInRichString.xtend
@@ -33,7 +33,7 @@ class AutoEditMultiLineBlockInRichString extends AutoEditMultiLineBlock {
 
 	override protected findOpeningTerminal(int offset, extension AutoEditContext context) {
 		val result = super.findOpeningTerminal(offset, context)
-		if (result == null)
+		if (result === null)
 			return null
 		val endOffset = result.offset + result.length
 		val textBetween = getText(endOffset, offset)

--- a/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/framework/XtendLibraryDescription.xtend
+++ b/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/framework/XtendLibraryDescription.xtend
@@ -40,7 +40,7 @@ class XtendLibraryDescription extends CustomLibraryDescription {
 
 	def createLibraryDescription() {
 		val provider = providers.head
-		if (provider == null) {
+		if (provider === null) {
 			return null
 		}
 		return new NewLibraryConfiguration(XTEND_LIBRARY_NAME) {

--- a/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/highlighting/XtendHighlightingLexer.xtend
+++ b/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/highlighting/XtendHighlightingLexer.xtend
@@ -88,8 +88,8 @@ class XtendHighlightingLexer extends LexerBase {
 	}
 	
 	def getCurrentRichTextToken() {
-		if(_currentRichTextToken == null) {
-			if(delegate.currentToken != null) {
+		if(_currentRichTextToken === null) {
+			if(delegate.currentToken !== null) {
 				val tokenID = tokenDefMap.get(delegate.currentToken.type)
 				if (TOKEN_TYPE_NAMES_CONTAINING_GUILLEMETS.contains(tokenID))
 					_currentRichTextToken = createRichTextToken(tokenID, delegate.tokenStart,
@@ -104,21 +104,21 @@ class XtendHighlightingLexer extends LexerBase {
 	}
 
 	override getTokenEnd() {
-		if (currentRichTextToken != null)
+		if (currentRichTextToken !== null)
 			currentRichTextToken.tokenOffset + currentRichTextToken.tokenLength
 		else
 			delegate.tokenEnd
 	}
 
 	override getTokenStart() {
-		if (currentRichTextToken != null)
+		if (currentRichTextToken !== null)
 			currentRichTextToken.tokenOffset
 		else
 			delegate.tokenStart
 	}
 
 	override getTokenType() {
-		if (currentRichTextToken != null)
+		if (currentRichTextToken !== null)
 			currentRichTextToken.getTokenType
 		else
 			delegate.tokenType

--- a/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/intentions/XtendIntentionsProvider.xtend
+++ b/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/intentions/XtendIntentionsProvider.xtend
@@ -112,13 +112,13 @@ class XtendIntentionsProvider extends IdeaIntentionsProvider {
 
 		def findInsertionOffSet(XtendTypeDeclaration class1, Editor editor) {
 			val last = class1.members.last
-			if (last != null) {
+			if (last !== null) {
 				val n = NodeModelUtils.getNode(last)
 				return n.totalOffset + n.totalLength
 			} else {
 				val n = NodeModelUtils.getNode(class1)
 				val openingBracket = n.asTreeIterable.findFirst[it.text == '{']
-				if (openingBracket != null) {
+				if (openingBracket !== null) {
 					return openingBracket.offset + 1
 				}
 			}

--- a/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/macro/IdeaFileSystemSupport.xtend
+++ b/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/macro/IdeaFileSystemSupport.xtend
@@ -16,7 +16,7 @@ class IdeaFileSystemSupport extends AbstractFileSystemSupport {
 	
 	override getChildren(URI uri, Path path) {
 		val handler = VirtualFileBasedUriHandler.find(context)
-		if (handler == null)
+		if (handler === null)
 			return emptyList
 
 		return handler.getChildren(uri).map[getPath(uri, path)].filterNull

--- a/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/presentation/XtendItemPresentationProvider.xtend
+++ b/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/presentation/XtendItemPresentationProvider.xtend
@@ -87,10 +87,10 @@ class XtendItemPresentationProvider extends XtendJvmItemPresentationProvider {
 
 	def dispatch text(XtendFunction element) {
 		val simpleName = element.name
-		if (simpleName != null) {
+		if (simpleName !== null) {
 			val qnName = QualifiedName.create(simpleName)
 			val operator = operatorMapping.getOperator(qnName)
-			if (operator != null) {
+			if (operator !== null) {
 				return signature(operator.firstSegment, element.directlyInferredOperation) + ' (' + simpleName + ')'
 			}
 		}
@@ -98,10 +98,10 @@ class XtendItemPresentationProvider extends XtendJvmItemPresentationProvider {
 	}
 
 	def dispatch text(XtendField element) {
-		if (element.name == null && element.extension)
+		if (element.name === null && element.extension)
 			return uiStrings.referenceToString(element.type, "extension")
 		val fieldType = element.displayedType
-		if (fieldType != null) {
+		if (fieldType !== null) {
 			val type = uiStrings.referenceToString(fieldType, "")
 			if (type.length != 0) {
 				return element.name + " : " + type
@@ -120,7 +120,7 @@ class XtendItemPresentationProvider extends XtendJvmItemPresentationProvider {
 
 	protected def JvmTypeReference getDisplayedType(XtendField field) {
 		val jvmField = field.jvmField
-		if (jvmField != null) {
+		if (jvmField !== null) {
 			return jvmField.getType
 		} else {
 			val i = field.jvmElements.iterator

--- a/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/structureview/XtendStructureViewTreeElementProvider.xtend
+++ b/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/structureview/XtendStructureViewTreeElementProvider.xtend
@@ -78,7 +78,7 @@ class XtendStructureViewTreeElementProvider extends DefaultStructureViewTreeElem
 	}
 
 	protected def isShowInherited() {
-		if (treeActionsOwner == null) {
+		if (treeActionsOwner === null) {
 			return false
 		}
 		treeActionsOwner.isActionActive(XtendShowInheritedNodeProvider.ID)

--- a/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/validation/XtendIdeaValidator.xtend
+++ b/org.eclipse.xtend.idea/src/org/eclipse/xtend/core/idea/validation/XtendIdeaValidator.xtend
@@ -70,7 +70,7 @@ class XtendIdeaValidator extends AbstractDeclarativeValidator {
 		ApplicationManager.application.<Boolean>runReadAction[
 			val module = annotation.module
 			val psiFacade = JavaPsiFacade.getInstance(module.project)
-			return psiFacade.findClass(annotationType.qualifiedName, module.moduleScope) != null
+			return psiFacade.findClass(annotationType.qualifiedName, module.moduleScope) !== null
 		]
 	}
 	
@@ -81,11 +81,11 @@ class XtendIdeaValidator extends AbstractDeclarativeValidator {
 	@Check
 	def void checkFileNameConventions(XtendFile xtendFile) {
 		var expectedPackage = xtendFile.expectedPackageName
-		if (expectedPackage == null) {
+		if (expectedPackage === null) {
 			return
 		}
 		var declaredPackage = xtendFile.package
-		if (expectedPackage.empty && declaredPackage == null) {
+		if (expectedPackage.empty && declaredPackage === null) {
 			return
 		}
 		if (expectedPackage == declaredPackage) {

--- a/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/completion/XtendCodeContextType.java
+++ b/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/completion/XtendCodeContextType.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.idea.completion;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.intellij.codeInsight.template.EverywhereContextType;
 import com.intellij.codeInsight.template.TemplateContextType;
@@ -189,12 +188,11 @@ public abstract class XtendCodeContextType extends TemplateContextType {
       final Lexer lexer = this.parserDefinition.createLexer(_project);
       String _text = file.getText();
       lexer.start(_text);
-      while (((!Objects.equal(lexer.getTokenType(), null)) && (lexer.getTokenEnd() <= offset))) {
+      while (((lexer.getTokenType() != null) && (lexer.getTokenEnd() <= offset))) {
         lexer.advance();
       }
       final IElementType tokenType = lexer.getTokenType();
-      boolean _equals = Objects.equal(tokenType, null);
-      if (_equals) {
+      if ((tokenType == null)) {
         return Boolean.valueOf(false);
       }
       _xblockexpression = this.tokenSetProvider.getTokenSet(tokenType);

--- a/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/completion/XtendCompletionContributor.java
+++ b/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/completion/XtendCompletionContributor.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.idea.completion;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.intellij.codeInsight.completion.CompletionParameters;
 import com.intellij.codeInsight.completion.CompletionProvider;
@@ -132,8 +131,7 @@ public class XtendCompletionContributor extends AbstractXtendCompletionContribut
           _containerOfType=EcoreUtil2.<XtendTypeDeclaration>getContainerOfType(_findEObject, XtendTypeDeclaration.class);
         }
         final XtendTypeDeclaration clazz = _containerOfType;
-        boolean _equals = Objects.equal(clazz, null);
-        if (_equals) {
+        if ((clazz == null)) {
           return;
         }
         final EObject jvmType = XtendCompletionContributor.this.jvmModelAssociations.getPrimaryJvmElement(clazz);

--- a/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/config/XtendLibraryConfigurator.java
+++ b/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/config/XtendLibraryConfigurator.java
@@ -91,8 +91,7 @@ public class XtendLibraryConfigurator {
     JavaPsiFacade _instance = JavaPsiFacade.getInstance(_project);
     String _name = Data.class.getName();
     final PsiClass psiClass = _instance.findClass(_name, scope);
-    boolean _equals = Objects.equal(psiClass, null);
-    if (_equals) {
+    if ((psiClass == null)) {
       final boolean testScope = this.isTestScope(context);
       if ((this._platformUtil.isMavenInstalled() && this._mavenUtility.isMavenizedModule(module))) {
         this._mavenUtility.addXtendLibMavenDependency(module, testScope);
@@ -119,7 +118,7 @@ public class XtendLibraryConfigurator {
   
   public void addJavaRuntimeLibrary(final Module module, final ModifiableRootModel rootModel) {
     final Library library = this.createOrGetXtendJavaLibrary(rootModel, module);
-    if (((!Objects.equal(library, null)) && (rootModel.findLibraryOrderEntry(library) == null))) {
+    if (((library != null) && (rootModel.findLibraryOrderEntry(library) == null))) {
       boolean _isWritable = rootModel.isWritable();
       if (_isWritable) {
         rootModel.addLibraryEntry(library);

--- a/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/config/XtendProjectConfigurator.java
+++ b/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/config/XtendProjectConfigurator.java
@@ -191,18 +191,16 @@ public class XtendProjectConfigurator extends XtextProjectConfigurator {
     try {
       String _outputDirectory = state.getOutputDirectory();
       VirtualFile xtendGenMain = VfsUtil.createDirectoryIfMissing(_outputDirectory);
-      boolean _notEquals = (!Objects.equal(xtendGenMain, null));
-      if (_notEquals) {
+      if ((xtendGenMain != null)) {
         this.addAsSourceFolder(rootModel, xtendGenMain, JavaSourceRootType.SOURCE);
       }
       String _outputDirectory_1 = state.getOutputDirectory();
       String _testOutputDirectory = state.getTestOutputDirectory();
-      boolean _notEquals_1 = (!Objects.equal(_outputDirectory_1, _testOutputDirectory));
-      if (_notEquals_1) {
+      boolean _notEquals = (!Objects.equal(_outputDirectory_1, _testOutputDirectory));
+      if (_notEquals) {
         String _testOutputDirectory_1 = state.getTestOutputDirectory();
         VirtualFile xtendGenTest = VfsUtil.createDirectoryIfMissing(_testOutputDirectory_1);
-        boolean _notEquals_2 = (!Objects.equal(xtendGenTest, null));
-        if (_notEquals_2) {
+        if ((xtendGenTest != null)) {
           this.addAsSourceFolder(rootModel, xtendGenTest, JavaSourceRootType.TEST_SOURCE);
         }
       }

--- a/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/debug/XtendSourcePositionProvider.java
+++ b/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/debug/XtendSourcePositionProvider.java
@@ -51,18 +51,16 @@ public class XtendSourcePositionProvider extends SourcePositionProvider {
     if ((ele instanceof LeafXtextPsiElement)) {
       INode _iNode = ((LeafXtextPsiElement)ele).getINode();
       final EObject eobj = _iNode.getSemanticElement();
-      boolean _equals = Objects.equal(eobj, null);
-      if (_equals) {
+      if ((eobj == null)) {
         return null;
       }
       final IScope scope = this.scopeProvider.getScope(eobj, XbasePackage.Literals.XABSTRACT_FEATURE_CALL__FEATURE);
       QualifiedName _create = QualifiedName.create(name);
       final IEObjectDescription element = scope.getSingleElement(_create);
-      if (((!Objects.equal(element, null)) && Objects.equal(element.getEObjectOrProxy().eResource(), eobj.eResource()))) {
+      if (((element != null) && Objects.equal(element.getEObjectOrProxy().eResource(), eobj.eResource()))) {
         EObject _eObjectOrProxy = element.getEObjectOrProxy();
         final ICompositeNode node = NodeModelUtils.getNode(_eObjectOrProxy);
-        boolean _notEquals = (!Objects.equal(node, null));
-        if (_notEquals) {
+        if ((node != null)) {
           final int offset = node.getOffset();
           BaseXtextFile _xtextFile = ((LeafXtextPsiElement)ele).getXtextFile();
           return SourcePosition.createFromOffset(_xtextFile, offset);

--- a/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/editorActions/AutoEditMultiLineBlockInRichString.java
+++ b/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/editorActions/AutoEditMultiLineBlockInRichString.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.idea.editorActions;
 
-import com.google.common.base.Objects;
 import org.eclipse.xtext.idea.editorActions.AutoEditContext;
 import org.eclipse.xtext.idea.editorActions.AutoEditMultiLineBlock;
 import org.eclipse.xtext.util.TextRegion;
@@ -37,8 +36,7 @@ public class AutoEditMultiLineBlockInRichString extends AutoEditMultiLineBlock {
   @Override
   protected TextRegion findOpeningTerminal(final int offset, @Extension final AutoEditContext context) {
     final TextRegion result = super.findOpeningTerminal(offset, context);
-    boolean _equals = Objects.equal(result, null);
-    if (_equals) {
+    if ((result == null)) {
       return null;
     }
     int _offset = result.getOffset();

--- a/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/framework/XtendLibraryDescription.java
+++ b/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/framework/XtendLibraryDescription.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.idea.framework;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import com.intellij.openapi.roots.OrderRootType;
 import com.intellij.openapi.roots.libraries.LibraryKind;
@@ -67,8 +66,7 @@ public class XtendLibraryDescription extends CustomLibraryDescription {
     
     List<XtendLibraryPresentationProvider> _providers = XtendLibraryDescription.getProviders();
     final XtendLibraryPresentationProvider provider = IterableExtensions.<XtendLibraryPresentationProvider>head(_providers);
-    boolean _equals = Objects.equal(provider, null);
-    if (_equals) {
+    if ((provider == null)) {
       return null;
     }
     return new __XtendLibraryDescription_1(XtendLibraryDescription.XTEND_LIBRARY_NAME) {

--- a/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/highlighting/XtendHighlightingLexer.java
+++ b/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/highlighting/XtendHighlightingLexer.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.idea.highlighting;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.intellij.lexer.LexerBase;
 import com.intellij.lexer.LexerPosition;
@@ -116,11 +115,10 @@ public class XtendHighlightingLexer extends LexerBase {
   }
   
   public XtendHighlightingLexer.RichTextToken getCurrentRichTextToken() {
-    boolean _equals = Objects.equal(this._currentRichTextToken, null);
-    if (_equals) {
+    if ((this._currentRichTextToken == null)) {
       CommonToken _currentToken = this.delegate.getCurrentToken();
-      boolean _notEquals = (!Objects.equal(_currentToken, null));
-      if (_notEquals) {
+      boolean _tripleNotEquals = (_currentToken != null);
+      if (_tripleNotEquals) {
         Map<Integer, String> _tokenDefMap = this._antlrTokenDefProvider.getTokenDefMap();
         CommonToken _currentToken_1 = this.delegate.getCurrentToken();
         int _type = _currentToken_1.getType();
@@ -155,8 +153,8 @@ public class XtendHighlightingLexer extends LexerBase {
   public int getTokenEnd() {
     int _xifexpression = (int) 0;
     XtendHighlightingLexer.RichTextToken _currentRichTextToken = this.getCurrentRichTextToken();
-    boolean _notEquals = (!Objects.equal(_currentRichTextToken, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_currentRichTextToken != null);
+    if (_tripleNotEquals) {
       XtendHighlightingLexer.RichTextToken _currentRichTextToken_1 = this.getCurrentRichTextToken();
       int _tokenOffset = _currentRichTextToken_1.getTokenOffset();
       XtendHighlightingLexer.RichTextToken _currentRichTextToken_2 = this.getCurrentRichTextToken();
@@ -172,8 +170,8 @@ public class XtendHighlightingLexer extends LexerBase {
   public int getTokenStart() {
     int _xifexpression = (int) 0;
     XtendHighlightingLexer.RichTextToken _currentRichTextToken = this.getCurrentRichTextToken();
-    boolean _notEquals = (!Objects.equal(_currentRichTextToken, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_currentRichTextToken != null);
+    if (_tripleNotEquals) {
       XtendHighlightingLexer.RichTextToken _currentRichTextToken_1 = this.getCurrentRichTextToken();
       _xifexpression = _currentRichTextToken_1.getTokenOffset();
     } else {
@@ -186,8 +184,8 @@ public class XtendHighlightingLexer extends LexerBase {
   public IElementType getTokenType() {
     IElementType _xifexpression = null;
     XtendHighlightingLexer.RichTextToken _currentRichTextToken = this.getCurrentRichTextToken();
-    boolean _notEquals = (!Objects.equal(_currentRichTextToken, null));
-    if (_notEquals) {
+    boolean _tripleNotEquals = (_currentRichTextToken != null);
+    if (_tripleNotEquals) {
       XtendHighlightingLexer.RichTextToken _currentRichTextToken_1 = this.getCurrentRichTextToken();
       _xifexpression = _currentRichTextToken_1.getTokenType();
     } else {

--- a/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/intentions/XtendIntentionsProvider.java
+++ b/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/intentions/XtendIntentionsProvider.java
@@ -156,8 +156,7 @@ public class XtendIntentionsProvider extends IdeaIntentionsProvider {
     public int findInsertionOffSet(final XtendTypeDeclaration class1, final Editor editor) {
       EList<XtendMember> _members = class1.getMembers();
       final XtendMember last = IterableExtensions.<XtendMember>last(_members);
-      boolean _notEquals = (!Objects.equal(last, null));
-      if (_notEquals) {
+      if ((last != null)) {
         final ICompositeNode n = NodeModelUtils.getNode(last);
         int _totalOffset = n.getTotalOffset();
         int _totalLength = n.getTotalLength();
@@ -170,8 +169,7 @@ public class XtendIntentionsProvider extends IdeaIntentionsProvider {
           return Boolean.valueOf(Objects.equal(_text, "{"));
         };
         final INode openingBracket = IterableExtensions.<INode>findFirst(_asTreeIterable, _function);
-        boolean _notEquals_1 = (!Objects.equal(openingBracket, null));
-        if (_notEquals_1) {
+        if ((openingBracket != null)) {
           int _offset = openingBracket.getOffset();
           return (_offset + 1);
         }

--- a/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/macro/IdeaFileSystemSupport.java
+++ b/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/macro/IdeaFileSystemSupport.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.idea.macro;
 
-import com.google.common.base.Objects;
 import java.util.Set;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.ResourceSet;
@@ -24,8 +23,7 @@ public class IdeaFileSystemSupport extends AbstractFileSystemSupport {
   public Iterable<? extends Path> getChildren(final URI uri, final Path path) {
     ResourceSet _context = this.getContext();
     final IdeaResourceSetProvider.VirtualFileBasedUriHandler handler = IdeaResourceSetProvider.VirtualFileBasedUriHandler.find(_context);
-    boolean _equals = Objects.equal(handler, null);
-    if (_equals) {
+    if ((handler == null)) {
       return CollectionLiterals.<Path>emptyList();
     }
     Set<URI> _children = handler.getChildren(uri);

--- a/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/presentation/XtendItemPresentationProvider.java
+++ b/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/presentation/XtendItemPresentationProvider.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.idea.presentation;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.intellij.psi.PsiElement;
 import java.util.Arrays;
@@ -138,12 +137,10 @@ public class XtendItemPresentationProvider extends XtendJvmItemPresentationProvi
   
   protected String _text(final XtendFunction element) {
     final String simpleName = element.getName();
-    boolean _notEquals = (!Objects.equal(simpleName, null));
-    if (_notEquals) {
+    if ((simpleName != null)) {
       final QualifiedName qnName = QualifiedName.create(simpleName);
       final QualifiedName operator = this.operatorMapping.getOperator(qnName);
-      boolean _notEquals_1 = (!Objects.equal(operator, null));
-      if (_notEquals_1) {
+      if ((operator != null)) {
         String _firstSegment = operator.getFirstSegment();
         JvmOperation _directlyInferredOperation = this._iXtendJvmAssociations.getDirectlyInferredOperation(element);
         String _signature = this.signature(_firstSegment, _directlyInferredOperation);
@@ -160,17 +157,16 @@ public class XtendItemPresentationProvider extends XtendJvmItemPresentationProvi
   protected String _text(final XtendField element) {
     String _xblockexpression = null;
     {
-      if ((Objects.equal(element.getName(), null) && element.isExtension())) {
+      if (((element.getName() == null) && element.isExtension())) {
         JvmTypeReference _type = element.getType();
         return this.uiStrings.referenceToString(_type, "extension");
       }
       final JvmTypeReference fieldType = this.getDisplayedType(element);
-      boolean _notEquals = (!Objects.equal(fieldType, null));
-      if (_notEquals) {
+      if ((fieldType != null)) {
         final String type = this.uiStrings.referenceToString(fieldType, "");
         int _length = type.length();
-        boolean _notEquals_1 = (_length != 0);
-        if (_notEquals_1) {
+        boolean _notEquals = (_length != 0);
+        if (_notEquals) {
           String _name = element.getName();
           String _plus = (_name + " : ");
           return (_plus + type);
@@ -197,8 +193,7 @@ public class XtendItemPresentationProvider extends XtendJvmItemPresentationProvi
     Object _xblockexpression = null;
     {
       final JvmField jvmField = this._iXtendJvmAssociations.getJvmField(field);
-      boolean _notEquals = (!Objects.equal(jvmField, null));
-      if (_notEquals) {
+      if ((jvmField != null)) {
         return jvmField.getType();
       } else {
         Set<EObject> _jvmElements = this._iXtendJvmAssociations.getJvmElements(field);

--- a/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/structureview/XtendStructureViewTreeElementProvider.java
+++ b/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/structureview/XtendStructureViewTreeElementProvider.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.xtend.core.idea.structureview;
 
-import com.google.common.base.Objects;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.intellij.icons.AllIcons;
@@ -109,8 +108,7 @@ public class XtendStructureViewTreeElementProvider extends DefaultStructureViewT
   protected boolean isShowInherited() {
     boolean _xblockexpression = false;
     {
-      boolean _equals = Objects.equal(this.treeActionsOwner, null);
-      if (_equals) {
+      if ((this.treeActionsOwner == null)) {
         return false;
       }
       _xblockexpression = this.treeActionsOwner.isActionActive(XtendShowInheritedNodeProvider.ID);

--- a/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/validation/XtendIdeaValidator.java
+++ b/org.eclipse.xtend.idea/xtend-gen/org/eclipse/xtend/core/idea/validation/XtendIdeaValidator.java
@@ -88,7 +88,7 @@ public class XtendIdeaValidator extends AbstractDeclarativeValidator {
       String _qualifiedName = annotationType.getQualifiedName();
       GlobalSearchScope _moduleScope = module.getModuleScope();
       PsiClass _findClass = psiFacade.findClass(_qualifiedName, _moduleScope);
-      return Boolean.valueOf((!Objects.equal(_findClass, null)));
+      return Boolean.valueOf((_findClass != null));
     };
     return (_application.<Boolean>runReadAction(_function)).booleanValue();
   }
@@ -102,16 +102,15 @@ public class XtendIdeaValidator extends AbstractDeclarativeValidator {
   @Check
   public void checkFileNameConventions(final XtendFile xtendFile) {
     String expectedPackage = this.getExpectedPackageName(xtendFile);
-    boolean _equals = Objects.equal(expectedPackage, null);
-    if (_equals) {
+    if ((expectedPackage == null)) {
       return;
     }
     String declaredPackage = xtendFile.getPackage();
-    if ((expectedPackage.isEmpty() && Objects.equal(declaredPackage, null))) {
+    if ((expectedPackage.isEmpty() && (declaredPackage == null))) {
       return;
     }
-    boolean _equals_1 = Objects.equal(expectedPackage, declaredPackage);
-    if (_equals_1) {
+    boolean _equals = Objects.equal(expectedPackage, declaredPackage);
+    if (_equals) {
       return;
     }
     StringConcatenation _builder = new StringConcatenation();


### PR DESCRIPTION
For comparison with null the triple (not) equal operator should be used. 
Resolved compiler warnings
Regenerated xtend-gen

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>