### PR TITLE
[492072] Fixed compile issue for RichString in feature calls

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.xtend
@@ -13,7 +13,7 @@ import org.eclipse.xtext.generator.IFilePostProcessor
 import org.junit.Test
 
 class XtendCompilerTest extends AbstractXtendCompilerTest {
-
+	static String RS = "'''";
 	@Inject protected IFilePostProcessor postProcessor
 
 	@Test
@@ -4202,8 +4202,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 				  public String test() {
 				    StringConcatenation _builder = new StringConcatenation();
 				    _builder.append("SomeString");
-				    String _string = _builder.toString();
-				    return _string;
+				    return _builder.toString();
 				  }
 				}
 			''')
@@ -4282,6 +4281,65 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 				  }
 				}
 			''')
+	}
+	
+	@Test
+	def testRichStringMemberFeatureCall_01 () {
+		'''
+			class Foo {
+				def void bar () {
+					x = «RS»Hello World«RS».toString
+				}
+				
+				def void setX (String s) {
+					
+				}
+			}
+		'''.assertCompilesTo('''
+			import org.eclipse.xtend2.lib.StringConcatenation;
+			
+			@SuppressWarnings("all")
+			public class Foo {
+			  public void bar() {
+			    StringConcatenation _builder = new StringConcatenation();
+			    _builder.append("Hello World");
+			    this.setX(_builder.toString());
+			  }
+			  
+			  public void setX(final String s) {
+			  }
+			}
+		''')
+	}
+
+	@Test
+	def testRichStringMemberFeatureCall_02 () {
+		'''
+			class Foo {
+				def void bar () {
+					x = «RS»Hello World«RS».toString.trim
+				}
+				
+				def void setX (String s) {
+					
+				}
+			}
+		'''.assertCompilesTo('''
+			import org.eclipse.xtend2.lib.StringConcatenation;
+			
+			@SuppressWarnings("all")
+			public class Foo {
+			  public void bar() {
+			    StringConcatenation _builder = new StringConcatenation();
+			    _builder.append("Hello World");
+			    String _string = _builder.toString();
+			    this.setX(_string.trim());
+			  }
+			  
+			  public void setX(final String s) {
+			  }
+			}
+		''')
 	}
 
 	@Test

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 
 @SuppressWarnings("all")
 public class XtendCompilerTest extends AbstractXtendCompilerTest {
+  private static String RS = "\'\'\'";
+  
   @Inject
   protected IFilePostProcessor postProcessor;
   
@@ -9361,10 +9363,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder.append("_builder.append(\"SomeString\");");
     _builder.newLine();
     _builder.append("    ");
-    _builder.append("String _string = _builder.toString();");
-    _builder.newLine();
-    _builder.append("    ");
-    _builder.append("return _string;");
+    _builder.append("return _builder.toString();");
     _builder.newLine();
     _builder.append("  ");
     _builder.append("}");
@@ -9504,6 +9503,141 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder.newLine();
     this.assertCompilesTo(
       "class Foo { def test(){ System::out.println(println(\'\'\'SomeString\'\'\')) } }", _builder);
+  }
+  
+  @Test
+  public void testRichStringMemberFeatureCall_01() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def void bar () {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("x = ");
+    _builder.append(XtendCompilerTest.RS, "\t\t");
+    _builder.append("Hello World");
+    _builder.append(XtendCompilerTest.RS, "\t\t");
+    _builder.append(".toString");
+    _builder.newLineIfNotEmpty();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def void setX (String s) {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import org.eclipse.xtend2.lib.StringConcatenation;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public void bar() {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("StringConcatenation _builder = new StringConcatenation();");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("_builder.append(\"Hello World\");");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("this.setX(_builder.toString());");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public void setX(final String s) {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
+  }
+  
+  @Test
+  public void testRichStringMemberFeatureCall_02() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def void bar () {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("x = ");
+    _builder.append(XtendCompilerTest.RS, "\t\t");
+    _builder.append("Hello World");
+    _builder.append(XtendCompilerTest.RS, "\t\t");
+    _builder.append(".toString.trim");
+    _builder.newLineIfNotEmpty();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def void setX (String s) {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import org.eclipse.xtend2.lib.StringConcatenation;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public void bar() {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("StringConcatenation _builder = new StringConcatenation();");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("_builder.append(\"Hello World\");");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("String _string = _builder.toString();");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("this.setX(_string.trim());");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public void setX(final String s) {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
   }
   
   @Test

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendCompiler.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendCompiler.java
@@ -40,6 +40,7 @@ import org.eclipse.xtext.common.types.JvmTypeReference;
 import org.eclipse.xtext.generator.trace.LocationData;
 import org.eclipse.xtext.util.ITextRegionWithLineInformation;
 import org.eclipse.xtext.util.Strings;
+import org.eclipse.xtext.xbase.XAbstractFeatureCall;
 import org.eclipse.xtext.xbase.XCatchClause;
 import org.eclipse.xtext.xbase.XClosure;
 import org.eclipse.xtext.xbase.XConstructorCall;
@@ -47,7 +48,6 @@ import org.eclipse.xtext.xbase.XExpression;
 import org.eclipse.xtext.xbase.XFeatureCall;
 import org.eclipse.xtext.xbase.XForLoopExpression;
 import org.eclipse.xtext.xbase.XListLiteral;
-import org.eclipse.xtext.xbase.XMemberFeatureCall;
 import org.eclipse.xtext.xbase.XStringLiteral;
 import org.eclipse.xtext.xbase.XVariableDeclaration;
 import org.eclipse.xtext.xbase.XbasePackage;
@@ -585,10 +585,6 @@ public class XtendCompiler extends XbaseCompiler {
 					}
 				}
 			}
-		}
-		if (!result && expr instanceof XMemberFeatureCall && 
-				((XMemberFeatureCall)expr).getMemberCallTarget() instanceof RichString) {
-			return true;
 		}
 		return result;
 	}


### PR DESCRIPTION
The XtendCompiler failed with an exception when used without variable
declaration for a feature call.

The new test XtendCompilerTest#testRichStringMemberFeatureCall
reproduces the situation.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>