### PR TITLE
fixed content assist tests after changes to collection literals

### DIFF
--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/AbstractXbaseContentAssistTest.java
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/AbstractXbaseContentAssistTest.java
@@ -136,46 +136,54 @@ public abstract class AbstractXbaseContentAssistTest extends Assert implements R
 	}
 	
 	protected static String[] KEYWORDS_AND_STATICS = {
-		"if", 
-		"while", "for", "do",
-		"true", "false",
-		"typeof",
-		"try",
-		"switch",
-		"new",
-		"throw",
-		"return",
-		"null",
-		// Collection Literals
-		"emptyList",
-		"emptySet",
-		"emptyMap",
-		"newArrayOfSize()",
-		"newBooleanArrayOfSize()", 
-		"newByteArrayOfSize()", 
-		"newShortArrayOfSize()",
-		"newCharArrayOfSize()", 
-		"newIntArrayOfSize()", 
-		"newLongArrayOfSize()", 
-		"newFloatArrayOfSize()", 
-		"newDoubleArrayOfSize()", 
-		"newImmutableList()",
-		"newImmutableSet()",
-		"newImmutableMap()",
-		"newArrayList()",
-		"newLinkedList()",
-		"newHashSet()",
-		"newLinkedHashSet()",
-		"newTreeSet()",
-		"newHashMap()",
-		"newLinkedHashMap()",
-		"newTreeMap()",
-		// InputOutput,
-		"print()",
-		"println",
-		"println()",
-		"synchronized"
-	};
+			"if", 
+			"while", "for", "do",
+			"true", "false",
+			"typeof",
+			"try",
+			"switch",
+			"new",
+			"throw",
+			"return",
+			"null",
+			// Collection Literals
+			"emptyList",
+			"emptySet",
+			"emptyMap",
+			"newArrayOfSize()",
+			"newBooleanArrayOfSize()", 
+			"newByteArrayOfSize()", 
+			"newShortArrayOfSize()",
+			"newCharArrayOfSize()", 
+			"newIntArrayOfSize()", 
+			"newLongArrayOfSize()", 
+			"newFloatArrayOfSize()", 
+			"newDoubleArrayOfSize()", 
+			"newImmutableList()",
+			"newImmutableSet()",
+			"newImmutableMap()",
+			"newArrayList",
+			"newArrayList()",
+			"newLinkedList",
+			"newLinkedList()",
+			"newHashSet",
+			"newHashSet()",
+			"newLinkedHashSet",
+			"newLinkedHashSet()",
+			"newTreeSet()",
+			"newTreeSet()",
+			"newHashMap()",
+			"newHashMap",
+			"newLinkedHashMap()",
+			"newLinkedHashMap",
+			"newTreeMap()",
+			"newTreeMap()",
+			// InputOutput,
+			"print()",
+			"println",
+			"println()",
+			"synchronized"
+		};
 	
 	protected static String[] STRING_OPERATORS = {
 		"===", "!==", "==", "!=",
@@ -673,7 +681,7 @@ public abstract class AbstractXbaseContentAssistTest extends Assert implements R
 	}
 	
 	@Test public void testCamelCase_01() throws Exception {
-		newBuilder().append("newLLis").assertText("newLinkedList()");
+		newBuilder().append("newLLis").assertText("newLinkedList", "newLinkedList()");
 	}
 	
 	@Test public void testCamelCase_02() throws Exception {

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/Bug364966Test.java
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/Bug364966Test.java
@@ -16,11 +16,11 @@ import org.junit.Test;
 public class Bug364966Test extends AbstractXtendContentAssistBugTest {
 
 	@Test public void testFieldInitializer_01() throws Exception {
-		newBuilder().append("String s = newArrayLis").assertText("newArrayList()");
+		newBuilder().append("String s = newArrayLis").assertText("newArrayList","newArrayList()");
 	}
 	
 	@Test public void testFieldInitializer_02() throws Exception {
-		newBuilder().append("static String s = newArrayLis").assertText("newArrayList()");
+		newBuilder().append("static String s = newArrayLis").assertText("newArrayList","newArrayList()");
 	}
 	
 	@Test public void testFieldInitializer_03() throws Exception {


### PR DESCRIPTION
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>