### PR TITLE
Change the visibility of isRelevantAnnotationTarget.

### DIFF
--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendValidator.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendValidator.java
@@ -429,7 +429,7 @@ public class XtendValidator extends XbaseWithAnnotationsValidator {
 	}
 
 
-	private boolean isRelevantAnnotationTarget(final XtendAnnotationTarget annotationTarget) {
+	protected boolean isRelevantAnnotationTarget(final XtendAnnotationTarget annotationTarget) {
 		return any(targetInfos.keySet(), new Predicate<Class<?>>() {
 			@Override
 			public boolean apply(Class<?> input) {


### PR DESCRIPTION
In order to use the isRelevantAnnotationTarget() function within subtypes of XtendValidator, the visibility of this function should be changed from "private" to "protected".

Signed-off-by: Stéphane Galland <galland@arakhne.org>