### PR TITLE
do rich string highlighting inside constrcutors as well. fixes #49

### DIFF
--- a/org.eclipse.xtend.ide.common/src/org/eclipse/xtend/ide/common/highlighting/XtendHighlightingCalculator.java
+++ b/org.eclipse.xtend.ide.common/src/org/eclipse/xtend/ide/common/highlighting/XtendHighlightingCalculator.java
@@ -143,6 +143,7 @@ public class XtendHighlightingCalculator extends XbaseHighlightingCalculator imp
 					highlightElement((XtendField) object, acceptor, cancelIndicator);
 					break;
 				case XtendPackage.XTEND_CONSTRUCTOR:
+					highlightElement((XtendConstructor) object, acceptor, cancelIndicator);
 					break;
 				case XtendPackage.XTEND_FUNCTION:
 					highlightElement((XtendFunction) object, acceptor, cancelIndicator);
@@ -188,6 +189,14 @@ public class XtendHighlightingCalculator extends XbaseHighlightingCalculator imp
 		
 		XExpression initializer = field.getInitialValue();
 		highlightRichStrings(initializer, acceptor);
+	}
+	
+	/**
+	 * @since 2.12
+	 */
+	protected void highlightElement(XtendConstructor function, IHighlightedPositionAcceptor acceptor, CancelIndicator cancelIndicator) {
+		XExpression rootExpression = function.getExpression();
+		highlightRichStrings(rootExpression, acceptor);
 	}
 	
 	protected void highlightElement(XtendFunction function, IHighlightedPositionAcceptor acceptor, CancelIndicator cancelIndicator) {

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/highlighting/XtendHighlightingCalculatorTest.java
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/highlighting/XtendHighlightingCalculatorTest.java
@@ -733,7 +733,16 @@ public class XtendHighlightingCalculatorTest extends AbstractXtendTestCase imple
 		expectAbsolute(model.indexOf("1"), 1, HighlightingStyles.NUMBER_ID);
 		highlight(model);
 	}
-
+	
+	@Test
+	public void testIssue49() {
+		String model =
+			"new() {\n    val x = '''\n        demo\n    '''\n}";
+		expectInsignificant(model.indexOf("demo")-8, 8);
+		expectInsignificant(model.indexOf("demo")+5, 4);
+		highlight(model);
+	}
+	
 	protected void highlight(String functionBody) {
 		try {
 			EObject model = member(functionBody);


### PR DESCRIPTION
do rich string highlighting inside constrcutors as well. fixes #49

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>