### PR TITLE
[502897] Bundle-Vendor changed

### DIFF
--- a/org.eclipse.xtend.caliper.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.caliper.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Xtend Microbenchmarks
 Bundle-SymbolicName: org.eclipse.xtend.caliper.tests
 Bundle-Version: 2.11.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Vendor: Eclipse Xtend
+Bundle-Vendor: Eclipse Xtext
 Require-Bundle: com.google.inject;bundle-version="3.0.0",
  org.eclipse.emf.ecore;bundle-version="2.10.2",
  com.google.guava;bundle-version="[14.0.0,19.0.0)",

--- a/org.eclipse.xtend.core.tests.java8/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.core.tests.java8/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Xtend Core Java 8 Tests
 Bundle-SymbolicName: org.eclipse.xtend.core.tests.java8
 Bundle-Version: 2.11.0.qualifier
-Bundle-Vendor: Eclipse Xtend
+Bundle-Vendor: Eclipse Xtext
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.xtend.core,
  org.eclipse.xtend.core.tests,

--- a/org.eclipse.xtend.core.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.core.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Xtend Core Tests
 Bundle-SymbolicName: org.eclipse.xtend.core.tests
 Bundle-Version: 2.11.0.qualifier
-Bundle-Vendor: Eclipse Xtend
+Bundle-Vendor: Eclipse Xtext
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.xtend.core,
  org.eclipse.xtext.junit4,

--- a/org.eclipse.xtend.core/plugin.properties
+++ b/org.eclipse.xtend.core/plugin.properties
@@ -8,4 +8,4 @@
 ###############################################################################
 
 pluginName = Xtend Core
-providerName = Eclipse Xtend
+providerName = Eclipse Xtext

--- a/org.eclipse.xtend.doc/plugin.properties
+++ b/org.eclipse.xtend.doc/plugin.properties
@@ -15,4 +15,4 @@
 # ====================================================================
 
 pluginName = Xtend Documentation 
-providerName = Eclipse Xtend
+providerName = Eclipse Xtext

--- a/org.eclipse.xtend.examples/plugin.properties
+++ b/org.eclipse.xtend.examples/plugin.properties
@@ -8,7 +8,7 @@
 ###############################################################################
 
 pluginName = Xtend Examples 
-providerName = Eclipse Xtend
+providerName = Eclipse Xtext
 XtendExamples_category=Xtend Examples
 XtendExamples_category2=Examples
 XtendTutorial_name=Xtend Introductory Examples

--- a/org.eclipse.xtend.examples/projects/xtend-annotation-examples-client/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.examples/projects/xtend-annotation-examples-client/META-INF/MANIFEST.MF
@@ -8,5 +8,5 @@ Require-Bundle: org.eclipse.xtend.lib,
  com.google.guava;bundle-version="[14.0.0,19.0.0)",
  org.eclipse.xtext.xbase.lib,
  xtend-annotation-examples;bundle-version="2.4.3"
-Bundle-Vendor: Eclipse Xtend
+Bundle-Vendor: Eclipse Xtext
 

--- a/org.eclipse.xtend.examples/projects/xtend-annotation-examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.examples/projects/xtend-annotation-examples/META-INF/MANIFEST.MF
@@ -20,5 +20,5 @@ Export-Package: extract,
  i18n,
  lazy,
  observables
-Bundle-Vendor: Eclipse Xtend
+Bundle-Vendor: Eclipse Xtext
 

--- a/org.eclipse.xtend.examples/projects/xtend-examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.examples/projects/xtend-examples/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Xtend Tutorial
 Bundle-SymbolicName: xtend-examples
 Bundle-Version: 2.11.0.qualifier
-Bundle-Vendor: Eclipse Xtend
+Bundle-Vendor: Eclipse Xtext
 Require-Bundle: org.eclipse.xtext.xbase.lib,
  org.eclipse.xtend.lib,
  org.junit;bundle-version="4.5.0"

--- a/org.eclipse.xtend.gwt.feature/feature.properties
+++ b/org.eclipse.xtend.gwt.feature/feature.properties
@@ -1,3 +1,3 @@
 featureName=Xtend Library for GWT
 description=The GWT-compatible version of Xtend's runtime library. (http://www.gwtproject.org)
