### PR TITLE
use reverse lookup map to find source files for generated files

### DIFF
--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/builder/XtendParallelBuilderParticipant.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/builder/XtendParallelBuilderParticipant.java
@@ -70,7 +70,7 @@ public class XtendParallelBuilderParticipant extends ParallelBuilderParticipant 
 				generatorMarkers.put(config, markers);
 			}
 		}
-		return generatorMarkers;
+		return buildGeneratorMarkersReverseLookupMap(generatorMarkers);
 	}
 	
 	public List<IPath> getSourceFolderPathes(IProject project){


### PR DESCRIPTION
fixes https://github.com/eclipse/xtext-eclipse/issues/225

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>