### PR TITLE
[515801] ClassCastException in OverrideHelper.findOverriddenOperation and AbstractResolvedOperation.getOverriddenAndImplementedMethodCandidates

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/OverrideHelperTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/OverrideHelperTest.xtend
@@ -136,4 +136,16 @@ class OverrideHelperTest extends AbstractXtendTestCase {
 		assertNotNull(operation.findOverriddenOperation)
 	}
 	
+	@Test def checkFindOverriddenOperation_05() {
+		val xtendFile = file('''
+			package foo
+			class Foo implements int {
+				override bar(Map<?, ?> map) {}
+			}
+		''')
+		
+		val operation = xtendFile.xtendTypes.head.members.filter(XtendFunction).head.getPrimaryJvmElement as JvmOperation
+		assertNull(operation.findOverriddenOperation)
+	}
+	
 }

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/XtendValidationTest.java
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/XtendValidationTest.java
@@ -3029,4 +3029,18 @@ public class XtendValidationTest extends AbstractXtendTestCase {
 			"}");
 		helper.assertNoIssues(file);
 	}
+	
+	@Test public void testOverridingBug515801() throws Exception {
+		XtendClass clazz = clazz(
+				"class Foo implements int {"+
+					"override void doSth(Object obj){ "+
+					"}"+
+				"}");
+		List<Issue> issues = helper.validate(clazz);
+		for (Issue issue : issues) {
+			if (issue.getMessage() != null && issue.getMessage().contains("Error executing EValidator")) {
+				fail(issue.getMessage());
+			}
+		}
+	}
 }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/OverrideHelperTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/OverrideHelperTest.java
@@ -256,4 +256,26 @@ public class OverrideHelperTest extends AbstractXtendTestCase {
       throw Exceptions.sneakyThrow(_e);
     }
   }
+  
+  @Test
+  public void checkFindOverriddenOperation_05() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("package foo");
+      _builder.newLine();
+      _builder.append("class Foo implements int {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("override bar(Map<?, ?> map) {}");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      final XtendFile xtendFile = this.file(_builder.toString());
+      EObject _primaryJvmElement = this._iJvmModelAssociations.getPrimaryJvmElement(IterableExtensions.<XtendFunction>head(Iterables.<XtendFunction>filter(IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes()).getMembers(), XtendFunction.class)));
+      final JvmOperation operation = ((JvmOperation) _primaryJvmElement);
+      Assert.assertNull(this.overrideHelper.findOverriddenOperation(operation));
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
 }


### PR DESCRIPTION
[515801] ClassCastException in OverrideHelper.findOverriddenOperation and AbstractResolvedOperation.getOverriddenAndImplementedMethodCandidates

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>