### PR TITLE
Copy UserData in DirtyStateResourceDescription.Manager.computeTypes(Resource)

### DIFF
--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/editor/DirtyStateResourceDescriptionTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/editor/DirtyStateResourceDescriptionTest.xtend
@@ -17,6 +17,7 @@ import org.eclipse.xtext.resource.XtextResourceSet
 import org.eclipse.xtext.ui.editor.DirtyStateResourceDescription
 import org.eclipse.xtext.util.StringInputStream
 import org.junit.Test
+import org.eclipse.xtend.core.resource.XtendResourceDescriptionStrategy
 
 /**
  * @author Jan Koehnlein - Initial contribution and API
@@ -39,6 +40,9 @@ class DirtyStateResourceDescriptionTest extends AbstractXtendUITestCase {
 		val textHash = d.exportedObjects.head.getUserData(DirtyStateResourceDescription.Manager.TEXT_HASH)
 		assertNotNull(textHash)
 		assertFalse('' == textHash)
+		val sig = d.exportedObjects.head.getUserData(XtendResourceDescriptionStrategy.SIGNATURE_HASH_KEY)
+		assertNotNull(sig)
+		assertFalse('' == sig)
 	}
 	
 	@Test

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/editor/DirtyStateResourceDescriptionTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/editor/DirtyStateResourceDescriptionTest.java
@@ -13,6 +13,7 @@ import com.google.inject.Provider;
 import java.util.Collections;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.xtend.core.resource.XtendResourceDescriptionStrategy;
 import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.resource.IEObjectDescription;
@@ -54,6 +55,10 @@ public class DirtyStateResourceDescriptionTest extends AbstractXtendUITestCase {
     Assert.assertNotNull(textHash);
     boolean _equals = Objects.equal("", textHash);
     Assert.assertFalse(_equals);
+    final String sig = IterableExtensions.<IEObjectDescription>head(d.getExportedObjects()).getUserData(XtendResourceDescriptionStrategy.SIGNATURE_HASH_KEY);
+    Assert.assertNotNull(sig);
+    boolean _equals_1 = Objects.equal("", sig);
+    Assert.assertFalse(_equals_1);
   }
   
   @Test


### PR DESCRIPTION
Copy UserData in DirtyStateResourceDescription.Manager.computeTypes(Resource)
(Tests)
https://github.com/eclipse/xtext/issues/2452

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>