### PR TITLE
References on j.f.Assert replaced by j.f.TestCase

### DIFF
--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/autobuild/MultiModuleTest.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/autobuild/MultiModuleTest.java
@@ -35,7 +35,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Collections;
 import java.util.List;
-import junit.framework.Assert;
+import junit.framework.TestCase;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtend.core.idea.facet.XtendFacetConfiguration;
 import org.eclipse.xtend.core.idea.lang.XtendLanguage;
@@ -107,13 +107,13 @@ public class MultiModuleTest extends PsiTestCase {
         _findChild_3=_findChild_2.findChild("MyClass.java");
       }
       final VirtualFile generatedReferenced = _findChild_3;
-      Assert.assertNotNull(generatedReferencing);
-      Assert.assertNotNull(generatedReferenced);
+      TestCase.assertNotNull(generatedReferencing);
+      TestCase.assertNotNull(generatedReferenced);
       VirtualFile _virtualFile_2 = referenced.getVirtualFile();
       VirtualFile _parent_2 = _virtualFile_2.getParent();
       VirtualFile _findChild_4 = _parent_2.findChild("xtend-gen");
       VirtualFile _findChild_5 = _findChild_4.findChild("OtherClass.java");
-      Assert.assertNull(_findChild_5);
+      TestCase.assertNull(_findChild_5);
       StringConcatenation _builder_2 = new StringConcatenation();
       _builder_2.append("public class OtherClass extends MyClass {");
       _builder_2.newLine();
@@ -166,14 +166,14 @@ public class MultiModuleTest extends PsiTestCase {
       };
       final Provider<VirtualFile> generatedReferenced = _function_1;
       VirtualFile _get = generatedReferencing.get();
-      Assert.assertNotNull(_get);
+      TestCase.assertNotNull(_get);
       VirtualFile _get_1 = generatedReferenced.get();
-      Assert.assertNotNull(_get_1);
+      TestCase.assertNotNull(_get_1);
       VirtualFile _virtualFile = referenced.getVirtualFile();
       VirtualFile _parent = _virtualFile.getParent();
       VirtualFile _findChild = _parent.findChild("xtend-gen");
       VirtualFile _findChild_1 = _findChild.findChild("OtherClass.java");
-      Assert.assertNull(_findChild_1);
+      TestCase.assertNull(_findChild_1);
       VirtualFile _get_2 = generatedReferencing.get();
       StringConcatenation _builder_2 = new StringConcatenation();
       _builder_2.append("public class OtherClass /* implements MyClass  */{");
@@ -253,8 +253,8 @@ public class MultiModuleTest extends PsiTestCase {
         _findChild_3=_findChild_2.findChild("MyClass.java");
       }
       final VirtualFile generatedReferenced = _findChild_3;
