### PR TITLE
[479942] Add Support for Task Tags inside Rich String Comments in Xtend

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/tasks/XtendTaskFinderTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/tasks/XtendTaskFinderTest.xtend
@@ -1,0 +1,87 @@
+/** 
+ * Copyright (c) 2017 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.core.tests.tasks
+
+import com.google.inject.Inject
+import java.util.List
+import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.xtend.core.tests.AbstractXtendTestCase
+import org.eclipse.xtext.tasks.ITaskFinder
+import org.eclipse.xtext.tasks.Priority
+import org.eclipse.xtext.tasks.Task
+import org.eclipse.xtext.tasks.TaskTag
+import org.junit.Test
+
+/** 
+ * @author Christian Dietrich - Initial contribution and API
+ */
+class XtendTaskFinderTest extends AbstractXtendTestCase {
+	
+	@Inject
+	ITaskFinder finder
+	
+	@Test
+	def void test() {
+		val contents = '''
+		package foo
+		
+		class Foo {
+			def foo() {
+				«"'''"»
+				«"«"»«"«"»«"«"» TODO this is a todo
+				TODO this is not a todo
+				«"«"»«"«"»«"«"» FIXME this is a fixme
+				«"'''"»
+			}
+		}
+		'''
+		val file = file(contents)
+		
+		file.eResource.assertContainsTasks(#[
+			new Task => [
+				tag = new TaskTag => [
+					name = "TODO"
+					priority = Priority.NORMAL
+				]
+				description = " this is a todo"
+				offset = 50
+				lineNumber = 6
+			],
+			new Task => [
+				tag = new TaskTag => [
+					name = "FIXME"
+					priority = Priority.HIGH
+				]
+				description = " this is a fixme"
+				offset = 102
+				lineNumber = 8
+			]
+		])
+		
+	}
+
+	private def assertContainsTasks(Resource resource, List<Task> expectedTasks) {
+		val actualTasks = finder.findTasks(resource)
+		assertEquals(expectedTasks.size, actualTasks.size)
+		for (i : 0 ..< expectedTasks.size) {
+			assertExactMatch(expectedTasks.get(i), actualTasks.get(i))
+		}
+	}
+	
+	def static void assertExactMatch(Task expected, Task actual) {
+		assertExactMatch(expected.tag, actual.tag)
+		assertEquals(expected.description, actual.description)
+		assertEquals(expected.lineNumber, actual.lineNumber)
+		assertEquals(expected.offset, actual.offset)
+	}
+	
+	def static void assertExactMatch(TaskTag expected, TaskTag actual) {
+		assertEquals(expected.name, actual.name)
+		assertEquals(expected.priority, actual.priority)	
+	}
+}

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/tasks/XtendTaskFinderTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/tasks/XtendTaskFinderTest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2017 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.core.tests.tasks;
+
+import com.google.inject.Inject;
+import java.util.Collections;
+import java.util.List;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.xtend.core.tests.AbstractXtendTestCase;
+import org.eclipse.xtend.core.xtend.XtendFile;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.tasks.ITaskFinder;
+import org.eclipse.xtext.tasks.Priority;
+import org.eclipse.xtext.tasks.Task;
+import org.eclipse.xtext.tasks.TaskTag;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.ExclusiveRange;
+import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Christian Dietrich - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class XtendTaskFinderTest extends AbstractXtendTestCase {
+  @Inject
+  private ITaskFinder finder;
+  
+  @Test
+  public void test() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("package foo");
+      _builder.newLine();
+      _builder.newLine();
+      _builder.append("class Foo {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("def foo() {");
+      _builder.newLine();
+      _builder.append("\t\t");
+      _builder.append("\'\'\'", "\t\t");
+      _builder.newLineIfNotEmpty();
+      _builder.append("\t\t");
+      _builder.append("«", "\t\t");
+      _builder.append("«", "\t\t");
+      _builder.append("«", "\t\t");
+      _builder.append(" TODO this is a todo");
+      _builder.newLineIfNotEmpty();
+      _builder.append("\t\t");
+      _builder.append("TODO this is not a todo");
+      _builder.newLine();
+      _builder.append("\t\t");
+      _builder.append("«", "\t\t");
+      _builder.append("«", "\t\t");
+      _builder.append("«", "\t\t");
+      _builder.append(" FIXME this is a fixme");
+      _builder.newLineIfNotEmpty();
+      _builder.append("\t\t");
+      _builder.append("\'\'\'", "\t\t");
+      _builder.newLineIfNotEmpty();
+      _builder.append("\t");
+      _builder.append("}");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      final String contents = _builder.toString();
+      final XtendFile file = this.file(contents);
+      Task _task = new Task();
+      final Procedure1<Task> _function = (Task it) -> {
+        TaskTag _taskTag = new TaskTag();
+        final Procedure1<TaskTag> _function_1 = (TaskTag it_1) -> {
+          it_1.setName("TODO");
+          it_1.setPriority(Priority.NORMAL);
+        };
+        TaskTag _doubleArrow = ObjectExtensions.<TaskTag>operator_doubleArrow(_taskTag, _function_1);
+        it.setTag(_doubleArrow);
+        it.setDescription(" this is a todo");
+        it.setOffset(50);
+        it.setLineNumber(6);
+      };
+      Task _doubleArrow = ObjectExtensions.<Task>operator_doubleArrow(_task, _function);
+      Task _task_1 = new Task();
+      final Procedure1<Task> _function_1 = (Task it) -> {
+        TaskTag _taskTag = new TaskTag();
+        final Procedure1<TaskTag> _function_2 = (TaskTag it_1) -> {
+          it_1.setName("FIXME");
+          it_1.setPriority(Priority.HIGH);
+        };
+        TaskTag _doubleArrow_1 = ObjectExtensions.<TaskTag>operator_doubleArrow(_taskTag, _function_2);
+        it.setTag(_doubleArrow_1);
+        it.setDescription(" this is a fixme");
+        it.setOffset(102);
+        it.setLineNumber(8);
+      };
+      Task _doubleArrow_1 = ObjectExtensions.<Task>operator_doubleArrow(_task_1, _function_1);
+      this.assertContainsTasks(file.eResource(), 
+        Collections.<Task>unmodifiableList(CollectionLiterals.<Task>newArrayList(_doubleArrow, _doubleArrow_1)));
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  private void assertContainsTasks(final Resource resource, final List<Task> expectedTasks) {
+    final List<Task> actualTasks = this.finder.findTasks(resource);
+    Assert.assertEquals(expectedTasks.size(), actualTasks.size());
+    int _size = expectedTasks.size();
+    ExclusiveRange _doubleDotLessThan = new ExclusiveRange(0, _size, true);
+    for (final Integer i : _doubleDotLessThan) {
+      XtendTaskFinderTest.assertExactMatch(expectedTasks.get((i).intValue()), actualTasks.get((i).intValue()));
+    }
+  }
+  
+  public static void assertExactMatch(final Task expected, final Task actual) {
+    XtendTaskFinderTest.assertExactMatch(expected.getTag(), actual.getTag());
+    Assert.assertEquals(expected.getDescription(), actual.getDescription());
+    Assert.assertEquals(expected.getLineNumber(), actual.getLineNumber());
+    Assert.assertEquals(expected.getOffset(), actual.getOffset());
+  }
+  
+  public static void assertExactMatch(final TaskTag expected, final TaskTag actual) {
+    Assert.assertEquals(expected.getName(), actual.getName());
+    Assert.assertEquals(expected.getPriority(), actual.getPriority());
+  }
+}

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/XtendRuntimeModule.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/XtendRuntimeModule.xtend
@@ -106,6 +106,8 @@ import org.eclipse.xtext.xbase.typesystem.util.HumanReadableTypeNames
 import org.eclipse.xtext.xbase.util.XExpressionHelper
 import org.eclipse.xtext.xbase.validation.EarlyExitValidator
 import org.eclipse.xtext.xbase.validation.ImplicitReturnFinder
+import org.eclipse.xtext.tasks.ITaskFinder
+import org.eclipse.xtend.core.tasks.XtendTaskFinder
 
 /** 
  * Use this class to register components to be used at runtime / without the Equinox extension registry.
@@ -332,5 +334,9 @@ class XtendRuntimeModule extends AbstractXtendRuntimeModule {
 
 	def Class<? extends IShouldGenerate> bindIShouldGenerate() {
 		return IShouldGenerate.Always
+	}
+
+	def Class<? extends ITaskFinder> bindITaskFinder() {
+		return XtendTaskFinder
 	}
 }

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/tasks/XtendTaskFinder.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/tasks/XtendTaskFinder.xtend
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2017 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.core.tasks
+
+import org.eclipse.xtext.tasks.DefaultTaskFinder
+import com.google.inject.Inject
+import org.eclipse.xtend.core.services.XtendGrammarAccess
+import org.eclipse.xtext.nodemodel.ILeafNode
+import org.eclipse.xtext.RuleCall
+
+/**
+ * @author Christian Dietrich - Initial contribution and API
+ * @since 
+ */
+class XtendTaskFinder extends DefaultTaskFinder {
+
+	@Inject extension XtendGrammarAccess
+
+	override protected canContainTaskTags(ILeafNode node) {
+		var result = super.canContainTaskTags(node)
+		if (!result) {
+			return node.isRichComment
+		}
+		return result
+	}
+
+	override protected stripText(ILeafNode node, String text) {
+		if (node.isRichComment) {
+			val char newLine = '\n'
+			val index = text.indexOf(newLine)
+			if (index !== -1) {
+				return text.substring(0, index)
+			}
+			return text
+		}
+		super.stripText(node, text)
+	}
+
+	private def isRichComment(ILeafNode node) {
+		if (node.grammarElement instanceof RuleCall) {
+			return (node.grammarElement as RuleCall).rule == COMMENT_RICH_TEXT_ENDRule ||
+				(node.grammarElement as RuleCall).rule == COMMENT_RICH_TEXT_INBETWEENRule 
+		}
+		return false
+	}
+
+}

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/XtendRuntimeModule.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/XtendRuntimeModule.java
@@ -42,6 +42,7 @@ import org.eclipse.xtend.core.resource.XtendResourceDescriptionStrategy;
 import org.eclipse.xtend.core.scoping.AnonymousClassConstructorScopes;
 import org.eclipse.xtend.core.scoping.XtendImportedNamespaceScopeProvider;
 import org.eclipse.xtend.core.serializer.XtendSerializerScopeProvider;
+import org.eclipse.xtend.core.tasks.XtendTaskFinder;
 import org.eclipse.xtend.core.tasks.XtendTaskTagProvider;
 import org.eclipse.xtend.core.typesystem.LocalClassAwareTypeNames;
 import org.eclipse.xtend.core.typesystem.TypeDeclarationAwareBatchTypeResolver;
@@ -83,6 +84,7 @@ import org.eclipse.xtext.resource.persistence.IResourceStorageFacade;
 import org.eclipse.xtext.scoping.IScopeProvider;
 import org.eclipse.xtext.scoping.impl.AbstractDeclarativeScopeProvider;
 import org.eclipse.xtext.serializer.tokens.SerializerScopeProviderBinding;
+import org.eclipse.xtext.tasks.ITaskFinder;
 import org.eclipse.xtext.tasks.ITaskTagProvider;
 import org.eclipse.xtext.validation.CompositeEValidator;
 import org.eclipse.xtext.validation.ConfigurableIssueCodesProvider;
@@ -360,5 +362,9 @@ public class XtendRuntimeModule extends AbstractXtendRuntimeModule {
   
   public Class<? extends IShouldGenerate> bindIShouldGenerate() {
     return IShouldGenerate.Always.class;
+  }
+  
+  public Class<? extends ITaskFinder> bindITaskFinder() {
+    return XtendTaskFinder.class;
   }
 }

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/tasks/XtendTaskFinder.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/tasks/XtendTaskFinder.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2017 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.core.tasks;
+
+import com.google.common.base.Objects;
+import com.google.inject.Inject;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtend.core.services.XtendGrammarAccess;
+import org.eclipse.xtext.RuleCall;
+import org.eclipse.xtext.nodemodel.ILeafNode;
+import org.eclipse.xtext.tasks.DefaultTaskFinder;
+import org.eclipse.xtext.xbase.lib.Extension;
+
+/**
+ * @author Christian Dietrich - Initial contribution and API
+ * @since
+ */
+@SuppressWarnings("all")
+public class XtendTaskFinder extends DefaultTaskFinder {
+  @Inject
+  @Extension
+  private XtendGrammarAccess _xtendGrammarAccess;
+  
+  @Override
+  protected boolean canContainTaskTags(final ILeafNode node) {
+    boolean result = super.canContainTaskTags(node);
+    if ((!result)) {
+      return this.isRichComment(node);
+    }
+    return result;
+  }
+  
+  @Override
+  protected String stripText(final ILeafNode node, final String text) {
+    String _xblockexpression = null;
+    {
+      boolean _isRichComment = this.isRichComment(node);
+      if (_isRichComment) {
+        final char newLine = '\n';
+        final int index = text.indexOf(newLine);
+        if ((index != (-1))) {
+          return text.substring(0, index);
+        }
+        return text;
+      }
+      _xblockexpression = super.stripText(node, text);
+    }
+    return _xblockexpression;
+  }
+  
+  private boolean isRichComment(final ILeafNode node) {
+    EObject _grammarElement = node.getGrammarElement();
+    if ((_grammarElement instanceof RuleCall)) {
+      return (Objects.equal(((RuleCall) node.getGrammarElement()).getRule(), this._xtendGrammarAccess.getCOMMENT_RICH_TEXT_ENDRule()) || 
+        Objects.equal(((RuleCall) node.getGrammarElement()).getRule(), this._xtendGrammarAccess.getCOMMENT_RICH_TEXT_INBETWEENRule()));
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
[479942] Add Support for Task Tags inside Rich String Comments in Xtend

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>