-providerName=Eclipse Xtend
+providerName=Eclipse Xtext

--- a/org.eclipse.xtend.ide.common/plugin.properties
+++ b/org.eclipse.xtend.ide.common/plugin.properties
@@ -8,4 +8,4 @@
 ###############################################################################
 
 pluginName = Xtend IDE Common
-providerName = Eclipse Xtend
+providerName = Eclipse Xtext

--- a/org.eclipse.xtend.ide.swtbot.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.ide.swtbot.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Xtend SWT Tests
 Bundle-SymbolicName: org.eclipse.xtend.ide.swtbot.tests
 Bundle-Version: 2.11.0.qualifier
-Bundle-Vendor: Eclipse Xtend
+Bundle-Vendor: Eclipse Xtext
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.apache.log4j;version="1.2.15",
  org.junit;version="4.5.0",

--- a/org.eclipse.xtend.ide.tests.data/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.ide.tests.data/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Plug-in for testing restricted access
 Bundle-SymbolicName: org.eclipse.xtend.ide.tests.data
 Bundle-Version: 2.11.0.qualifier
-Bundle-Vendor: Eclipse Xtend
+Bundle-Vendor: Eclipse Xtext
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtend.core.tests.internal;x-internal:=true,
  org.eclipse.xtend.ide.tests.data,

--- a/org.eclipse.xtend.ide.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.ide.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Xtend UI Tests
 Bundle-SymbolicName: org.eclipse.xtend.ide.tests
 Bundle-Version: 2.11.0.qualifier
-Bundle-Vendor: Eclipse Xtend
+Bundle-Vendor: Eclipse Xtext
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.xtend.core,
  org.eclipse.xtext.junit4,

--- a/org.eclipse.xtend.ide/plugin.properties
+++ b/org.eclipse.xtend.ide/plugin.properties
@@ -8,7 +8,7 @@
 ###############################################################################
 
 pluginName = Xtend IDE
-providerName = Eclipse Xtend
+providerName = Eclipse Xtext
 
 JavaLaunchShortcut.description=Launches a local Java application
 JavaApplicationShortcut.label=Java Application

--- a/org.eclipse.xtend.m2e/plugin.properties
+++ b/org.eclipse.xtend.m2e/plugin.properties
@@ -17,4 +17,4 @@
 # ====================================================================
 
 pluginName = Xtend m2e Integration 
-providerName = Eclipse Xtend
+providerName = Eclipse Xtext

--- a/org.eclipse.xtend.performance.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.performance.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Xtend Benchmarks
 Bundle-SymbolicName: org.eclipse.xtend.performance.tests
 Bundle-Version: 2.11.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Vendor: Eclipse Xtend
+Bundle-Vendor: Eclipse Xtext
 Bundle-ClassPath: .
 Require-Bundle: com.google.inject;bundle-version="3.0.0",
  org.eclipse.emf.ecore;bundle-version="2.9.0",

--- a/org.eclipse.xtend.sdk.feature/feature.properties
+++ b/org.eclipse.xtend.sdk.feature/feature.properties
@@ -1,4 +1,4 @@
 featureName=Xtend IDE
 
-providerName=Eclipse Xtend
+providerName=Eclipse Xtext
 description=The Xtend Eclipse Plug-in. Includes everything you need to get started with programming Xtend in Eclipse.

--- a/org.eclipse.xtend.standalone/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.standalone/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.xtend.standalone
 Bundle-Name: Xtend Standalone Bundle
-Bundle-Vendor: Eclipse Xtend
+Bundle-Vendor: Eclipse Xtext
 Bundle-Version: 2.11.0.qualifier
 Require-Bundle: org.eclipse.xtend.core;visibility:=reexport,
  org.eclipse.xtext.junit4;visibility:=reexport,

--- a/org.eclipse.xtend.swtbot/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.swtbot/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Xtend Fragment for SWTBot
 Bundle-SymbolicName: org.eclipse.xtend.swtbot
 Bundle-Version: 2.11.0.qualifier
-Bundle-Vendor: Eclipse Xtend
+Bundle-Vendor: Eclipse Xtext
 Fragment-Host: org.eclipse.swtbot.swt.finder;bundle-version="2.1.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8


### PR DESCRIPTION
Must be Eclipse Xtext instead of Eclipse Xtend, see #48

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>