### PR TITLE
fixed #194 [formatter] Formatting a long line messes up the indentation

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendFormatterBugTests.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendFormatterBugTests.xtend
@@ -273,6 +273,21 @@ class XtendFormatterBugTests extends AbstractXtendFormatterTest {
 	}
 	
 	@Test
+	def testBug_xtext_xtend_194(){
+		assertFormatted('''
+			class Foo {
+			
+				static val SOME_MULTI_LINE_THINGY = new StringBuilder('a').append('b').
+					append('c').append('d').append('e').append('f').append('g').append('h').
+					append('i').append('j').append('k').append('l').append('m').toString;
+			
+				var bar = new Object
+			
+			}
+		''')
+	}
+	
+	@Test
 	def testBug455582() {
 		assertFormatted('''
 		abstract package class XtendTest {

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendFormatterBugTests.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendFormatterBugTests.java
@@ -512,6 +512,31 @@ public class XtendFormatterBugTests extends AbstractXtendFormatterTest {
   }
   
   @Test
+  public void testBug_xtext_xtend_194() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("static val SOME_MULTI_LINE_THINGY = new StringBuilder(\'a\').append(\'b\').");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("append(\'c\').append(\'d\').append(\'e\').append(\'f\').append(\'g\').append(\'h\').");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("append(\'i\').append(\'j\').append(\'k\').append(\'l\').append(\'m\').toString;");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("var bar = new Object");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.assertFormatted(_builder);
+  }
+  
+  @Test
   public void testBug455582() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("abstract package class XtendTest {");


### PR DESCRIPTION
This commit only adds a test. 
The actual fix is https://github.com/eclipse/xtext-core/issues/301

Signed-off-by: Moritz Eysholdt <moritz.eysholdt@typefox.io>