### PR TITLE
[483783] Fixed MalformedTreeException that lead to File Rename on Xtend File not working

### DIFF
--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/refactoring/XtendFileRenameParticipant.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/refactoring/XtendFileRenameParticipant.java
@@ -50,7 +50,7 @@ public class XtendFileRenameParticipant extends AbstractProcessorBasedRenamePart
 								((IChangeRedirector.Aware) renameElementContext).setChangeRedirector(new IChangeRedirector() {
 									@Override
 									public IPath getRedirectedPath(IPath source) {
-										return source.equals(filePath) ? newPath : filePath;
+										return source.equals(filePath) ? newPath : source;
 									}
 									
 								});


### PR DESCRIPTION
[483783] Fixed MalformedTreeException that lead to File Rename on Xtend File not working

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>