### PR TITLE
Reassignment of checked types is missing in template expression's 'ELSEIF' #230

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerXtendIssue230Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerXtendIssue230Test.xtend
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2017 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.core.tests.compiler
+
+import org.junit.Test
+
+/**
+ * @author Christian Dietrich - Initial contribution and API
+ */
+class CompilerXtendIssue230Test extends AbstractXtendCompilerTest {
+	
+	@Test def void testIssue230() {
+		assertCompilesTo("
+		package b
+		
+		import org.eclipse.xtend.lib.annotations.Accessors
+		
+		class MyTest {
+			
+			@Accessors
+			static class A1 {String name}
+			@Accessors
+			static class A2 {String name}
+			
+			def doItWithNumber(Object n) '''
+			«IF n instanceof A1»
+				A1: «n.name»
+			«ELSEIF n instanceof A2»
+				A2: «n.name»
+			«ELSE»
+				Else: «n»
+			«ENDIF»
+			'''
+		}
+		", '''
+		package b;
+		
+		import org.eclipse.xtend.lib.annotations.Accessors;
+		import org.eclipse.xtend2.lib.StringConcatenation;
+		import org.eclipse.xtext.xbase.lib.Pure;
+		
+		@SuppressWarnings("all")
+		public class MyTest {
+		  @Accessors
+		  public static class A1 {
+		    private String name;
+		    
+		    @Pure
+		    public String getName() {
+		      return this.name;
+		    }
+		    
+		    public void setName(final String name) {
+		      this.name = name;
+		    }
+		  }
+		  
+		  @Accessors
+		  public static class A2 {
+		    private String name;
+		    
+		    @Pure
+		    public String getName() {
+		      return this.name;
+		    }
+		    
+		    public void setName(final String name) {
+		      this.name = name;
+		    }
+		  }
+		  
+		  public CharSequence doItWithNumber(final Object n) {
+		    StringConcatenation _builder = new StringConcatenation();
+		    {
+		      if ((n instanceof MyTest.A1)) {
+		        _builder.append("A1: ");
+		        _builder.append(((MyTest.A1)n).name);
+		        _builder.newLineIfNotEmpty();
+		      } else {
+		        if ((n instanceof MyTest.A2)) {
+		          _builder.append("A2: ");
+		          _builder.append(((MyTest.A2)n).name);
+		          _builder.newLineIfNotEmpty();
+		        } else {
+		          _builder.append("Else: ");
+		          _builder.append(n);
+		          _builder.newLineIfNotEmpty();
+		        }
+		      }
+		    }
+		    return _builder;
+		  }
+		}
+		''')
+	}
+	
+}

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerXtendIssue230Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerXtendIssue230Test.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) 2017 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.core.tests.compiler;
+
+import org.eclipse.xtend.core.tests.compiler.AbstractXtendCompilerTest;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.junit.Test;
+
+/**
+ * @author Christian Dietrich - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class CompilerXtendIssue230Test extends AbstractXtendCompilerTest {
+  @Test
+  public void testIssue230() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package b;");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("import org.eclipse.xtend.lib.annotations.Accessors;");
+    _builder.newLine();
+    _builder.append("import org.eclipse.xtend2.lib.StringConcatenation;");
+    _builder.newLine();
+    _builder.append("import org.eclipse.xtext.xbase.lib.Pure;");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("@SuppressWarnings(\"all\")");
+    _builder.newLine();
+    _builder.append("public class MyTest {");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("@Accessors");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("public static class A1 {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("private String name;");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("@Pure");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("public String getName() {");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("return this.name;");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("public void setName(final String name) {");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("this.name = name;");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("@Accessors");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("public static class A2 {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("private String name;");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("@Pure");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("public String getName() {");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("return this.name;");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("public void setName(final String name) {");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("this.name = name;");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("public CharSequence doItWithNumber(final Object n) {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("StringConcatenation _builder = new StringConcatenation();");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("{");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("if ((n instanceof MyTest.A1)) {");
+    _builder.newLine();
+    _builder.append("        ");
+    _builder.append("_builder.append(\"A1: \");");
+    _builder.newLine();
+    _builder.append("        ");
+    _builder.append("_builder.append(((MyTest.A1)n).name);");
+    _builder.newLine();
+    _builder.append("        ");
+    _builder.append("_builder.newLineIfNotEmpty();");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("} else {");
+    _builder.newLine();
+    _builder.append("        ");
+    _builder.append("if ((n instanceof MyTest.A2)) {");
+    _builder.newLine();
+    _builder.append("          ");
+    _builder.append("_builder.append(\"A2: \");");
+    _builder.newLine();
+    _builder.append("          ");
+    _builder.append("_builder.append(((MyTest.A2)n).name);");
+    _builder.newLine();
+    _builder.append("          ");
+    _builder.append("_builder.newLineIfNotEmpty();");
+    _builder.newLine();
+    _builder.append("        ");
+    _builder.append("} else {");
+    _builder.newLine();
+    _builder.append("          ");
+    _builder.append("_builder.append(\"Else: \");");
+    _builder.newLine();
+    _builder.append("          ");
+    _builder.append("_builder.append(n);");
+    _builder.newLine();
+    _builder.append("          ");
+    _builder.append("_builder.newLineIfNotEmpty();");
+    _builder.newLine();
+    _builder.append("        ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("return _builder;");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.assertCompilesTo("\n\t\tpackage b\n\t\t\n\t\timport org.eclipse.xtend.lib.annotations.Accessors\n\t\t\n\t\tclass MyTest {\n\t\t\t\n\t\t\t@Accessors\n\t\t\tstatic class A1 {String name}\n\t\t\t@Accessors\n\t\t\tstatic class A2 {String name}\n\t\t\t\n\t\t\tdef doItWithNumber(Object n) \'\'\'\n\t\t\t«IF n instanceof A1»\n\t\t\t\tA1: «n.name»\n\t\t\t«ELSEIF n instanceof A2»\n\t\t\t\tA2: «n.name»\n\t\t\t«ELSE»\n\t\t\t\tElse: «n»\n\t\t\t«ENDIF»\n\t\t\t\'\'\'\n\t\t}\n\t\t", _builder);
+  }
+}

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/typesystem/XtendTypeComputer.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/typesystem/XtendTypeComputer.java
@@ -138,7 +138,8 @@ public class XtendTypeComputer extends XbaseWithAnnotationsTypeComputer {
 		thenState.withExpectation(charSequence).computeTypes(thenExpression);
 		for(RichStringElseIf elseIf: object.getElseIfs()) {
 			state.withExpectation(booleanType).computeTypes(elseIf.getIf());
-			state.withExpectation(charSequence).computeTypes(elseIf.getThen());
+			ITypeComputationState elseState = reassignCheckedType(elseIf.getIf(), elseIf.getThen(), state);
+			elseState.withExpectation(charSequence).computeTypes(elseIf.getThen());
 		}
 		state.withExpectation(charSequence).computeTypes(object.getElse());
 		state.acceptActualType(charSequence);


### PR DESCRIPTION
Reassignment of checked types is missing in template expression's 'ELSEIF' #230

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>