### PR TITLE
Sort References on Rename Refactoring to Prevent NPE

### DIFF
--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/refactoring/JavaRefactoringIntegrationTest.java
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/refactoring/JavaRefactoringIntegrationTest.java
@@ -33,7 +33,6 @@ import org.eclipse.xtend.ide.tests.WorkbenchTestHelper;
 import org.eclipse.xtext.common.types.ui.refactoring.participant.CompositeRefactoringProcessor;
 import org.eclipse.xtext.resource.EObjectAtOffsetHelper;
 import org.eclipse.xtext.resource.XtextResource;
-import org.eclipse.xtext.testing.Flaky;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.refactoring.IRenameRefactoringProvider;
 import org.eclipse.xtext.ui.refactoring.impl.AbstractRenameProcessor;
@@ -1334,7 +1333,6 @@ public class JavaRefactoringIntegrationTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	@Flaky(trials=10)
 	public void testBug489208_1() throws Exception {
 		try {
 			testHelper.getProject().close(null);
@@ -1356,7 +1354,6 @@ public class JavaRefactoringIntegrationTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	@Flaky(trials=10)
 	public void testBug489208_2() throws Exception {
 		try {
 			testHelper.getProject().close(null);

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/refactoring/XtendReferenceUpdater.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/refactoring/XtendReferenceUpdater.xtend
@@ -7,14 +7,15 @@
  *******************************************************************************/
 package org.eclipse.xtend.ide.refactoring
 
-import org.eclipse.xtext.xbase.ui.refactoring.XbaseReferenceUpdater
-import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.common.util.URI
+import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.EReference
+import org.eclipse.xtend.core.xtend.AnonymousClass
+import org.eclipse.xtext.common.types.JvmType
+import org.eclipse.xtext.resource.IReferenceDescription
 import org.eclipse.xtext.ui.refactoring.IRefactoringUpdateAcceptor
 import org.eclipse.xtext.xbase.XConstructorCall
-import org.eclipse.xtext.common.types.JvmType
-import org.eclipse.xtend.core.xtend.AnonymousClass
+import org.eclipse.xtext.xbase.ui.refactoring.XbaseReferenceUpdater
 
 /**
  * @author Jan Koehnlein - Initial contribution and API
@@ -30,6 +31,27 @@ class XtendReferenceUpdater extends XbaseReferenceUpdater {
 			return;
 		}
 		super.createReferenceUpdate(referringElement, referringResourceURI, reference, indexInList, newTargetElement, updateAcceptor)
+	}
+	
+	override protected getNotImportTypeReferences(Iterable<IReferenceDescription> referenceDescriptions) {
+		val result = super.getNotImportTypeReferences(referenceDescriptions).toList
+		val localClassesFragmentPart = "@localClasses."
+		// sort @localClasses to the end since the refactoring of local classes is order dependent
+		result.sort[o1,o2|
+			val f1 = o1.sourceEObjectUri.fragment
+			val f2 = o2.sourceEObjectUri.fragment
+			if (f1.contains(localClassesFragmentPart) && f2.contains(localClassesFragmentPart)) {
+				return f1.compareTo(f2)
+			}
+			if (f1.contains(localClassesFragmentPart)) {
+				return 1
+			}
+			if (f2.contains(localClassesFragmentPart)) {
+				return -1
+			}
+			return f1.compareTo(f2)
+		]
+		result
 	}
 	
 }

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/refactoring/XtendReferenceUpdater.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/refactoring/XtendReferenceUpdater.java
@@ -7,13 +7,17 @@
  */
 package org.eclipse.xtend.ide.refactoring;
 
+import java.util.Comparator;
+import java.util.List;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.xtend.core.xtend.AnonymousClass;
 import org.eclipse.xtext.common.types.JvmType;
+import org.eclipse.xtext.resource.IReferenceDescription;
 import org.eclipse.xtext.ui.refactoring.IRefactoringUpdateAcceptor;
 import org.eclipse.xtext.xbase.XConstructorCall;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.ui.refactoring.XbaseReferenceUpdater;
 
 /**
@@ -29,5 +33,33 @@ public class XtendReferenceUpdater extends XbaseReferenceUpdater {
       return;
     }
     super.createReferenceUpdate(referringElement, referringResourceURI, reference, indexInList, newTargetElement, updateAcceptor);
+  }
+  
+  @Override
+  protected Iterable<IReferenceDescription> getNotImportTypeReferences(final Iterable<IReferenceDescription> referenceDescriptions) {
+    List<IReferenceDescription> _xblockexpression = null;
+    {
+      final List<IReferenceDescription> result = IterableExtensions.<IReferenceDescription>toList(super.getNotImportTypeReferences(referenceDescriptions));
+      final String localClassesFragmentPart = "@localClasses.";
+      final Comparator<IReferenceDescription> _function = (IReferenceDescription o1, IReferenceDescription o2) -> {
+        final String f1 = o1.getSourceEObjectUri().fragment();
+        final String f2 = o2.getSourceEObjectUri().fragment();
+        if ((f1.contains(localClassesFragmentPart) && f2.contains(localClassesFragmentPart))) {
+          return f1.compareTo(f2);
+        }
+        boolean _contains = f1.contains(localClassesFragmentPart);
+        if (_contains) {
+          return 1;
+        }
+        boolean _contains_1 = f2.contains(localClassesFragmentPart);
+        if (_contains_1) {
+          return (-1);
+        }
+        return f1.compareTo(f2);
+      };
+      result.sort(_function);
+      _xblockexpression = result;
+    }
+    return _xblockexpression;
   }
 }


### PR DESCRIPTION
Sort References on Rename Refactoring to Prevent NPE when Anon Inner Class Constructors are Involved. Fixes https://github.com/eclipse/xtext-core/issues/300

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>