### PR TITLE
[426073] [xtend][compiler] The generated Java code contains a conflict between a field name and an imported class name

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug426073Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug426073Test.xtend
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2017 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.core.tests.compiler
+
+import org.junit.Test
+
+/**
+ * @author Christian Dietrich - Initial contribution and API
+ */
+class CompilerBug426073Test extends AbstractXtendCompilerTest {
+
+	@Test
+	def test_01() {
+		assertCompilesTo('''
+			package foo
+			
+			import static extension org.eclipse.emf.common.util.URI.*
+			
+			class Foo {
+			
+				val URI = "lalala".createURI 
+			
+			}
+		''', '''
+			package foo;
+			
+			import org.eclipse.emf.common.util.URI;
+			
+			@SuppressWarnings("all")
+			public class Foo {
+			  private final URI URI = org.eclipse.emf.common.util.URI.createURI("lalala");
+			}
+		''')
+	}
+
+	@Test
+	def test_02() {
+		assertCompilesTo('''
+			package foo
+			
+			import static extension org.eclipse.emf.common.util.URI.*
+			
+			class Foo {
+			
+				val URI2 = "lalala".createURI 
+			
+			}
+		''', '''
+			package foo;
+			
+			import org.eclipse.emf.common.util.URI;
+			
+			@SuppressWarnings("all")
+			public class Foo {
+			  private final URI URI2 = URI.createURI("lalala");
+			}
+		''')
+	}
+
+}

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug426073Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug426073Test.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2017 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.core.tests.compiler;
+
+import org.eclipse.xtend.core.tests.compiler.AbstractXtendCompilerTest;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.junit.Test;
+
+/**
+ * @author Christian Dietrich - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class CompilerBug426073Test extends AbstractXtendCompilerTest {
+  @Test
+  public void test_01() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package foo");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("import static extension org.eclipse.emf.common.util.URI.*");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("val URI = \"lalala\".createURI ");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("package foo;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.emf.common.util.URI;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("private final URI URI = org.eclipse.emf.common.util.URI.createURI(\"lalala\");");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
+  }
+  
+  @Test
+  public void test_02() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package foo");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("import static extension org.eclipse.emf.common.util.URI.*");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("val URI2 = \"lalala\".createURI ");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("package foo;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.emf.common.util.URI;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("private final URI URI2 = URI.createURI(\"lalala\");");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
+  }
+}


### PR DESCRIPTION
[426073] [xtend][compiler] The generated Java code contains a conflict between a field name and an imported class name

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>