### PR TITLE
widened version range for asm to include version 6

### DIFF
--- a/org.eclipse.xtend.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.core/META-INF/MANIFEST.MF
@@ -63,7 +63,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.xtend.lib,
  org.eclipse.xtext.smap,
  org.apache.ant;bundle-version="1.7.1";resolution:=optional;x-installation:=greedy,
- org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional,
+ org.objectweb.asm;bundle-version="[5.0.1,7.0.0)";resolution:=optional,
  org.eclipse.xtext.xbase.testing;resolution:=optional,
  org.eclipse.xtext.generator;resolution:=optional,
  org.eclipse.emf.mwe2.launch;resolution:=optional


### PR DESCRIPTION
widened version range for asm to include version 6
https://github.com/eclipse/xtext-core/issues/501

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>