### PR TITLE
[477445] dont use richstring inside annotations for j2x

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/javaconverter/JavaConverterTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/javaconverter/JavaConverterTest.xtend
@@ -1769,6 +1769,28 @@ public String loadingURI='''classpath:/«('''«someVar»LoadingResourceWithError'''
 		assertTrue("Force statement when parent is executable", j2x.shouldForceStatementMode(block))
 	}
 	
+	@Test
+	def testBug477445() {
+		var xtendCode = toXtendCode('''
+			public class Foo {
+				
+				private static final String CONSTANT = "depre";
+				
+				@SuppressWarnings(CONSTANT+"cation") public String toString() {
+					return "bar";
+				}
+			}
+		''')
+		val expected = '''
+			class Foo {
+				static final String CONSTANT="depre"
+				@SuppressWarnings(CONSTANT + "cation")override String toString() {
+					return "bar" 
+				}
+			}'''
+		assertEquals(expected, xtendCode)
+	}
+	
 	def protected XtendClass toValidXtendClass(CharSequence javaCode) throws Exception {
 		return toValidTypeDeclaration("Clazz", javaCode) as XtendClass
 	}

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/javaconverter/JavaConverterTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/javaconverter/JavaConverterTest.java
@@ -33,6 +33,7 @@ import org.eclipse.xtext.xbase.XStringLiteral;
 import org.eclipse.xtext.xbase.annotations.xAnnotations.impl.XAnnotationsFactoryImpl;
 import org.eclipse.xtext.xbase.impl.XbaseFactoryImpl;
 import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.InputOutput;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.junit.Assert;
@@ -3217,6 +3218,54 @@ public class JavaConverterTest extends AbstractXtendTestCase {
     final XBlockExpression block = new XbaseFactoryImpl().createXBlockExpression();
     xc.setExpression(block);
     Assert.assertTrue("Force statement when parent is executable", this.j2x.shouldForceStatementMode(block));
+  }
+  
+  @Test
+  public void testBug477445() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("public class Foo {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("private static final String CONSTANT = \"depre\";");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("@SuppressWarnings(CONSTANT+\"cation\") public String toString() {");
+      _builder.newLine();
+      _builder.append("\t\t");
+      _builder.append("return \"bar\";");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("}");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      String xtendCode = this.toXtendCode(_builder);
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("class Foo {");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("static final String CONSTANT=\"depre\"");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("@SuppressWarnings(CONSTANT + \"cation\")override String toString() {");
+      _builder_1.newLine();
+      _builder_1.append("\t\t");
+      _builder_1.append("return \"bar\" ");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("}");
+      _builder_1.newLine();
+      _builder_1.append("}");
+      final String expected = _builder_1.toString();
+      Assert.assertEquals(expected, xtendCode);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
   }
   
   protected XtendClass toValidXtendClass(final CharSequence javaCode) throws Exception {

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/javaconverter/ASTFlattenerUtils.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/javaconverter/ASTFlattenerUtils.xtend
@@ -47,6 +47,7 @@ import org.eclipse.jdt.core.dom.VariableDeclaration
 import org.eclipse.jdt.core.dom.VariableDeclarationExpression
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement
+import org.eclipse.jdt.core.dom.SingleMemberAnnotation
 
 /**
  * @author dhuebner - Initial contribution and API
@@ -197,6 +198,10 @@ class ASTFlattenerUtils {
 			// Do not convert static final fields
 			if (typeDeclr.isInterface || parentFieldDecl.modifiers().isFinal && parentFieldDecl.modifiers().isStatic)
 				return false
+		}
+		val parentSingleMemberAnnotation = node.findParentOfType(SingleMemberAnnotation)
+		if (parentSingleMemberAnnotation !== null) {
+			return false
 		}
 		val nodes = node.collectCompatibleNodes()
 		return !nodes.empty && nodes.forall[canTranslate]

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/javaconverter/ASTFlattenerUtils.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/javaconverter/ASTFlattenerUtils.java
@@ -43,6 +43,7 @@ import org.eclipse.jdt.core.dom.PrimitiveType;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.ReturnStatement;
 import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SingleMemberAnnotation;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.StringLiteral;
@@ -231,6 +232,10 @@ public class ASTFlattenerUtils {
       if ((typeDeclr.isInterface() || (this.isFinal(parentFieldDecl.modifiers()) && this.isStatic(parentFieldDecl.modifiers())))) {
         return false;
       }
+    }
+    final SingleMemberAnnotation parentSingleMemberAnnotation = this.<SingleMemberAnnotation>findParentOfType(node, SingleMemberAnnotation.class);
+    if ((parentSingleMemberAnnotation != null)) {
+      return false;
     }
     final Iterable<StringLiteral> nodes = this.collectCompatibleNodes(node);
     return ((!IterableExtensions.isEmpty(nodes)) && IterableExtensions.<StringLiteral>forall(nodes, ((Function1<StringLiteral, Boolean>) (StringLiteral it) -> {


### PR DESCRIPTION
[477445] dont use richstring inside annotations for j2x

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>