### PR TITLE
[eclipse/xtext-eclipse#463] Adjusted Xtend to the modifications done for this issue

### DIFF
--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/GenerateXtend.mwe2
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/GenerateXtend.mwe2
@@ -125,6 +125,9 @@ Workflow {
 			fragment = ui.refactoring.RefactorElementNameFragment2 auto-inject {
 				useJdtRefactoring = true
 			}
+			
+			fragment = ui.editor.EditorFragment2 {}
+			
 			fragment = types.TypesGeneratorFragment2 {}
 			fragment = xbase.XbaseGeneratorFragment2 {
 				generateXtendInferrer = false

--- a/org.eclipse.xtend.ide/plugin.xml
+++ b/org.eclipse.xtend.ide/plugin.xml
@@ -566,7 +566,7 @@
 	<extension
          point="org.eclipse.core.runtime.adapters">
       <factory class="org.eclipse.xtend.ide.XtendExecutableExtensionFactory:org.eclipse.xtext.builder.smap.StratumBreakpointAdapterFactory"
-         adaptableType="org.eclipse.xtext.ui.editor.XtextEditor">
+         adaptableType="org.eclipse.xtend.ide.editor.XtendEditor">
          <adapter type="org.eclipse.debug.ui.actions.IToggleBreakpointsTarget"/>
       </factory> 
    </extension>

--- a/org.eclipse.xtend.ide/plugin.xml_gen
+++ b/org.eclipse.xtend.ide/plugin.xml_gen
@@ -508,7 +508,7 @@
 	</extension>
 	<extension point="org.eclipse.core.runtime.adapters">
 		<factory class="org.eclipse.xtend.ide.XtendExecutableExtensionFactory:org.eclipse.xtext.builder.smap.StratumBreakpointAdapterFactory"
-			adaptableType="org.eclipse.xtext.ui.editor.XtextEditor">
+			adaptableType="org.eclipse.xtend.ide.editor.XtendEditor">
 			<adapter type="org.eclipse.debug.ui.actions.IToggleBreakpointsTarget"/>
 		</factory> 
 	</extension>

--- a/org.eclipse.xtend.ide/src-gen/org/eclipse/xtend/ide/AbstractXtendUiModule.java
+++ b/org.eclipse.xtend.ide/src-gen/org/eclipse/xtend/ide/AbstractXtendUiModule.java
@@ -20,6 +20,7 @@ import org.eclipse.xtend.ide.common.contentassist.antlr.PartialXtendContentAssis
 import org.eclipse.xtend.ide.common.contentassist.antlr.XtendParser;
 import org.eclipse.xtend.ide.common.contentassist.antlr.internal.InternalXtendLexer;
 import org.eclipse.xtend.ide.contentassist.XtendProposalProvider;
+import org.eclipse.xtend.ide.editor.XtendEditor;
 import org.eclipse.xtend.ide.outline.XtendOutlineTreeProvider;
 import org.eclipse.xtend.ide.quickfix.XtendQuickfixProvider;
 import org.eclipse.xtext.builder.BuilderParticipant;
@@ -98,7 +99,6 @@ import org.eclipse.xtext.xbase.annotations.ui.DefaultXbaseWithAnnotationsUiModul
 import org.eclipse.xtext.xbase.imports.IUnresolvedTypeResolver;
 import org.eclipse.xtext.xbase.ui.contentassist.ImportingTypesProposalProvider;
 import org.eclipse.xtext.xbase.ui.editor.XbaseDocumentProvider;
-import org.eclipse.xtext.xbase.ui.editor.XbaseEditor;
 import org.eclipse.xtext.xbase.ui.generator.trace.XbaseOpenGeneratedFileHandler;
 import org.eclipse.xtext.xbase.ui.imports.InteractiveUnresolvedTypeResolver;
 import org.eclipse.xtext.xbase.ui.jvmmodel.findrefs.JvmModelFindReferenceHandler;
@@ -132,7 +132,7 @@ public abstract class AbstractXtendUiModule extends DefaultXbaseWithAnnotationsU
 	
 	// contributed by org.eclipse.xtext.xtext.generator.ImplicitFragment
 	public Class<? extends XtextEditor> bindXtextEditor() {
-		return XbaseEditor.class;
+		return XtendEditor.class;
 	}
 	
 	// contributed by org.eclipse.xtext.xtext.generator.ImplicitFragment

--- a/org.eclipse.xtend.ide/src-gen/org/eclipse/xtend/ide/editor/XtendEditor.java
+++ b/org.eclipse.xtend.ide/src-gen/org/eclipse/xtend/ide/editor/XtendEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010-2017 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,8 @@ package org.eclipse.xtend.ide.editor;
 import org.eclipse.xtext.xbase.ui.editor.XbaseEditor;
 
 /**
- * @author Karsten Thoms (karsten.thoms@itemis.de) - Initial contribution and API
+ * This class was generated. Customizations should only happen in a newly
+ * introduced subclass.
  */
 public class XtendEditor extends XbaseEditor {
-	// empty yet, but required for specialized adapter target
 }

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/XtendUiModule.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/XtendUiModule.xtend
@@ -346,10 +346,6 @@ class XtendUiModule extends AbstractXtendUiModule {
 		return XtendHoverDocumentationProvider
 	}
 
-	override Class<? extends XtextEditor> bindXtextEditor() {
-		return XtendEditor
-	}
-
 	override Class<? extends ITemplateProposalProvider> bindITemplateProposalProvider() {
 		return TemplateProposalProvider
 	}

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/XtendUiModule.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/XtendUiModule.java
@@ -48,7 +48,6 @@ import org.eclipse.xtend.ide.editor.RichStringAwareSourceViewer;
 import org.eclipse.xtend.ide.editor.RichStringAwareToggleCommentAction;
 import org.eclipse.xtend.ide.editor.SingleLineCommentHelper;
 import org.eclipse.xtend.ide.editor.XtendDoubleClickStrategyProvider;
-import org.eclipse.xtend.ide.editor.XtendEditor;
 import org.eclipse.xtend.ide.editor.XtendEditorErrorTickUpdater;
 import org.eclipse.xtend.ide.editor.XtendFoldingRegionProvider;
 import org.eclipse.xtend.ide.editor.XtendNatureAddingEditorCallback;
@@ -371,11 +370,6 @@ public class XtendUiModule extends AbstractXtendUiModule {
   @Override
   public Class<? extends IEObjectHoverDocumentationProvider> bindIEObjectHoverDocumentationProvider() {
     return XtendHoverDocumentationProvider.class;
-  }
-  
-  @Override
-  public Class<? extends XtextEditor> bindXtextEditor() {
-    return XtendEditor.class;
   }
   
   @Override


### PR DESCRIPTION
Added the new EditorFragment2 to GenerateXtend.mwe2 and configured the generated XtendEditor for the StratumBreakpointAdapterFactory.

Main part of the fix for [eclipse/xtext-eclipse#463] is in pull request [eclipse/xtext-core#561]

Signed-off-by: Florian Stolte <fstolte@itemis.de>