-      Assert.assertNotNull(generatedReferencing);
-      Assert.assertNotNull(generatedReferenced);
+      TestCase.assertNotNull(generatedReferencing);
+      TestCase.assertNotNull(generatedReferenced);
       Application _application = ApplicationManager.getApplication();
       final Runnable _function = () -> {
         ModuleRootManager _instance = ModuleRootManager.getInstance(moduleA);
@@ -276,7 +276,7 @@ public class MultiModuleTest extends PsiTestCase {
         return Boolean.valueOf(_fileString.endsWith("OtherClass.xtend"));
       };
       boolean _exists = IterableExtensions.<IResourceDescription>exists(_allResourceDescriptions, _function_1);
-      Assert.assertTrue(_exists);
+      TestCase.assertTrue(_exists);
       ChunkedResourceDescriptions _index_1 = this.getIndex();
       Iterable<IResourceDescription> _allResourceDescriptions_1 = _index_1.getAllResourceDescriptions();
       final Function1<IResourceDescription, Boolean> _function_2 = (IResourceDescription it) -> {
@@ -285,7 +285,7 @@ public class MultiModuleTest extends PsiTestCase {
         return Boolean.valueOf(_fileString.endsWith("MyClass.xtend"));
       };
       boolean _exists_1 = IterableExtensions.<IResourceDescription>exists(_allResourceDescriptions_1, _function_2);
-      Assert.assertFalse("Deleted module file removed from index", _exists_1);
+      TestCase.assertFalse("Deleted module file removed from index", _exists_1);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -351,16 +351,16 @@ public class MultiModuleTest extends PsiTestCase {
         _findChild_3=_findChild_2.findChild("ClassB.java");
       }
       final VirtualFile generatedB = _findChild_3;
-      Assert.assertNotNull(generatedA);
-      Assert.assertNotNull(generatedB);
+      TestCase.assertNotNull(generatedA);
+      TestCase.assertNotNull(generatedB);
       InputStream _inputStream = generatedA.getInputStream();
       final String aString = Files.readStreamIntoString(_inputStream);
       boolean _contains = aString.contains("->");
-      Assert.assertFalse(aString, _contains);
+      TestCase.assertFalse(aString, _contains);
       InputStream _inputStream_1 = generatedB.getInputStream();
       final String bString = Files.readStreamIntoString(_inputStream_1);
       boolean _contains_1 = bString.contains("->");
-      Assert.assertTrue(bString, _contains_1);
+      TestCase.assertTrue(bString, _contains_1);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -371,7 +371,7 @@ public class MultiModuleTest extends PsiTestCase {
       InputStream _inputStream = file.getInputStream();
       InputStreamReader _inputStreamReader = new InputStreamReader(_inputStream);
       final String result = CharStreams.toString(_inputStreamReader);
-      Assert.assertEquals(string, result);
+      TestCase.assertEquals(string, result);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/completion/XtendCodeContextTypeTest.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/completion/XtendCodeContextTypeTest.java
@@ -12,7 +12,7 @@ import com.intellij.codeInsight.template.impl.TemplateManagerImpl;
 import com.intellij.openapi.editor.CaretModel;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.psi.PsiFile;
-import junit.framework.Assert;
+import junit.framework.TestCase;
 import org.eclipse.xtend.core.idea.completion.XtendCodeContextType;
 import org.eclipse.xtend.idea.LightXtendTest;
 import org.eclipse.xtend.lib.annotations.Data;
@@ -234,7 +234,7 @@ public class XtendCodeContextTypeTest extends LightXtendTest {
       CaretModel _caretModel = _editor.getCaretModel();
       int _offset = _caretModel.getOffset();
       boolean _isInContext = type.contextType.isInContext(file, _offset);
-      Assert.assertEquals(_builder.toString(), 
+      TestCase.assertEquals(_builder.toString(), 
         type.shouldMatch, _isInContext);
     }
   }

--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/completion/XtendCompletionTest.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/completion/XtendCompletionTest.java
@@ -14,7 +14,7 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.SelectionModel;
 import java.util.List;
-import junit.framework.Assert;
+import junit.framework.TestCase;
 import org.eclipse.xtend.idea.LightXtendTest;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
@@ -49,7 +49,7 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("ArrayList");
-    Assert.assertTrue(_string, _contains);
+    TestCase.assertTrue(_string, _contains);
   }
   
   public void testTypeReferenceNoTypeArgs_Type() {
@@ -66,7 +66,7 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string_1 = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("ArrayList");
-    Assert.assertTrue(_string_1, _contains);
+    TestCase.assertTrue(_string_1, _contains);
   }
   
   public void testJvmParameterizedTypeReference_Type_03() {
@@ -96,7 +96,7 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string_1 = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("ArrayList");
-    Assert.assertTrue(_string_1, _contains);
+    TestCase.assertTrue(_string_1, _contains);
   }
   
   public void testXImportDeclaration_ImportedType() {
@@ -104,7 +104,7 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("ArrayList");
-    Assert.assertTrue(_string, _contains);
+    TestCase.assertTrue(_string, _contains);
   }
   
   public void testXImportDeclaration_ImportedType_02() {
@@ -112,7 +112,7 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("ArrayList");
-    Assert.assertTrue(_string, _contains);
+    TestCase.assertTrue(_string, _contains);
   }
   
   public void testAppliedXImportDeclaration() {
@@ -122,7 +122,7 @@ public class XtendCompletionTest extends LightXtendTest {
     Document _document = _editor.getDocument();
     String _text = _document.getText();
     String _string = _text.toString();
-    Assert.assertEquals("import java.util.ArrayList", _string);
+    TestCase.assertEquals("import java.util.ArrayList", _string);
   }
   
   public void testAppliedXImportDeclaration_01() {
@@ -132,7 +132,7 @@ public class XtendCompletionTest extends LightXtendTest {
     Document _document = _editor.getDocument();
     String _text = _document.getText();
     String _string = _text.toString();
-    Assert.assertEquals("import java.util.ArrayList", _string);
+    TestCase.assertEquals("import java.util.ArrayList", _string);
   }
   
   public void testAppliedTypeReferenceImportsType_01() {
@@ -161,7 +161,7 @@ public class XtendCompletionTest extends LightXtendTest {
     Document _document = _editor.getDocument();
     String _text = _document.getText();
     String _string_2 = _text.toString();
-    Assert.assertEquals(_string_1, _string_2);
+    TestCase.assertEquals(_string_1, _string_2);
   }
   
   public void testAppliedTypeReferenceImportsType_02() {
@@ -193,7 +193,7 @@ public class XtendCompletionTest extends LightXtendTest {
     Document _document = _editor.getDocument();
     String _text = _document.getText();
     String _string_2 = _text.toString();
-    Assert.assertEquals(_string_1, _string_2);
+    TestCase.assertEquals(_string_1, _string_2);
   }
   
   public void testAppliedTypeReferenceImportsType_03() {
@@ -223,7 +223,7 @@ public class XtendCompletionTest extends LightXtendTest {
     Document _document = _editor.getDocument();
     String _text = _document.getText();
     String _string_2 = _text.toString();
-    Assert.assertEquals(_string_1, _string_2);
+    TestCase.assertEquals(_string_1, _string_2);
   }
   
   public void testAppliedTypeReferenceImportsType_04() {
@@ -254,7 +254,7 @@ public class XtendCompletionTest extends LightXtendTest {
     Document _document = _editor.getDocument();
     String _text = _document.getText();
     String _string_2 = _text.toString();
-    Assert.assertEquals(_string_1, _string_2);
+    TestCase.assertEquals(_string_1, _string_2);
   }
   
   public void testAppliedTypeReferenceImportsType_05() {
@@ -291,7 +291,7 @@ public class XtendCompletionTest extends LightXtendTest {
     Document _document = _editor.getDocument();
     String _text = _document.getText();
     String _string_2 = _text.toString();
-    Assert.assertEquals(_string_1, _string_2);
+    TestCase.assertEquals(_string_1, _string_2);
   }
   
   public void testAppliedTypeReferenceImportsType_06() {
@@ -334,7 +334,7 @@ public class XtendCompletionTest extends LightXtendTest {
     Document _document = _editor.getDocument();
     String _text = _document.getText();
     String _string_2 = _text.toString();
-    Assert.assertEquals(_string_1, _string_2);
+    TestCase.assertEquals(_string_1, _string_2);
   }
   
   public void testXConstructorCall_Constructor() {
@@ -366,16 +366,16 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string_1 = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("ArrayList");
-    Assert.assertTrue(_string_1, _contains);
+    TestCase.assertTrue(_string_1, _contains);
     String _string_2 = lookupElementStrings.toString();
     boolean _contains_1 = lookupElementStrings.contains("Bar");
-    Assert.assertTrue(_string_2, _contains_1);
+    TestCase.assertTrue(_string_2, _contains_1);
     String _string_3 = lookupElementStrings.toString();
     boolean _contains_2 = lookupElementStrings.contains("AbstractBar");
-    Assert.assertFalse(_string_3, _contains_2);
+    TestCase.assertFalse(_string_3, _contains_2);
     String _string_4 = lookupElementStrings.toString();
     boolean _contains_3 = lookupElementStrings.contains("InterfaceBar");
-    Assert.assertFalse(_string_4, _contains_3);
+    TestCase.assertFalse(_string_4, _contains_3);
   }
   
   public void testXTypeLiteral_Type() {
@@ -398,10 +398,10 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string_1 = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("ArrayList");
-    Assert.assertTrue(_string_1, _contains);
+    TestCase.assertTrue(_string_1, _contains);
     String _string_2 = lookupElementStrings.toString();
     boolean _contains_1 = lookupElementStrings.contains("Foo");
-    Assert.assertTrue(_string_2, _contains_1);
+    TestCase.assertTrue(_string_2, _contains_1);
   }
   
   public void testXAnnotation_AnnotationType() {
@@ -417,7 +417,7 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string_1 = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("Deprecated");
-    Assert.assertTrue(_string_1, _contains);
+    TestCase.assertTrue(_string_1, _contains);
   }
   
   public void testXAnnotation_AnnotationType_02() {
@@ -433,7 +433,7 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string_1 = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("ArrayList");
-    Assert.assertFalse(_string_1, _contains);
+    TestCase.assertFalse(_string_1, _contains);
   }
   
   public void testXAnnotation_Value() {
@@ -449,7 +449,7 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string_1 = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("ArrayList");
-    Assert.assertTrue(_string_1, _contains);
+    TestCase.assertTrue(_string_1, _contains);
   }
   
   public void testOverrideCompletion_01() {
@@ -466,19 +466,19 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string_1 = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("override equals(Object)");
-    Assert.assertTrue(_string_1, _contains);
+    TestCase.assertTrue(_string_1, _contains);
     String _string_2 = lookupElementStrings.toString();
     boolean _contains_1 = lookupElementStrings.contains("override hashCode()");
-    Assert.assertTrue(_string_2, _contains_1);
+    TestCase.assertTrue(_string_2, _contains_1);
     String _string_3 = lookupElementStrings.toString();
     boolean _contains_2 = lookupElementStrings.contains("override toString()");
-    Assert.assertTrue(_string_3, _contains_2);
+    TestCase.assertTrue(_string_3, _contains_2);
     String _string_4 = lookupElementStrings.toString();
     boolean _contains_3 = lookupElementStrings.contains("override clone()");
-    Assert.assertTrue(_string_4, _contains_3);
+    TestCase.assertTrue(_string_4, _contains_3);
     String _string_5 = lookupElementStrings.toString();
     boolean _contains_4 = lookupElementStrings.contains("override finalize()");
-    Assert.assertTrue(_string_5, _contains_4);
+    TestCase.assertTrue(_string_5, _contains_4);
   }
   
   public void testOverrideCompletion_02() {
@@ -504,7 +504,7 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string_1 = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("override toString()");
-    Assert.assertFalse(_string_1, _contains);
+    TestCase.assertFalse(_string_1, _contains);
   }
   
   public void testOverrideCompletion_03() {
@@ -530,7 +530,7 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string_1 = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("override equals(Object)");
-    Assert.assertTrue(_string_1, _contains);
+    TestCase.assertTrue(_string_1, _contains);
   }
   
   public void testOverrideCompletion_04() {
@@ -568,11 +568,11 @@ public class XtendCompletionTest extends LightXtendTest {
     Document _document = _editor.getDocument();
     String _text = _document.getText();
     String _string_2 = _text.toString();
-    Assert.assertEquals(_string_1, _string_2);
+    TestCase.assertEquals(_string_1, _string_2);
     Editor _editor_1 = this.myFixture.getEditor();
     SelectionModel _selectionModel = _editor_1.getSelectionModel();
     String _selectedText = _selectionModel.getSelectedText();
-    Assert.assertEquals("throw new UnsupportedOperationException()", _selectedText);
+    TestCase.assertEquals("throw new UnsupportedOperationException()", _selectedText);
   }
   
   public void testOverrideCompletion_05() {
@@ -643,11 +643,11 @@ public class XtendCompletionTest extends LightXtendTest {
     Document _document = _editor.getDocument();
     String _text = _document.getText();
     String _string_2 = _text.toString();
-    Assert.assertEquals(_string_1, _string_2);
+    TestCase.assertEquals(_string_1, _string_2);
     Editor _editor_1 = this.myFixture.getEditor();
     SelectionModel _selectionModel = _editor_1.getSelectionModel();
     String _selectedText = _selectionModel.getSelectedText();
-    Assert.assertEquals("throw new UnsupportedOperationException()", _selectedText);
+    TestCase.assertEquals("throw new UnsupportedOperationException()", _selectedText);
   }
   
   public void testOverrideCompletion_06() {
@@ -712,7 +712,7 @@ public class XtendCompletionTest extends LightXtendTest {
     Document _document = _editor.getDocument();
     String _text = _document.getText();
     String _string_2 = _text.toString();
-    Assert.assertEquals(_string_1, _string_2);
+    TestCase.assertEquals(_string_1, _string_2);
     Editor _editor_1 = this.myFixture.getEditor();
     Document _document_1 = _editor_1.getDocument();
     String _text_1 = _document_1.getText();
@@ -723,7 +723,7 @@ public class XtendCompletionTest extends LightXtendTest {
     CaretModel _caretModel = _editor_2.getCaretModel();
     Caret _currentCaret = _caretModel.getCurrentCaret();
     int _offset = _currentCaret.getOffset();
-    Assert.assertEquals(offset, _offset);
+    TestCase.assertEquals(offset, _offset);
   }
   
   public void testOverrideCompletion_07() {
@@ -821,11 +821,11 @@ public class XtendCompletionTest extends LightXtendTest {
     Document _document = _editor.getDocument();
     String _text = _document.getText();
     String _string_2 = _text.toString();
-    Assert.assertEquals(_string_1, _string_2);
+    TestCase.assertEquals(_string_1, _string_2);
     Editor _editor_1 = this.myFixture.getEditor();
     SelectionModel _selectionModel = _editor_1.getSelectionModel();
     String _selectedText = _selectionModel.getSelectedText();
-    Assert.assertEquals("throw new UnsupportedOperationException()", _selectedText);
+    TestCase.assertEquals("throw new UnsupportedOperationException()", _selectedText);
   }
   
   public void testOverrideCompletion_08() {
@@ -851,7 +851,7 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string_1 = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("override toString()");
-    Assert.assertFalse(_string_1, _contains);
+    TestCase.assertFalse(_string_1, _contains);
   }
   
   public void testOverrideCompletion_09() {
@@ -877,7 +877,7 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string_1 = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("override toString()");
-    Assert.assertFalse(_string_1, _contains);
+    TestCase.assertFalse(_string_1, _contains);
   }
   
   public void testOverrideCompletion_10() {
@@ -902,7 +902,7 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string_1 = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("override toString()");
-    Assert.assertFalse(_string_1, _contains);
+    TestCase.assertFalse(_string_1, _contains);
   }
   
   public void testOverrideCompletion_11() {
@@ -927,7 +927,7 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string_1 = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("override toString()");
-    Assert.assertFalse(_string_1, _contains);
+    TestCase.assertFalse(_string_1, _contains);
   }
   
   public void testSingleLineComment() {
@@ -941,7 +941,7 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string_1 = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("ArrayList");
-    Assert.assertFalse(_string_1, _contains);
+    TestCase.assertFalse(_string_1, _contains);
   }
   
   public void testMultiLineComment() {
@@ -955,7 +955,7 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string_1 = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("ArrayList");
-    Assert.assertTrue(_string_1, _contains);
+    TestCase.assertTrue(_string_1, _contains);
   }
   
   public void testStringLiteral_01() {
@@ -978,7 +978,7 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string_1 = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("ArrayList");
-    Assert.assertFalse(_string_1, _contains);
+    TestCase.assertFalse(_string_1, _contains);
   }
   
   public void testStringLiteral_02() {
@@ -1001,7 +1001,7 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string_1 = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("ArrayList");
-    Assert.assertFalse(_string_1, _contains);
+    TestCase.assertFalse(_string_1, _contains);
   }
   
   public void testRichString_01() {
@@ -1026,7 +1026,7 @@ public class XtendCompletionTest extends LightXtendTest {
     final List<String> lookupElementStrings = this.myFixture.getLookupElementStrings();
     String _string_1 = lookupElementStrings.toString();
     boolean _contains = lookupElementStrings.contains("ArrayList");
-    Assert.assertFalse(_string_1, _contains);
+    TestCase.assertFalse(_string_1, _contains);
   }
   
   public void testRichString_02() {
@@ -1071,7 +1071,7 @@ public class XtendCompletionTest extends LightXtendTest {
     Document _document = _editor.getDocument();
     String _text = _document.getText();
     String _string_2 = _text.toString();
-    Assert.assertEquals(_string_1, _string_2);
+    TestCase.assertEquals(_string_1, _string_2);
   }
   
   public void testJavaTypeInExpressionContext() {
@@ -1106,16 +1106,16 @@ public class XtendCompletionTest extends LightXtendTest {
       return Boolean.valueOf(Objects.equal(_value, "zzz"));
     };
     final Pair<Integer, String> methodProposal = IterableExtensions.<Pair<Integer, String>>findFirst(lookupElementStrings, _function);
-    Assert.assertNotNull(methodProposal);
+    TestCase.assertNotNull(methodProposal);
     final Function1<Pair<Integer, String>, Boolean> _function_1 = (Pair<Integer, String> it) -> {
       String _value = it.getValue();
       return Boolean.valueOf(Objects.equal(_value, "ArrayList"));
     };
     final Pair<Integer, String> typeProposal = IterableExtensions.<Pair<Integer, String>>findFirst(lookupElementStrings, _function_1);
-    Assert.assertNotNull(typeProposal);
+    TestCase.assertNotNull(typeProposal);
     Integer _key = methodProposal.getKey();
     Integer _key_1 = typeProposal.getKey();
     boolean _lessThan = (_key.compareTo(_key_1) < 0);
-    Assert.assertTrue(_lessThan);
+    TestCase.assertTrue(_lessThan);
   }
 }

--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/config/GradleBuildFileUtilTest.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/config/GradleBuildFileUtilTest.java
@@ -14,7 +14,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
-import junit.framework.Assert;
+import junit.framework.TestCase;
 import org.eclipse.xtend.core.idea.config.GradleBuildFileUtility;
 import org.eclipse.xtend.core.idea.config.MavenArtifact;
 import org.eclipse.xtend.core.idea.config.XtendLibraryConfigurator;
@@ -43,7 +43,7 @@ public class GradleBuildFileUtilTest extends LightXtendTest {
   public void testSetupGradleBuildEmptyFile() {
     PsiFile _addFileToProject = this.myFixture.addFileToProject("build.gradle", "");
     final GroovyFile buildFile = ((GroovyFile) _addFileToProject);
-    Assert.assertNotNull(buildFile);
+    TestCase.assertNotNull(buildFile);
     Project _project = this.myFixture.getProject();
     final Runnable _function = () -> {
       this.util.setupGradleBuild(this.myModule, buildFile);
@@ -86,13 +86,13 @@ public class GradleBuildFileUtilTest extends LightXtendTest {
     String _string = _builder.toString();
     String _trim = _string.trim();
     String _text = buildFile.getText();
-    Assert.assertEquals(_trim, _text);
+    TestCase.assertEquals(_trim, _text);
   }
   
   public void testSetupGradleBuildFileWithContent() {
     PsiFile _addFileToProject = this.myFixture.addFileToProject("build.gradle", "buildscript{dependencies{}}");
     final GroovyFile buildFile = ((GroovyFile) _addFileToProject);
-    Assert.assertNotNull(buildFile);
+    TestCase.assertNotNull(buildFile);
     Project _project = this.myFixture.getProject();
     final Runnable _function = () -> {
       this.util.setupGradleBuild(this.myModule, buildFile);
@@ -131,13 +131,13 @@ public class GradleBuildFileUtilTest extends LightXtendTest {
     String _string = _builder.toString();
     String _trim = _string.trim();
     String _text = buildFile.getText();
-    Assert.assertEquals(_trim, _text);
+    TestCase.assertEquals(_trim, _text);
   }
   
   public void testAddDependencyEmptyFile() {
     PsiFile _addFileToProject = this.myFixture.addFileToProject("build.gradle", "");
     final GroovyFile buildFile = ((GroovyFile) _addFileToProject);
-    Assert.assertNotNull(buildFile);
+    TestCase.assertNotNull(buildFile);
     Project _project = this.myFixture.getProject();
     final Runnable _function = () -> {
       MavenArtifact _xtendLibMavenId = XtendLibraryConfigurator.xtendLibMavenId();
@@ -160,7 +160,7 @@ public class GradleBuildFileUtilTest extends LightXtendTest {
     _builder.append("}");
     String _string_1 = _builder.toString();
     String _text = buildFile.getText();
-    Assert.assertEquals(_string_1, _text);
+    TestCase.assertEquals(_string_1, _text);
   }
   
   public void testAddDependencyFileWithContent() {
@@ -168,7 +168,7 @@ public class GradleBuildFileUtilTest extends LightXtendTest {
     _builder.append("dependencies {}");
     PsiFile _addFileToProject = this.myFixture.addFileToProject("build.gradle", _builder.toString());
     final GroovyFile buildFile = ((GroovyFile) _addFileToProject);
-    Assert.assertNotNull(buildFile);
+    TestCase.assertNotNull(buildFile);
     Project _project = this.myFixture.getProject();
     final Runnable _function = () -> {
       MavenArtifact _xtendLibMavenId = XtendLibraryConfigurator.xtendLibMavenId();
@@ -191,22 +191,22 @@ public class GradleBuildFileUtilTest extends LightXtendTest {
     _builder_1.append("}");
     String _string_1 = _builder_1.toString();
     String _text = buildFile.getText();
-    Assert.assertEquals(_string_1, _text);
+    TestCase.assertEquals(_string_1, _text);
   }
   
   public void testIsGradleModule() {
     PlatformUtil _platformUtil = new PlatformUtil();
     boolean _isGradleInstalled = _platformUtil.isGradleInstalled();
-    Assert.assertTrue(_isGradleInstalled);
+    TestCase.assertTrue(_isGradleInstalled);
     Module _module = this.myFixture.getModule();
     boolean _isGradleedModule = this.util.isGradleedModule(_module);
-    Assert.assertFalse(_isGradleedModule);
+    TestCase.assertFalse(_isGradleedModule);
   }
   
   public void assertTree(final GroovyFile buildFile) {
     GrStatement[] _statements = buildFile.getStatements();
     int _length = _statements.length;
-    Assert.assertEquals(2, _length);
+    TestCase.assertEquals(2, _length);
     GrStatement[] _statements_1 = buildFile.getStatements();
     Iterable<GrMethodCallExpression> _filter = Iterables.<GrMethodCallExpression>filter(((Iterable<?>)Conversions.doWrapArray(_statements_1)), GrMethodCallExpression.class);
     final Function1<GrMethodCallExpression, Boolean> _function = (GrMethodCallExpression it) -> {
@@ -216,17 +216,17 @@ public class GradleBuildFileUtilTest extends LightXtendTest {
     };
     final Iterable<GrMethodCallExpression> bsCol = IterableExtensions.<GrMethodCallExpression>filter(_filter, _function);
     int _size = IterableExtensions.size(bsCol);
-    Assert.assertEquals(1, _size);
+    TestCase.assertEquals(1, _size);
     final GrMethodCallExpression bs = IterableExtensions.<GrMethodCallExpression>head(bsCol);
     GrExpression _invokedExpression = bs.getInvokedExpression();
     String _text = _invokedExpression.getText();
-    Assert.assertEquals("buildscript", _text);
+    TestCase.assertEquals("buildscript", _text);
     GrClosableBlock[] _closureArguments = bs.getClosureArguments();
     GrClosableBlock _head = IterableExtensions.<GrClosableBlock>head(((Iterable<GrClosableBlock>)Conversions.doWrapArray(_closureArguments)));
     PsiElement[] _children = _head.getChildren();
     final Iterable<GrMethodCallExpression> children = Iterables.<GrMethodCallExpression>filter(((Iterable<?>)Conversions.doWrapArray(_children)), GrMethodCallExpression.class);
     int _size_1 = IterableExtensions.size(children);
-    Assert.assertEquals(2, _size_1);
+    TestCase.assertEquals(2, _size_1);
     final Function1<GrMethodCallExpression, Boolean> _function_1 = (GrMethodCallExpression it) -> {
       GrExpression _invokedExpression_1 = it.getInvokedExpression();
       String _text_1 = _invokedExpression_1.getText();
@@ -234,26 +234,26 @@ public class GradleBuildFileUtilTest extends LightXtendTest {
     };
     Iterable<GrMethodCallExpression> _filter_1 = IterableExtensions.<GrMethodCallExpression>filter(children, _function_1);
     final GrMethodCallExpression dps = IterableExtensions.<GrMethodCallExpression>head(_filter_1);
-    Assert.assertNotNull(dps);
+    TestCase.assertNotNull(dps);
     PsiElement[] _children_1 = dps.getChildren();
     int _length_1 = _children_1.length;
-    Assert.assertEquals(3, _length_1);
+    TestCase.assertEquals(3, _length_1);
     GrClosableBlock[] _closureArguments_1 = dps.getClosureArguments();
     final GrClosableBlock closureBlock = IterableExtensions.<GrClosableBlock>head(((Iterable<GrClosableBlock>)Conversions.doWrapArray(_closureArguments_1)));
     GrStatement[] _statements_2 = closureBlock.getStatements();
     int _length_2 = _statements_2.length;
-    Assert.assertEquals(1, _length_2);
+    TestCase.assertEquals(1, _length_2);
     GrStatement[] _statements_3 = closureBlock.getStatements();
     Iterable<GrApplicationStatement> _filter_2 = Iterables.<GrApplicationStatement>filter(((Iterable<?>)Conversions.doWrapArray(_statements_3)), GrApplicationStatement.class);
     final GrApplicationStatement clEntry = IterableExtensions.<GrApplicationStatement>head(_filter_2);
-    Assert.assertNotNull(clEntry);
+    TestCase.assertNotNull(clEntry);
     GrExpression _invokedExpression_1 = clEntry.getInvokedExpression();
     String _text_1 = _invokedExpression_1.getText();
-    Assert.assertEquals("classpath", _text_1);
+    TestCase.assertEquals("classpath", _text_1);
     GrCommandArgumentList _argumentList = clEntry.getArgumentList();
     String _text_2 = _argumentList.getText();
     boolean _startsWith = _text_2.startsWith("\'org.xtext:xtext-gradle-plugin:");
-    Assert.assertTrue(_startsWith);
+    TestCase.assertTrue(_startsWith);
     final Function1<GrMethodCallExpression, Boolean> _function_2 = (GrMethodCallExpression it) -> {
       GrExpression _invokedExpression_2 = it.getInvokedExpression();
       String _text_3 = _invokedExpression_2.getText();
@@ -261,7 +261,7 @@ public class GradleBuildFileUtilTest extends LightXtendTest {
     };
     Iterable<GrMethodCallExpression> _filter_3 = IterableExtensions.<GrMethodCallExpression>filter(children, _function_2);
     final GrMethodCallExpression repos = IterableExtensions.<GrMethodCallExpression>head(_filter_3);
-    Assert.assertNotNull(repos);
+    TestCase.assertNotNull(repos);
     GrClosableBlock[] _closureArguments_2 = repos.getClosureArguments();
     GrClosableBlock _head_1 = IterableExtensions.<GrClosableBlock>head(((Iterable<GrClosableBlock>)Conversions.doWrapArray(_closureArguments_2)));
     GrStatement[] _statements_4 = _head_1.getStatements();
@@ -269,6 +269,6 @@ public class GradleBuildFileUtilTest extends LightXtendTest {
     final GrMethodCallExpression jcenterEntry = IterableExtensions.<GrMethodCallExpression>head(_filter_4);
     GrExpression _invokedExpression_2 = jcenterEntry.getInvokedExpression();
     String _text_3 = _invokedExpression_2.getText();
-    Assert.assertEquals("jcenter", _text_3);
+    TestCase.assertEquals("jcenter", _text_3);
   }
 }

--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/config/XtendLibraryManagerTest.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/config/XtendLibraryManagerTest.java
@@ -23,7 +23,7 @@ import com.intellij.openapi.roots.OrderEntry;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.Consumer;
-import junit.framework.Assert;
+import junit.framework.TestCase;
 import org.eclipse.xtend.core.idea.config.XtendLibraryConfigurator;
 import org.eclipse.xtend.core.idea.framework.XtendLibraryDescription;
 import org.eclipse.xtend.core.idea.intentions.XtendIntentionsProvider;
@@ -153,7 +153,7 @@ public class XtendLibraryManagerTest extends LightXtendTest {
     };
     final Iterable<OrderEntry> xtendlibs = IterableExtensions.<OrderEntry>filter(((Iterable<OrderEntry>)Conversions.doWrapArray(_orderEntries)), _function);
     int _size = IterableExtensions.size(xtendlibs);
-    Assert.assertEquals("Xtend libraries in module", 1, _size);
+    TestCase.assertEquals("Xtend libraries in module", 1, _size);
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();

--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/config/XtendSupportConfigurableTest.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/config/XtendSupportConfigurableTest.java
@@ -46,7 +46,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import junit.framework.Assert;
+import junit.framework.TestCase;
 import org.eclipse.xtend.core.idea.facet.XtendFacetConfiguration;
 import org.eclipse.xtend.core.idea.facet.XtendFacetType;
 import org.eclipse.xtend.core.idea.lang.XtendFileType;
@@ -66,23 +66,23 @@ public class XtendSupportConfigurableTest extends PsiTestCase {
     final ModuleRootManager manager = ModuleRootManager.getInstance(this.myModule);
     VirtualFile[] _contentRoots = manager.getContentRoots();
     int _size = ((List<VirtualFile>)Conversions.doWrapArray(_contentRoots)).size();
-    Assert.assertEquals(0, _size);
+    TestCase.assertEquals(0, _size);
     this.addFrameworkSupport(this.myModule);
     VirtualFile[] _contentRoots_1 = manager.getContentRoots();
     int _size_1 = ((List<VirtualFile>)Conversions.doWrapArray(_contentRoots_1)).size();
-    Assert.assertEquals(1, _size_1);
+    TestCase.assertEquals(1, _size_1);
     FacetManager _instance = FacetManager.getInstance(this.myModule);
     Collection<Facet<XtendFacetConfiguration>> _facetsByType = _instance.<Facet<XtendFacetConfiguration>>getFacetsByType(XtendFacetType.TYPEID);
     final Facet<XtendFacetConfiguration> facet = IterableExtensions.<Facet<XtendFacetConfiguration>>head(_facetsByType);
-    Assert.assertNotNull(facet);
+    TestCase.assertNotNull(facet);
     XtendFacetConfiguration _configuration = facet.getConfiguration();
     final XbaseGeneratorConfigurationState xtendConfig = _configuration.getState();
     String _outputDirectory = xtendConfig.getOutputDirectory();
     boolean _endsWith = _outputDirectory.endsWith("xtend-gen");
-    Assert.assertTrue(_endsWith);
+    TestCase.assertTrue(_endsWith);
     String _testOutputDirectory = xtendConfig.getTestOutputDirectory();
     boolean _endsWith_1 = _testOutputDirectory.endsWith("xtend-gen");
-    Assert.assertTrue(_endsWith_1);
+    TestCase.assertTrue(_endsWith_1);
     ContentEntry[] _contentEntries = manager.getContentEntries();
     ContentEntry _head = IterableExtensions.<ContentEntry>head(((Iterable<ContentEntry>)Conversions.doWrapArray(_contentEntries)));
     SourceFolder[] _sourceFolders = _head.getSourceFolders();
@@ -98,7 +98,7 @@ public class XtendSupportConfigurableTest extends PsiTestCase {
     };
     Iterable<SourceFolder> _filter = IterableExtensions.<SourceFolder>filter(((Iterable<SourceFolder>)Conversions.doWrapArray(_sourceFolders)), _function);
     int _size_2 = IterableExtensions.size(_filter);
-    Assert.assertEquals(1, _size_2);
+    TestCase.assertEquals(1, _size_2);
   }
   
   public void testPlainJavaOutputConfiguration_02() {
@@ -124,24 +124,24 @@ public class XtendSupportConfigurableTest extends PsiTestCase {
     final ModuleRootManager manager = ModuleRootManager.getInstance(module);
     final VirtualFile[] srcFolders = manager.getSourceRoots(true);
     int _size = ((List<VirtualFile>)Conversions.doWrapArray(srcFolders)).size();
-    Assert.assertEquals(2, _size);
+    TestCase.assertEquals(2, _size);
     this.addFrameworkSupport(module);
     FacetManager _instance = FacetManager.getInstance(module);
     Collection<Facet<XtendFacetConfiguration>> _facetsByType = _instance.<Facet<XtendFacetConfiguration>>getFacetsByType(XtendFacetType.TYPEID);
     final Facet<XtendFacetConfiguration> facet = IterableExtensions.<Facet<XtendFacetConfiguration>>head(_facetsByType);
-    Assert.assertNotNull(facet);
+    TestCase.assertNotNull(facet);
     XtendFacetConfiguration _configuration = facet.getConfiguration();
     final XbaseGeneratorConfigurationState xtendConfig = _configuration.getState();
     String _outputDirectory = xtendConfig.getOutputDirectory();
     String _testOutputDirectory = xtendConfig.getTestOutputDirectory();
     boolean _equals = Objects.equal(_outputDirectory, _testOutputDirectory);
-    Assert.assertFalse(_equals);
+    TestCase.assertFalse(_equals);
     String _outputDirectory_1 = xtendConfig.getOutputDirectory();
     boolean _endsWith = _outputDirectory_1.endsWith("module1/src/main/xtend-gen");
-    Assert.assertTrue(_endsWith);
+    TestCase.assertTrue(_endsWith);
     String _testOutputDirectory_1 = xtendConfig.getTestOutputDirectory();
     boolean _endsWith_1 = _testOutputDirectory_1.endsWith("module1/src/test/xtend-gen");
-    Assert.assertTrue(_endsWith_1);
+    TestCase.assertTrue(_endsWith_1);
     ModuleRootManager _instance_1 = ModuleRootManager.getInstance(module);
     final VirtualFile[] sourceRoots = _instance_1.getSourceRoots(true);
     final Function1<VirtualFile, Boolean> _function_1 = (VirtualFile it) -> {
@@ -156,7 +156,7 @@ public class XtendSupportConfigurableTest extends PsiTestCase {
     };
     Iterable<VirtualFile> _filter = IterableExtensions.<VirtualFile>filter(((Iterable<VirtualFile>)Conversions.doWrapArray(sourceRoots)), _function_1);
     int _size_1 = IterableExtensions.size(_filter);
-    Assert.assertEquals(1, _size_1);
+    TestCase.assertEquals(1, _size_1);
     final Function1<VirtualFile, Boolean> _function_2 = (VirtualFile it) -> {
       boolean _xblockexpression = false;
       {
@@ -169,30 +169,30 @@ public class XtendSupportConfigurableTest extends PsiTestCase {
     };
     Iterable<VirtualFile> _filter_1 = IterableExtensions.<VirtualFile>filter(((Iterable<VirtualFile>)Conversions.doWrapArray(sourceRoots)), _function_2);
     int _size_2 = IterableExtensions.size(_filter_1);
-    Assert.assertEquals(1, _size_2);
+    TestCase.assertEquals(1, _size_2);
   }
   
   public void testPlainJavaOutputConfiguration_03() {
     final ModuleRootManager manager = ModuleRootManager.getInstance(this.myModule);
     VirtualFile[] _contentRoots = manager.getContentRoots();
     int _size = ((List<VirtualFile>)Conversions.doWrapArray(_contentRoots)).size();
-    Assert.assertEquals(0, _size);
+    TestCase.assertEquals(0, _size);
     this.addFrameworkSupportUsingDetector(this.myModule);
     VirtualFile[] _contentRoots_1 = manager.getContentRoots();
     int _size_1 = ((List<VirtualFile>)Conversions.doWrapArray(_contentRoots_1)).size();
-    Assert.assertEquals(1, _size_1);
+    TestCase.assertEquals(1, _size_1);
     FacetManager _instance = FacetManager.getInstance(this.myModule);
     Collection<Facet<XtendFacetConfiguration>> _facetsByType = _instance.<Facet<XtendFacetConfiguration>>getFacetsByType(XtendFacetType.TYPEID);
     final Facet<XtendFacetConfiguration> facet = IterableExtensions.<Facet<XtendFacetConfiguration>>head(_facetsByType);
-    Assert.assertNotNull(facet);
+    TestCase.assertNotNull(facet);
     XtendFacetConfiguration _configuration = facet.getConfiguration();
     final XbaseGeneratorConfigurationState xtendConfig = _configuration.getState();
     String _outputDirectory = xtendConfig.getOutputDirectory();
     boolean _endsWith = _outputDirectory.endsWith("xtend-gen");
-    Assert.assertTrue(_endsWith);
+    TestCase.assertTrue(_endsWith);
     String _testOutputDirectory = xtendConfig.getTestOutputDirectory();
     boolean _endsWith_1 = _testOutputDirectory.endsWith("xtend-gen");
-    Assert.assertTrue(_endsWith_1);
+    TestCase.assertTrue(_endsWith_1);
     ContentEntry[] _contentEntries = manager.getContentEntries();
     ContentEntry _head = IterableExtensions.<ContentEntry>head(((Iterable<ContentEntry>)Conversions.doWrapArray(_contentEntries)));
     SourceFolder[] _sourceFolders = _head.getSourceFolders();
@@ -208,7 +208,7 @@ public class XtendSupportConfigurableTest extends PsiTestCase {
     };
     Iterable<SourceFolder> _filter = IterableExtensions.<SourceFolder>filter(((Iterable<SourceFolder>)Conversions.doWrapArray(_sourceFolders)), _function);
     int _size_2 = IterableExtensions.size(_filter);
-    Assert.assertEquals(1, _size_2);
+    TestCase.assertEquals(1, _size_2);
   }
   
   protected void addFrameworkSupportUsingDetector(final Module moduleToHandle) {

--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/documentation/XtendDocumentationTest.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/documentation/XtendDocumentationTest.java
@@ -23,7 +23,7 @@ import com.intellij.testFramework.PlatformTestCase;
 import com.intellij.testFramework.PsiTestCase;
 import com.intellij.testFramework.PsiTestUtil;
 import java.io.File;
-import junit.framework.Assert;
+import junit.framework.TestCase;
 import org.eclipse.xtend.core.idea.lang.XtendLanguage;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.idea.tests.LightToolingTest;
@@ -98,7 +98,7 @@ public class XtendDocumentationTest extends PsiTestCase {
     final PsiReference xtend = this.createReferenceByFileWithMarker(this.src, "Bar.xtend", _builder_1.toString());
     final String expected = this.generateDocumentation(xtend);
     boolean _contains = expected.contains("mydocumentation");
-    Assert.assertTrue(_contains);
+    TestCase.assertTrue(_contains);
   }
   
   public void testXtendClass() {
@@ -124,7 +124,7 @@ public class XtendDocumentationTest extends PsiTestCase {
     final PsiReference xtend = this.createReferenceByFileWithMarker(this.src, "Bar.xtend", _builder_1.toString());
     final String expected = this.generateDocumentation(xtend);
     boolean _contains = expected.contains("mydocumentation");
-    Assert.assertTrue(_contains);
+    TestCase.assertTrue(_contains);
   }
   
   public void testXtendField() {
@@ -157,9 +157,9 @@ public class XtendDocumentationTest extends PsiTestCase {
     final PsiReference xtend = this.createReferenceByFileWithMarker(this.src, "Bar.xtend", _builder_1.toString());
     final String expected = this.generateDocumentation(xtend);
     boolean _contains = expected.contains("<b>myfoo = &quot;x&quot;</b>");
-    Assert.assertTrue(_contains);
+    TestCase.assertTrue(_contains);
     boolean _contains_1 = expected.contains("mydocumentation");
-    Assert.assertTrue(_contains_1);
+    TestCase.assertTrue(_contains_1);
   }
   
   public void testXtendMethod() {
@@ -192,9 +192,9 @@ public class XtendDocumentationTest extends PsiTestCase {
     final PsiReference xtend = this.createReferenceByFileWithMarker(this.src, "Bar.xtend", _builder_1.toString());
     final String expected = this.generateDocumentation(xtend);
     boolean _contains = expected.contains("<b>myfoo</b>()");
-    Assert.assertTrue(_contains);
+    TestCase.assertTrue(_contains);
     boolean _contains_1 = expected.contains("mydocumentation");
-    Assert.assertTrue(_contains_1);
+    TestCase.assertTrue(_contains_1);
   }
   
   public void testXtendConstructor() {
@@ -227,9 +227,9 @@ public class XtendDocumentationTest extends PsiTestCase {
     final PsiReference xtend = this.createReferenceByFileWithMarker(this.src, "Bar.xtend", _builder_1.toString());
     final String expected = this.generateDocumentation(xtend);
     boolean _contains = expected.contains("<b>Foo</b>()");
-    Assert.assertTrue(_contains);
+    TestCase.assertTrue(_contains);
     boolean _contains_1 = expected.contains("mydocumentation");
-    Assert.assertTrue(_contains_1);
+    TestCase.assertTrue(_contains_1);
   }
   
   protected PsiFile createFile(final VirtualFile dir, final String fileName, final String contents) {
@@ -262,8 +262,8 @@ public class XtendDocumentationTest extends PsiTestCase {
     {
       final PsiElement originalElement = reference.getElement();
       final PsiElement element = reference.resolve();
-      Assert.assertNotNull(originalElement);
-      Assert.assertNotNull(element);
+      TestCase.assertNotNull(originalElement);
+      TestCase.assertNotNull(element);
       _xblockexpression = this.generateDocumentation(element, originalElement);
     }
     return _xblockexpression;

--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/execution/TraceBasedConfigurationProducerTest.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/execution/TraceBasedConfigurationProducerTest.java
@@ -46,7 +46,7 @@ import com.intellij.util.containers.ContainerUtilRt;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import junit.framework.Assert;
+import junit.framework.TestCase;
 import org.eclipse.xtend.core.idea.execution.XtendApplicationConfigurationProducer;
 import org.eclipse.xtend.core.idea.execution.XtendJunitClassConfigurationProducer;
 import org.eclipse.xtend.core.idea.execution.XtendJunitMethodConfigurationProducer;
@@ -106,7 +106,7 @@ public class TraceBasedConfigurationProducerTest extends XtendIdeaTestCase {
       final VirtualFile file = this.addFile(_mappedTo);
       PsiManager _psiManager = this.getPsiManager();
       final PsiFile xtendFile = _psiManager.findFile(file);
-      Assert.assertTrue((xtendFile instanceof BaseXtextFile));
+      TestCase.assertTrue((xtendFile instanceof BaseXtextFile));
       FileViewProvider _viewProvider = xtendFile.getViewProvider();
       final PsiElement sourceElement = _viewProvider.findElementAt(cursorIdx);
       final ApplicationConfiguration configuration = this.<ApplicationConfiguration>createConfiguration(sourceElement, XtendApplicationConfigurationProducer.class);
@@ -114,21 +114,21 @@ public class TraceBasedConfigurationProducerTest extends XtendIdeaTestCase {
       Set<Module> _singleton = Collections.<Module>singleton(_module);
       Module[] _modules = configuration.getModules();
       HashSet<Module> _newHashSet = ContainerUtilRt.<Module>newHashSet(_modules);
-      Assert.assertEquals(_singleton, _newHashSet);
+      TestCase.assertEquals(_singleton, _newHashSet);
       PsiClass _mainClass = configuration.getMainClass();
       boolean _hasMainMethod = PsiMethodUtil.hasMainMethod(_mainClass);
-      Assert.assertTrue(_hasMainMethod);
+      TestCase.assertTrue(_hasMainMethod);
       PsiClass _mainClass_1 = configuration.getMainClass();
       String _qualifiedName = _mainClass_1.getQualifiedName();
-      Assert.assertEquals("XtendMainClass", _qualifiedName);
+      TestCase.assertEquals("XtendMainClass", _qualifiedName);
       String _name = configuration.getName();
-      Assert.assertEquals("XtendMainClass", _name);
+      TestCase.assertEquals("XtendMainClass", _name);
       TraceBasedConfigurationProducerTest.checkCanRun(configuration);
       final ApplicationConfiguration sameConfiguration = this.<ApplicationConfiguration>createConfiguration(sourceElement, XtendApplicationConfigurationProducer.class);
       final RunConfigurationProducer<ApplicationConfiguration> producer = RunConfigurationProducer.<XtendApplicationConfigurationProducer>getInstance(XtendApplicationConfigurationProducer.class);
       ConfigurationContext _createContext = this.createContext(sourceElement);
       boolean _isConfigurationFromContext = producer.isConfigurationFromContext(sameConfiguration, _createContext);
-      Assert.assertTrue(_isConfigurationFromContext);
+      TestCase.assertTrue(_isConfigurationFromContext);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -175,13 +175,13 @@ public class TraceBasedConfigurationProducerTest extends XtendIdeaTestCase {
       final VirtualFile file = this.addFile(_mappedTo);
       PsiManager _psiManager = this.getPsiManager();
       final PsiFile xtendFile = _psiManager.findFile(file);
-      Assert.assertTrue((xtendFile instanceof BaseXtextFile));
+      TestCase.assertTrue((xtendFile instanceof BaseXtextFile));
       FileViewProvider _viewProvider = xtendFile.getViewProvider();
       final PsiElement sourceElement = _viewProvider.findElementAt(cursorIdx);
       final ConfigurationContext context = this.createContext(sourceElement);
       final XtendApplicationConfigurationProducer producer = RunConfigurationProducer.<XtendApplicationConfigurationProducer>getInstance(XtendApplicationConfigurationProducer.class);
       final ConfigurationFromContext confFromContext = producer.createConfigurationFromContext(context);
-      Assert.assertNotNull(confFromContext);
+      TestCase.assertNotNull(confFromContext);
       RunConfiguration _configuration = confFromContext.getConfiguration();
       TraceBasedConfigurationProducerTest.checkCanRun(_configuration);
     } catch (Throwable _e) {
@@ -257,9 +257,9 @@ public class TraceBasedConfigurationProducerTest extends XtendIdeaTestCase {
       final PsiFile xtendFile = _psiManager.findFile(file);
       final JUnitConfiguration conf = this.<JUnitConfiguration>createConfiguration(xtendFile, XtendJunitClassConfigurationProducer.class);
       JUnitConfiguration.Data _persistentData = conf.getPersistentData();
-      Assert.assertEquals("XtendJunitClass", _persistentData.MAIN_CLASS_NAME);
+      TestCase.assertEquals("XtendJunitClass", _persistentData.MAIN_CLASS_NAME);
       JUnitConfiguration.Data _persistentData_1 = conf.getPersistentData();
-      Assert.assertEquals("class", _persistentData_1.TEST_OBJECT);
+      TestCase.assertEquals("class", _persistentData_1.TEST_OBJECT);
       TraceBasedConfigurationProducerTest.checkCanRun(conf);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
@@ -312,16 +312,16 @@ public class TraceBasedConfigurationProducerTest extends XtendIdeaTestCase {
       final VirtualFile file = this.addFile(_mappedTo);
       PsiManager _psiManager = this.getPsiManager();
       final PsiFile xtendFile = _psiManager.findFile(file);
-      Assert.assertTrue((xtendFile instanceof BaseXtextFile));
+      TestCase.assertTrue((xtendFile instanceof BaseXtextFile));
       FileViewProvider _viewProvider = xtendFile.getViewProvider();
       final PsiElement sourceElement = _viewProvider.findElementAt(cursorIdx);
       final JUnitConfiguration configuration = this.<JUnitConfiguration>createConfiguration(sourceElement, XtendJunitMethodConfigurationProducer.class);
       JUnitConfiguration.Data _persistentData = configuration.getPersistentData();
-      Assert.assertEquals("XtendJunitClass", _persistentData.MAIN_CLASS_NAME);
+      TestCase.assertEquals("XtendJunitClass", _persistentData.MAIN_CLASS_NAME);
       JUnitConfiguration.Data _persistentData_1 = configuration.getPersistentData();
-      Assert.assertEquals("method", _persistentData_1.TEST_OBJECT);
+      TestCase.assertEquals("method", _persistentData_1.TEST_OBJECT);
       JUnitConfiguration.Data _persistentData_2 = configuration.getPersistentData();
-      Assert.assertEquals("testMethod", _persistentData_2.METHOD_NAME);
+      TestCase.assertEquals("testMethod", _persistentData_2.METHOD_NAME);
       TraceBasedConfigurationProducerTest.checkCanRun(configuration);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
@@ -374,16 +374,16 @@ public class TraceBasedConfigurationProducerTest extends XtendIdeaTestCase {
       final VirtualFile file = this.addFile(_mappedTo);
       PsiManager _psiManager = this.getPsiManager();
       final PsiFile xtendFile = _psiManager.findFile(file);
-      Assert.assertTrue((xtendFile instanceof BaseXtextFile));
+      TestCase.assertTrue((xtendFile instanceof BaseXtextFile));
       FileViewProvider _viewProvider = xtendFile.getViewProvider();
       final PsiElement sourceElement = _viewProvider.findElementAt(cursorIdx);
       final JUnitConfiguration configuration = this.<JUnitConfiguration>createConfiguration(sourceElement, XtendJunitMethodConfigurationProducer.class);
       JUnitConfiguration.Data _persistentData = configuration.getPersistentData();
-      Assert.assertEquals("XtendJunitClass", _persistentData.MAIN_CLASS_NAME);
+      TestCase.assertEquals("XtendJunitClass", _persistentData.MAIN_CLASS_NAME);
       JUnitConfiguration.Data _persistentData_1 = configuration.getPersistentData();
-      Assert.assertEquals("method", _persistentData_1.TEST_OBJECT);
+      TestCase.assertEquals("method", _persistentData_1.TEST_OBJECT);
       JUnitConfiguration.Data _persistentData_2 = configuration.getPersistentData();
-      Assert.assertEquals("testMethod2", _persistentData_2.METHOD_NAME);
+      TestCase.assertEquals("testMethod2", _persistentData_2.METHOD_NAME);
       TraceBasedConfigurationProducerTest.checkCanRun(configuration);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
@@ -409,9 +409,9 @@ public class TraceBasedConfigurationProducerTest extends XtendIdeaTestCase {
   protected <T extends RunConfiguration> T createConfiguration(final PsiElement psiElement, final Class<? extends RunConfigurationProducer<T>> clazz) {
     final ConfigurationContext context = this.createContext(psiElement);
     final RunConfigurationProducer<T> producer = RunConfigurationProducer.<RunConfigurationProducer<T>>getInstance(clazz);
-    Assert.assertNotNull(producer);
+    TestCase.assertNotNull(producer);
     final ConfigurationFromContext fromContext = producer.createConfigurationFromContext(context);
-    Assert.assertNotNull(fromContext);
+    TestCase.assertNotNull(fromContext);
     RunConfiguration _configuration = fromContext.getConfiguration();
     return ((T) _configuration);
   }
@@ -424,8 +424,8 @@ public class TraceBasedConfigurationProducerTest extends XtendIdeaTestCase {
   private ConfigurationContext createContext(@NotNull final PsiElement psiClass, @NotNull final MapDataContext dataContext) {
     dataContext.<Project>put(CommonDataKeys.PROJECT, this.myProject);
     Module _data = LangDataKeys.MODULE.getData(dataContext);
-    boolean _equals = Objects.equal(_data, null);
-    if (_equals) {
+    boolean _tripleEquals = (_data == null);
+    if (_tripleEquals) {
       Module _findModuleForPsiElement = ModuleUtilCore.findModuleForPsiElement(psiClass);
       dataContext.<Module>put(LangDataKeys.MODULE, _findModuleForPsiElement);
     }
@@ -439,8 +439,8 @@ public class TraceBasedConfigurationProducerTest extends XtendIdeaTestCase {
     ExecutionEnvironmentBuilder _create = ExecutionEnvironmentBuilder.create(_runExecutorInstance, configuration);
     ExecutionEnvironment _build = _create.build();
     final RunProfileState state = _build.getState();
-    Assert.assertNotNull(state);
-    Assert.assertTrue((state instanceof JavaCommandLine));
+    TestCase.assertNotNull(state);
+    TestCase.assertTrue((state instanceof JavaCommandLine));
     try {
       configuration.checkConfiguration();
     } catch (final Throwable _t) {
@@ -448,12 +448,12 @@ public class TraceBasedConfigurationProducerTest extends XtendIdeaTestCase {
         final RuntimeConfigurationError e = (RuntimeConfigurationError)_t;
         String _message = e.getMessage();
         String _plus = ("cannot run: " + _message);
-        Assert.fail(_plus);
+        TestCase.fail(_plus);
       } else if (_t instanceof RuntimeConfigurationException) {
         final RuntimeConfigurationException e_1 = (RuntimeConfigurationException)_t;
         String _message_1 = e_1.getMessage();
         String _plus_1 = ("cannot run: " + _message_1);
-        Assert.fail(_plus_1);
+        TestCase.fail(_plus_1);
       } else {
         throw Exceptions.sneakyThrow(_t);
       }

--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/findUsages/XtendFindUsagesTest.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/findUsages/XtendFindUsagesTest.java
@@ -28,7 +28,7 @@ import com.intellij.util.CommonProcessors;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import junit.framework.Assert;
+import junit.framework.TestCase;
 import org.eclipse.xtend.idea.LightXtendTest;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
@@ -2340,7 +2340,7 @@ public class XtendFindUsagesTest extends LightXtendTest {
   protected void testHighlightUsages(final PsiElement element, final String expectation) {
     FindUsagesHandler _highlightUsagesHandler = this.getHighlightUsagesHandler(element);
     String _printHighlightUsages = this.printHighlightUsages(_highlightUsagesHandler, element);
-    Assert.assertEquals(expectation, _printHighlightUsages);
+    TestCase.assertEquals(expectation, _printHighlightUsages);
   }
   
   protected String printHighlightUsages(final FindUsagesHandler findUsagesHandler, final PsiElement element) {
@@ -2404,7 +2404,7 @@ public class XtendFindUsagesTest extends LightXtendTest {
   protected void testFindUsages(final PsiElement element, final String expectation) {
     FindUsagesHandler _findUsagesHandler = this.getFindUsagesHandler(element);
     String _printUsages = this.printUsages(_findUsagesHandler);
-    Assert.assertEquals(expectation, _printUsages);
+    TestCase.assertEquals(expectation, _printUsages);
   }
   
   protected String printUsages(final FindUsagesHandler findUsagesHandler) {

--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/highlighting/XtendHighlightingLexerTest.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/highlighting/XtendHighlightingLexerTest.java
@@ -9,7 +9,7 @@ package org.eclipse.xtend.idea.highlighting;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import junit.framework.Assert;
+import junit.framework.TestCase;
 import org.eclipse.xtend.core.idea.highlighting.XtendHighlightingLexer;
 import org.eclipse.xtend.idea.LightXtendTest;
 
@@ -25,25 +25,25 @@ public class XtendHighlightingLexerTest extends LightXtendTest {
     final XtendHighlightingLexer lexer = this.lexerProvider.get();
     lexer.start("package mypackage");
     int _tokenStart = lexer.getTokenStart();
-    Assert.assertEquals(0, _tokenStart);
+    TestCase.assertEquals(0, _tokenStart);
     lexer.advance();
     int _tokenStart_1 = lexer.getTokenStart();
-    Assert.assertNotSame(Integer.valueOf(0), Integer.valueOf(_tokenStart_1));
+    TestCase.assertNotSame(Integer.valueOf(0), Integer.valueOf(_tokenStart_1));
     lexer.start("package mypackage");
     int _tokenStart_2 = lexer.getTokenStart();
-    Assert.assertEquals(0, _tokenStart_2);
+    TestCase.assertEquals(0, _tokenStart_2);
   }
   
   public void ignoreStart_02() {
     final XtendHighlightingLexer lexer = this.lexerProvider.get();
     lexer.start("\'\'\' «» \'\'\'");
     int _tokenStart = lexer.getTokenStart();
-    Assert.assertEquals(0, _tokenStart);
+    TestCase.assertEquals(0, _tokenStart);
     lexer.advance();
     int _tokenStart_1 = lexer.getTokenStart();
-    Assert.assertNotSame(Integer.valueOf(0), Integer.valueOf(_tokenStart_1));
+    TestCase.assertNotSame(Integer.valueOf(0), Integer.valueOf(_tokenStart_1));
     lexer.start("\'\'\' «» \'\'\'");
     int _tokenStart_2 = lexer.getTokenStart();
-    Assert.assertEquals(0, _tokenStart_2);
+    TestCase.assertEquals(0, _tokenStart_2);
   }
 }

--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/intentions/IntentionsTest.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/intentions/IntentionsTest.java
@@ -16,7 +16,7 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
-import junit.framework.Assert;
+import junit.framework.TestCase;
 import org.eclipse.xtend.core.idea.intentions.XtendIntentionsProvider;
 import org.eclipse.xtend.idea.LightXtendTest;
 import org.eclipse.xtend2.lib.StringConcatenation;
@@ -204,6 +204,6 @@ public class IntentionsTest extends LightXtendTest {
     Editor _editor = this.myFixture.getEditor();
     Document _document = _editor.getDocument();
     String _text = _document.getText();
-    Assert.assertEquals(after, _text);
+    TestCase.assertEquals(after, _text);
   }
 }

--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/javaconverter/IdeaJavaConverterTest.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/javaconverter/IdeaJavaConverterTest.java
@@ -15,7 +15,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiJavaFile;
 import java.util.Iterator;
-import junit.framework.Assert;
+import junit.framework.TestCase;
 import org.eclipse.xtend.core.idea.javaconverter.ConvertJavaCodeHandler;
 import org.eclipse.xtend.core.idea.lang.XtendFileType;
 import org.eclipse.xtend.core.javaconverter.JavaConverter;
@@ -99,10 +99,10 @@ public class IdeaJavaConverterTest extends AbstractModelTestCase {
     String _nameWithoutExtension = _virtualFile.getNameWithoutExtension();
     String _text = javaCalzz.getText();
     final JavaConverter.ConversionResult result = this.converter.toXtend(_nameWithoutExtension, _text, this.myModule);
-    Assert.assertNotNull(result);
+    TestCase.assertNotNull(result);
     Iterable<String> _problems = result.getProblems();
     boolean _isEmpty = IterableExtensions.isEmpty(_problems);
-    Assert.assertTrue(_isEmpty);
+    TestCase.assertTrue(_isEmpty);
   }
   
   @Test
@@ -128,10 +128,10 @@ public class IdeaJavaConverterTest extends AbstractModelTestCase {
     final Iterable<PsiJavaFile> result = ConvertJavaCodeHandler.collectJavaFiles(new PsiElement[] { _parent_1, otherClazz });
     Iterator<PsiJavaFile> _iterator = result.iterator();
     boolean _hasNext = _iterator.hasNext();
-    Assert.assertTrue(_hasNext);
+    TestCase.assertTrue(_hasNext);
     Iterator<PsiJavaFile> _iterator_1 = result.iterator();
     int _size = IteratorExtensions.size(_iterator_1);
-    Assert.assertEquals(3, _size);
+    TestCase.assertEquals(3, _size);
   }
   
   public void testAnnotationDeclaration() throws Exception {

--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/macro/Bug473721.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/macro/Bug473721.java
@@ -9,7 +9,7 @@ package org.eclipse.xtend.idea.macro;
 
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
-import junit.framework.Assert;
+import junit.framework.TestCase;
 import org.eclipse.xtend.idea.LightXtendTest;
 import org.eclipse.xtend2.lib.StringConcatenation;
 
@@ -46,7 +46,7 @@ public class Bug473721 extends LightXtendTest {
     final PsiFile file = this.myFixture.addFileToProject("otherPackage/Bar.xtend", _builder_1.toString());
     VirtualFile _findFileInTempDir = this.myFixture.findFileInTempDir("xtend-gen/otherPackage/Bar.java");
     boolean _exists = _findFileInTempDir.exists();
-    Assert.assertTrue(_exists);
+    TestCase.assertTrue(_exists);
     VirtualFile _virtualFile = file.getVirtualFile();
     this.myFixture.testHighlighting(true, true, true, _virtualFile);
   }

--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/macro/IdeaProcessorProviderTest.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/macro/IdeaProcessorProviderTest.java
@@ -9,7 +9,7 @@ package org.eclipse.xtend.idea.macro;
 
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
-import junit.framework.Assert;
+import junit.framework.TestCase;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtend.core.idea.macro.IdeaProcessorProvider;
@@ -59,7 +59,7 @@ public class IdeaProcessorProviderTest extends LightXtendTest {
     final Object processor = this.provider.getProcessorInstance(processorType);
     Class<?> _class = processor.getClass();
     String _simpleName = _class.getSimpleName();
-    Assert.assertEquals("DataProcessor", _simpleName);
+    TestCase.assertEquals("DataProcessor", _simpleName);
   }
   
   @Test
@@ -86,26 +86,26 @@ public class IdeaProcessorProviderTest extends LightXtendTest {
       String _name = String.class.getName();
       Class<?> _loadClass = classLoader.loadClass(_name);
       ClassLoader _classLoader = _loadClass.getClassLoader();
-      Assert.assertNull(_classLoader);
+      TestCase.assertNull(_classLoader);
       ClassLoader _classLoader_1 = TransformationContext.class.getClassLoader();
       String _name_1 = TransformationContext.class.getName();
       Class<?> _loadClass_1 = classLoader.loadClass(_name_1);
       ClassLoader _classLoader_2 = _loadClass_1.getClassLoader();
-      Assert.assertEquals(_classLoader_1, _classLoader_2);
+      TestCase.assertEquals(_classLoader_1, _classLoader_2);
       ClassLoader _classLoader_3 = TransformationContext.class.getClassLoader();
       String _name_2 = Procedures.class.getName();
       Class<?> _loadClass_2 = classLoader.loadClass(_name_2);
       ClassLoader _classLoader_4 = _loadClass_2.getClassLoader();
-      Assert.assertEquals(_classLoader_3, _classLoader_4);
+      TestCase.assertEquals(_classLoader_3, _classLoader_4);
       ClassLoader _classLoader_5 = TransformationContext.class.getClassLoader();
       String _name_3 = Iterables.class.getName();
       Class<?> _loadClass_3 = classLoader.loadClass(_name_3);
       ClassLoader _classLoader_6 = _loadClass_3.getClassLoader();
-      Assert.assertEquals(_classLoader_5, _classLoader_6);
+      TestCase.assertEquals(_classLoader_5, _classLoader_6);
       String _identifier = processorType.getIdentifier();
       Class<?> _loadClass_4 = classLoader.loadClass(_identifier);
       ClassLoader _classLoader_7 = _loadClass_4.getClassLoader();
-      Assert.assertEquals(classLoader, _classLoader_7);
+      TestCase.assertEquals(classLoader, _classLoader_7);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/navigation/IdeaTraceTest.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/navigation/IdeaTraceTest.java
@@ -32,7 +32,7 @@ import java.io.ByteArrayInputStream;
 import java.net.URL;
 import java.util.List;
 import java.util.function.Consumer;
-import junit.framework.Assert;
+import junit.framework.TestCase;
 import org.eclipse.xtend.idea.LightXtendTest;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.generator.trace.AbsoluteURI;
@@ -70,7 +70,7 @@ public class IdeaTraceTest extends LightXtendTest {
       this.myFixture.addFileToProject("com/acme/MyClass.xtend", _builder.toString());
       final VirtualFile file = this.myFixture.findFileInTempDir("xtend-gen/com/acme/MyClass.java");
       boolean _exists = file.exists();
-      Assert.assertTrue(_exists);
+      TestCase.assertTrue(_exists);
       final String compiledContent = VfsUtil.loadText(file);
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append("package com.acme;");
@@ -83,16 +83,16 @@ public class IdeaTraceTest extends LightXtendTest {
       _builder_1.append("}");
       _builder_1.newLine();
       String _string = _builder_1.toString();
-      Assert.assertEquals(_string, compiledContent);
+      TestCase.assertEquals(_string, compiledContent);
       final VirtualFile traceFile = this.myFixture.findFileInTempDir("xtend-gen/com/acme/.MyClass.java._trace");
       boolean _exists_1 = file.exists();
-      Assert.assertTrue(_exists_1);
+      TestCase.assertTrue(_exists_1);
       byte[] _contentsToByteArray = traceFile.contentsToByteArray();
       ByteArrayInputStream _byteArrayInputStream = new ByteArrayInputStream(_contentsToByteArray);
       final AbstractTraceRegion trace = this.bareTraceReader.readTraceRegionFrom(_byteArrayInputStream);
       final SourceRelativeURI associatedPath = trace.getAssociatedSrcRelativePath();
       String _string_1 = associatedPath.toString();
-      Assert.assertEquals("com/acme/MyClass.xtend", _string_1);
+      TestCase.assertEquals("com/acme/MyClass.xtend", _string_1);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -111,7 +111,7 @@ public class IdeaTraceTest extends LightXtendTest {
     Project _project = file.getProject();
     VirtualFileInProject _virtualFileInProject = new VirtualFileInProject(_virtualFile, _project);
     final IIdeaTrace trace = this.traceProvider.getTraceToSource(_virtualFileInProject);
-    Assert.assertNull(trace);
+    TestCase.assertNull(trace);
   }
   
   public void testTraceToTarget() {
@@ -129,16 +129,16 @@ public class IdeaTraceTest extends LightXtendTest {
     final IIdeaTrace traceToTarget = this.traceProvider.getTraceToTarget(_virtualFileInProject);
     TextRegion _textRegion = new TextRegion(0, 1);
     final ILocationInVirtualFile noAssociatedLocation = traceToTarget.getBestAssociatedLocation(_textRegion);
-    Assert.assertNull(noAssociatedLocation);
+    TestCase.assertNull(noAssociatedLocation);
     TextRegion _textRegion_1 = new TextRegion(18, 1);
     final ILocationInVirtualFile associatedLocation = traceToTarget.getBestAssociatedLocation(_textRegion_1);
-    Assert.assertNotNull(associatedLocation);
+    TestCase.assertNotNull(associatedLocation);
     final SourceRelativeURI srcRelativeLocation = associatedLocation.getSrcRelativeResourceURI();
     String _string = srcRelativeLocation.toString();
-    Assert.assertEquals("com/acme/MyClass.java", _string);
+    TestCase.assertEquals("com/acme/MyClass.java", _string);
     AbsoluteURI _absoluteResourceURI = associatedLocation.getAbsoluteResourceURI();
     String _string_1 = _absoluteResourceURI.toString();
-    Assert.assertEquals("temp:///src/xtend-gen/com/acme/MyClass.java", _string_1);
+    TestCase.assertEquals("temp:///src/xtend-gen/com/acme/MyClass.java", _string_1);
   }
   
   @Ignore
@@ -170,7 +170,7 @@ public class IdeaTraceTest extends LightXtendTest {
     final IIdeaTrace traceToSource = this.traceProvider.getTraceToSource(_virtualFileInProject);
     TextRegion _textRegion = new TextRegion(8, 4);
     final ILocationInVirtualFile associatedLocation = traceToSource.getBestAssociatedLocation(_textRegion);
-    Assert.assertNotNull(associatedLocation);
+    TestCase.assertNotNull(associatedLocation);
   }
   
   public void testTraceForJar_01() {
@@ -184,13 +184,13 @@ public class IdeaTraceTest extends LightXtendTest {
     Project _project = this.getProject();
     VirtualFileInProject _virtualFileInProject = new VirtualFileInProject(generated, _project);
     final IIdeaTrace traceToSource = this.traceProvider.getTraceToSource(_virtualFileInProject);
-    Assert.assertNotNull(traceToSource);
+    TestCase.assertNotNull(traceToSource);
     Iterable<? extends ILocationInVirtualFile> _allAssociatedLocations = traceToSource.getAllAssociatedLocations();
     final Consumer<ILocationInVirtualFile> _function = (ILocationInVirtualFile it) -> {
       AbsoluteURI _absoluteResourceURI = it.getAbsoluteResourceURI();
       String _string = _absoluteResourceURI.toString();
       boolean _endsWith = _string.endsWith("smap-sources.jar!/de/itemis/HelloXtend.xtend");
-      Assert.assertTrue(_endsWith);
+      TestCase.assertTrue(_endsWith);
     };
     _allAssociatedLocations.forEach(_function);
   }
@@ -206,7 +206,7 @@ public class IdeaTraceTest extends LightXtendTest {
     Project _project = this.getProject();
     VirtualFileInProject _virtualFileInProject = new VirtualFileInProject(generated, _project);
     final IIdeaTrace traceToTarget = this.traceProvider.getTraceToTarget(_virtualFileInProject);
-    Assert.assertNull(traceToTarget);
+    TestCase.assertNull(traceToTarget);
   }
   
   public void addLibrary(final Module module, final VirtualFile bin, final VirtualFile src) {

--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/navigation/XtendNavigationTest.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/navigation/XtendNavigationTest.java
@@ -15,7 +15,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.impl.DebugUtil;
-import junit.framework.Assert;
+import junit.framework.TestCase;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtend.core.xtend.AnonymousClass;
 import org.eclipse.xtend.core.xtend.XtendClass;
@@ -841,13 +841,13 @@ public class XtendNavigationTest extends LightXtendTest {
       CaretModel _caretModel = _editor.getCaretModel();
       _caretModel.moveToOffset(referenceOffset);
       final PsiElement targetElement = this.myFixture.getElementAtCaret();
-      Assert.assertNotNull(targetElement);
+      TestCase.assertNotNull(targetElement);
       final PsiElement actualNavigationElement = targetElement.getNavigationElement();
       boolean _notEquals = (!Objects.equal(expectedNavigationElement, actualNavigationElement));
       if (_notEquals) {
         PsiFile _file = this.getFile();
         String _psiToString = DebugUtil.psiToString(_file, true, true);
-        Assert.assertEquals(_psiToString, expectedNavigationElement, actualNavigationElement);
+        TestCase.assertEquals(_psiToString, expectedNavigationElement, actualNavigationElement);
       }
       final EObject result = ((PsiEObject) targetElement).getEObject();
       Class<? extends EObject> _class = result.getClass();
@@ -855,7 +855,7 @@ public class XtendNavigationTest extends LightXtendTest {
       String _plus_1 = (_plus + expectedType);
       Class<? extends EObject> _class_1 = result.getClass();
       boolean _isAssignableFrom = expectedType.isAssignableFrom(_class_1);
-      Assert.assertTrue(_plus_1, _isAssignableFrom);
+      TestCase.assertTrue(_plus_1, _isAssignableFrom);
       _xblockexpression = ((T) result);
     }
     return _xblockexpression;
@@ -867,41 +867,38 @@ public class XtendNavigationTest extends LightXtendTest {
       PsiFile _file = this.getFile();
       int _startOffset = range.getStartOffset();
       PsiElement element = _file.findElementAt(_startOffset);
-      Assert.assertNotNull(element);
+      TestCase.assertNotNull(element);
       final PsiElement namedEObject = this.findPsiNamedEObject(element, range);
-      boolean _notEquals = (!Objects.equal(namedEObject, null));
-      if (_notEquals) {
+      if ((namedEObject != null)) {
         PsiElement _navigationElement = namedEObject.getNavigationElement();
-        Assert.assertEquals(namedEObject, _navigationElement);
+        TestCase.assertEquals(namedEObject, _navigationElement);
         return namedEObject;
       }
       while ((!Objects.equal(element.getTextRange(), range))) {
         {
           PsiElement _parent = element.getParent();
           element = _parent;
-          Assert.assertNotNull(element);
+          TestCase.assertNotNull(element);
         }
       }
       PsiElement _navigationElement_1 = element.getNavigationElement();
-      Assert.assertEquals(element, _navigationElement_1);
+      TestCase.assertEquals(element, _navigationElement_1);
       _xblockexpression = element;
     }
     return _xblockexpression;
   }
   
   protected PsiElement findPsiNamedEObject(final PsiElement element, final TextRange identifierRange) {
-    boolean _equals = Objects.equal(element, null);
-    if (_equals) {
+    if ((element == null)) {
       return null;
     }
     if ((element instanceof PsiNamedEObject)) {
       final PsiEObjectIdentifier nameIdentifier = ((PsiNamedEObject)element).getNameIdentifier();
-      boolean _notEquals = (!Objects.equal(nameIdentifier, null));
-      if (_notEquals) {
+      if ((nameIdentifier != null)) {
         PsiNamedEObject _xifexpression = null;
         TextRange _textRange = nameIdentifier.getTextRange();
-        boolean _equals_1 = Objects.equal(_textRange, identifierRange);
-        if (_equals_1) {
+        boolean _equals = Objects.equal(_textRange, identifierRange);
+        if (_equals) {
           _xifexpression = ((PsiNamedEObject)element);
         } else {
           _xifexpression = null;

--- a/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/psi/XtextPsiReferenceTest.java
+++ b/org.eclipse.xtend.idea.tests/xtend-gen/org/eclipse/xtend/idea/psi/XtextPsiReferenceTest.java
@@ -15,7 +15,7 @@ import com.intellij.psi.PsiField;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiReference;
-import junit.framework.Assert;
+import junit.framework.TestCase;
 import org.eclipse.xtend.idea.LightXtendTest;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.junit.Test;
@@ -57,7 +57,7 @@ public class XtextPsiReferenceTest extends LightXtendTest {
     String _plus = (textRange + " ");
     String _plus_1 = (_plus + Integer.valueOf(textOffset));
     boolean _contains = textRange.contains(textOffset);
-    Assert.assertTrue(_plus_1, _contains);
+    TestCase.assertTrue(_plus_1, _contains);
   }
   
   @Test
@@ -80,9 +80,9 @@ public class XtextPsiReferenceTest extends LightXtendTest {
     final PsiElement referencedElement = reference.resolve();
     if ((referencedElement instanceof PsiClass)) {
       String _qualifiedName = ((PsiClass)referencedElement).getQualifiedName();
-      Assert.assertEquals("java.lang.String", _qualifiedName);
+      TestCase.assertEquals("java.lang.String", _qualifiedName);
     } else {
-      Assert.fail(("" + referencedElement));
+      TestCase.fail(("" + referencedElement));
     }
   }
   
@@ -117,7 +117,7 @@ public class XtextPsiReferenceTest extends LightXtendTest {
     final int index = model.indexOf("Bar");
     final PsiReference reference = file.findReferenceAt(index);
     final PsiElement referencedElement = reference.resolve();
-    Assert.assertEquals(psiClass, referencedElement);
+    TestCase.assertEquals(psiClass, referencedElement);
   }
   
   @Test
@@ -146,11 +146,11 @@ public class XtextPsiReferenceTest extends LightXtendTest {
     final PsiElement referencedElement = reference.resolve();
     if ((referencedElement instanceof PsiMethod)) {
       boolean _isConstructor = ((PsiMethod)referencedElement).isConstructor();
-      Assert.assertTrue(_isConstructor);
+      TestCase.assertTrue(_isConstructor);
       String _name = ((PsiMethod)referencedElement).getName();
-      Assert.assertEquals("String", _name);
+      TestCase.assertEquals("String", _name);
     } else {
-      Assert.fail(("" + referencedElement));
+      TestCase.fail(("" + referencedElement));
     }
   }
   
@@ -192,9 +192,9 @@ public class XtextPsiReferenceTest extends LightXtendTest {
     final PsiElement referencedElement = reference.resolve();
     if ((referencedElement instanceof PsiField)) {
       String _name = ((PsiField)referencedElement).getName();
-      Assert.assertEquals("myField", _name);
+      TestCase.assertEquals("myField", _name);
     } else {
-      Assert.fail(("" + referencedElement));
+      TestCase.fail(("" + referencedElement));
     }
   }
   
@@ -236,9 +236,9 @@ public class XtextPsiReferenceTest extends LightXtendTest {
     final PsiElement referencedElement = reference.resolve();
     if ((referencedElement instanceof PsiEnumConstant)) {
       String _name = ((PsiEnumConstant)referencedElement).getName();
-      Assert.assertEquals("MY_ENUM_LITERAL", _name);
+      TestCase.assertEquals("MY_ENUM_LITERAL", _name);
     } else {
-      Assert.fail(("" + referencedElement));
+      TestCase.fail(("" + referencedElement));
     }
   }
   
@@ -273,7 +273,7 @@ public class XtextPsiReferenceTest extends LightXtendTest {
     final int index = model.indexOf("valueOf");
     final PsiReference reference = file.findReferenceAt(index);
     final PsiElement referencedElement = reference.resolve();
-    Assert.assertEquals(psiClass, referencedElement);
+    TestCase.assertEquals(psiClass, referencedElement);
   }
   
   @Test
@@ -307,7 +307,7 @@ public class XtextPsiReferenceTest extends LightXtendTest {
     final int index = model.indexOf("values");
     final PsiReference reference = file.findReferenceAt(index);
     final PsiElement referencedElement = reference.resolve();
-    Assert.assertEquals(psiClass, referencedElement);
+    TestCase.assertEquals(psiClass, referencedElement);
   }
   
   @Test
@@ -354,11 +354,11 @@ public class XtextPsiReferenceTest extends LightXtendTest {
     final PsiElement referencedElement = reference.resolve();
     if ((referencedElement instanceof PsiMethod)) {
       boolean _isConstructor = ((PsiMethod)referencedElement).isConstructor();
-      Assert.assertFalse(_isConstructor);
+      TestCase.assertFalse(_isConstructor);
       String _name = ((PsiMethod)referencedElement).getName();
-      Assert.assertEquals("myMethod", _name);
+      TestCase.assertEquals("myMethod", _name);
     } else {
-      Assert.fail(("" + referencedElement));
+      TestCase.fail(("" + referencedElement));
     }
   }
 }


### PR DESCRIPTION
Changes due to regenerated Xtend code.
Base class com.intellij.testFramework.UsefulTestCase extends
junit.framework.TestCase, which defines the static assert-methods.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>