### PR TITLE
Fixed broken XtendCompilerAntTaskTest. Added missing test resources.Fixes #126

### DIFF
--- a/org.eclipse.xtend.core.tests/batch-compiler-data/bug396747/test/EmptyFile.xtend
+++ b/org.eclipse.xtend.core.tests/batch-compiler-data/bug396747/test/EmptyFile.xtend
@@ -1,5 +1,0 @@
-//package test
-//
-//class EmptyFile {
-//	
-//}

--- a/org.eclipse.xtend.ide.tests/batch-compiler-data/bug396747/test/EmptyFile.xtend
+++ b/org.eclipse.xtend.ide.tests/batch-compiler-data/bug396747/test/EmptyFile.xtend
@@ -1,0 +1,5 @@
+//package test
+//
+//class EmptyFile {
+//	
+//}

--- a/org.eclipse.xtend.ide.tests/batch-compiler-data/test data/test/B.xtend
+++ b/org.eclipse.xtend.ide.tests/batch-compiler-data/test data/test/B.xtend
@@ -1,0 +1,8 @@
+package test
+// Test for Bug 377648
+class B implements TestInterface{
+
+	override void test() {
+		new C().test()
+	}
+}

--- a/org.eclipse.xtend.ide.tests/batch-compiler-data/test data/test/C.xtend
+++ b/org.eclipse.xtend.ide.tests/batch-compiler-data/test data/test/C.xtend
@@ -1,0 +1,6 @@
+package test
+// Test for Bug 377648
+class C {
+	def test() {
+	}
+}

--- a/org.eclipse.xtend.ide.tests/batch-compiler-data/test data/test/JavaB.java
+++ b/org.eclipse.xtend.ide.tests/batch-compiler-data/test data/test/JavaB.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package test;
+
+/**
+ * @author efftinge - Initial contribution and API
+ */
+public class JavaB extends XtendC {
+	public XtendA foo(XtendC test) {
+		XtendA result = new XtendA();
+		result.test2(new XtendB());
+		test.test( result);
+		return result;
+	}
+}

--- a/org.eclipse.xtend.ide.tests/batch-compiler-data/test data/test/OtherTypes.xtend
+++ b/org.eclipse.xtend.ide.tests/batch-compiler-data/test data/test/OtherTypes.xtend
@@ -1,0 +1,12 @@
+package test 
+
+annotation Annotation {	
+}
+
+interface Interface {
+	def void foo()	
+}
+
+enum Enum {
+	FOO, BAR, BAZ
+}

--- a/org.eclipse.xtend.ide.tests/batch-compiler-data/test data/test/TestInterface.java
+++ b/org.eclipse.xtend.ide.tests/batch-compiler-data/test data/test/TestInterface.java
@@ -1,0 +1,6 @@
+package test;
+//Test for Bug 377648
+public interface TestInterface {
+
+	void test();
+}

--- a/org.eclipse.xtend.ide.tests/batch-compiler-data/test data/test/XtendA.xtend
+++ b/org.eclipse.xtend.ide.tests/batch-compiler-data/test data/test/XtendA.xtend
@@ -1,0 +1,17 @@
+package test
+
+import test.JavaB
+import test.XtendC
+
+@SuppressWarnings("just here to trigger annotation processing")
+class XtendA extends JavaB {
+	
+	def JavaB test2(XtendC s) {
+		return s.foo.newJavaB
+	}
+	
+	def JavaB newJavaB() {
+		return new JavaB()
+	}
+	
+}

--- a/org.eclipse.xtend.ide.tests/batch-compiler-data/test data/test/XtendC.xtend
+++ b/org.eclipse.xtend.ide.tests/batch-compiler-data/test data/test/XtendC.xtend
@@ -1,0 +1,11 @@
+package test
+
+import test.JavaB
+import test.XtendA
+
+@SuppressWarnings("just here to trigger annotation processing")
+class XtendC {
+	def JavaB test(XtendA s) {
+		return null
+	}
+}

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/compiler/batch/XtendCompilerAntTaskTest.java
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/compiler/batch/XtendCompilerAntTaskTest.java
@@ -22,14 +22,11 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @author Dennis Huebner - Initial contribution and API
  */
-// https://github.com/eclipse/xtext-xtend/issues/126
-@Ignore
 public class XtendCompilerAntTaskTest {
 	protected Project project;
 	private StringBuffer outBuffer;


### PR DESCRIPTION
Fixed broken XtendCompilerAntTaskTest. Added missing test resources.Fixes #126

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>