### PR TITLE
[445698] Xtend serializer produces ambiguous syntax related to anonymous classes

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/serializer/AbstractXtendTestData.java
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/serializer/AbstractXtendTestData.java
@@ -237,5 +237,19 @@ public abstract class AbstractXtendTestData extends AbstractXtendTestCase {
 		str.append("}");
 		doTest(str.toString());
 	}
+	
+	@Test public void testBug445698() throws Exception {
+		StringBuilder str = new StringBuilder();
+		str.append("class MoreBlocks {\n");
+		str.append("    def i_am_created() {\n");
+		str.append("        val s = new java.util.Stack<Integer>;\n");
+		str.append("        {\n");
+		str.append("            val x = 0\n");
+		str.append("            println(x)\n");
+		str.append("        }\n");
+		str.append("    }\n");
+		str.append("}");
+		doTest(str.toString());
+	}
 
 }

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/serializer/XtendSyntacticSequencer.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/serializer/XtendSyntacticSequencer.java
@@ -1,5 +1,85 @@
 package org.eclipse.xtend.core.serializer;
 
+import java.util.List;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.Keyword;
+import org.eclipse.xtext.RuleCall;
+import org.eclipse.xtext.nodemodel.ICompositeNode;
+import org.eclipse.xtext.nodemodel.ILeafNode;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.serializer.analysis.ISyntacticSequencerPDAProvider.ISynNavigable;
+import org.eclipse.xtext.xbase.XBinaryOperation;
+import org.eclipse.xtext.xbase.XBlockExpression;
+import org.eclipse.xtext.xbase.XConstructorCall;
+import org.eclipse.xtext.xbase.XExpression;
+import org.eclipse.xtext.xbase.XForLoopExpression;
+import org.eclipse.xtext.xbase.XIfExpression;
+import org.eclipse.xtext.xbase.XPostfixOperation;
+import org.eclipse.xtext.xbase.XTryCatchFinallyExpression;
+import org.eclipse.xtext.xbase.XUnaryOperation;
 
 public class XtendSyntacticSequencer extends AbstractXtendSyntacticSequencer {
+	
+	boolean semicolonBeforeNextExpressionRequired = false;
+	
+	/**
+	 * Syntax: '('*
+	 */
+	@Override
+	protected void emit_XParenthesizedExpression_LeftParenthesisKeyword_0_a(EObject semanticObject,
+			ISynNavigable transition, List<INode> nodes) {
+
+		Keyword kw = grammarAccess.getXParenthesizedExpressionAccess().getLeftParenthesisKeyword_0();
+
+		if (nodes == null) {
+			if (semanticObject instanceof XIfExpression || semanticObject instanceof XTryCatchFinallyExpression) {
+				EObject cnt = semanticObject.eContainer();
+				if (cnt instanceof XExpression && !(cnt instanceof XBlockExpression)
+						&& !(cnt instanceof XForLoopExpression))
+					acceptUnassignedKeyword(kw, kw.getValue(), null);
+			}
+			if (semanticObject instanceof XConstructorCall) {
+				XConstructorCall call = (XConstructorCall) semanticObject;
+				if (!call.isExplicitConstructorCall() && call.getArguments().isEmpty()) {
+					acceptUnassignedKeyword(kw, kw.getValue(), null);
+				}
+			}
+		}
+		acceptNodes(transition, nodes);
+	}
+	
+	protected boolean startsWithUnaryOperator(EObject obj) {
+		if(obj instanceof XUnaryOperation)
+			return true;
+		if(obj instanceof XBinaryOperation)
+			return startsWithUnaryOperator(((XBinaryOperation)obj).getLeftOperand());
+		if(obj instanceof XPostfixOperation) {
+			return startsWithUnaryOperator(((XPostfixOperation)obj).getOperand());
+		}
+		return false;
+	}
+	
+	@Override
+	public boolean enterAssignedParserRuleCall(RuleCall rc, EObject semanticChild, ICompositeNode node) {
+		if (rc == grammarAccess.getXBlockExpressionAccess().getExpressionsXExpressionOrVarDeclarationParserRuleCall_2_0_0()) {
+			semicolonBeforeNextExpressionRequired = startsWithUnaryOperator(semanticChild);
+		} else
+			semicolonBeforeNextExpressionRequired = false;
+		return super.enterAssignedParserRuleCall(rc, semanticChild, node);
+	}
+	
+	/**
+	 * Syntax:
+	 *     ';'?
+	 */
+	@Override
+	protected void emit_XBlockExpression_SemicolonKeyword_2_1_q(EObject semanticObject, ISynNavigable transition, List<INode> nodes) {
+		if (semicolonBeforeNextExpressionRequired) {
+			ILeafNode node = nodes != null && nodes.size() == 1 && nodes.get(0) instanceof ILeafNode ? (ILeafNode) nodes.get(0) : null;
+			Keyword kw = grammarAccess.getXBlockExpressionAccess().getSemicolonKeyword_2_1();
+			acceptUnassignedKeyword(kw, kw.getValue(), node);
+		} else
+			acceptNodes(transition, nodes);
+	}
 }


### PR DESCRIPTION
[445698] Xtend serializer produces ambiguous syntax related to anonymous classes

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>