### PR TITLE
[446145] fixed replacement context length calculation for javadoc proposals

### DIFF
--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/contentassist/javadoc/XtendJavaDocProposalFactory.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/contentassist/javadoc/XtendJavaDocProposalFactory.java
@@ -10,9 +10,11 @@ package org.eclipse.xtend.ide.contentassist.javadoc;
 import org.eclipse.xtext.Assignment;
 import org.eclipse.xtext.Keyword;
 import org.eclipse.xtext.RuleCall;
+import org.eclipse.xtext.nodemodel.INode;
 import org.eclipse.xtext.ui.editor.contentassist.AbstractContentProposalProvider;
 import org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext;
 import org.eclipse.xtext.ui.editor.contentassist.ICompletionProposalAcceptor;
+import org.eclipse.xtext.util.ITextRegion;
 
 /**
  * @author Holger Schill - Initial contribution and API
@@ -27,5 +29,23 @@ public class XtendJavaDocProposalFactory extends AbstractContentProposalProvider
 
 	@Override
 	public void completeAssignment(Assignment object, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {}
+	
+	@Override
+	protected int getReplacementContextLength(ContentAssistContext context) {
+		int replacementOffset = context.getReplaceRegion().getOffset();
+		INode currentNode = context.getCurrentNode();
+		ITextRegion currentRegion = currentNode.getTextRegion();
+		String text = currentNode.getText();
+		int index = text.indexOf('}', replacementOffset - currentRegion.getOffset());
+		if (index == -1) {
+			index = text.indexOf('\n', replacementOffset - currentRegion.getOffset());
+		}
+		if (index != -1) {
+			int indexFromStart = index + currentNode.getOffset();
+			return indexFromStart - replacementOffset;
+		} else {
+			return context.getReplaceContextLength();
+		}
+	}
 
 }


### PR DESCRIPTION
[446145] fixed replacement context length calculation for javadoc proposals

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>