### PR TITLE
prevent JdtBasedProcessorProvider from exploding when using non efs filesystems

### DIFF
--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/macro/JdtBasedProcessorProvider.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/macro/JdtBasedProcessorProvider.xtend
@@ -133,7 +133,7 @@ class JdtBasedProcessorProvider extends ProcessorInstanceForJvmTypeProvider {
 					val IResource library = projectToUse.workspaceRoot.findMember(path)
 					url = if (library !== null) {
 						val locationUri = library.locationURI
-						if (EFS.SCHEME_FILE == locationUri) {
+						if (EFS.SCHEME_FILE == locationUri?.scheme) {
 							library.rawLocationURI?.toURL
 						} else {
 							//TODO we should support non default file systems as well

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/macro/JdtBasedProcessorProvider.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/macro/JdtBasedProcessorProvider.xtend
@@ -26,6 +26,7 @@ import org.eclipse.xtext.common.types.JvmType
 import org.eclipse.xtext.resource.ResourceSetContext
 import org.eclipse.xtext.resource.XtextResourceSet
 import org.eclipse.xtext.util.internal.Log
+import org.eclipse.core.filesystem.EFS
 
 @Log
 class JdtBasedProcessorProvider extends ProcessorInstanceForJvmTypeProvider {
@@ -131,7 +132,13 @@ class JdtBasedProcessorProvider extends ProcessorInstanceForJvmTypeProvider {
 					// thus we load it as a resource and take the raw path to find the location in the file system
 					val IResource library = projectToUse.workspaceRoot.findMember(path)
 					url = if (library !== null) {
-						library.rawLocationURI.toURL
+						val locationUri = library.locationURI
+						if (EFS.SCHEME_FILE == locationUri) {
+							library.rawLocationURI?.toURL
+						} else {
+							//TODO we should support non default file systems as well
+							null
+						}
 					} else {
 						// otherwise we use the path itself
 						path.toFile().toURI().toURL()

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/macro/JdtBasedProcessorProvider.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/macro/JdtBasedProcessorProvider.java
@@ -7,12 +7,14 @@
  */
 package org.eclipse.xtend.ide.macro;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import org.apache.log4j.Logger;
+import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.runtime.IPath;
@@ -171,7 +173,24 @@ public class JdtBasedProcessorProvider extends ProcessorInstanceForJvmTypeProvid
               final IResource library = this.getWorkspaceRoot(projectToUse).findMember(path_3);
               URL _xifexpression = null;
               if ((library != null)) {
-                _xifexpression = library.getRawLocationURI().toURL();
+                URL _xblockexpression = null;
+                {
+                  final java.net.URI locationUri = library.getLocationURI();
+                  URL _xifexpression_1 = null;
+                  boolean _equals = Objects.equal(EFS.SCHEME_FILE, locationUri);
+                  if (_equals) {
+                    java.net.URI _rawLocationURI = library.getRawLocationURI();
+                    URL _uRL_1 = null;
+                    if (_rawLocationURI!=null) {
+                      _uRL_1=_rawLocationURI.toURL();
+                    }
+                    _xifexpression_1 = _uRL_1;
+                  } else {
+                    _xifexpression_1 = null;
+                  }
+                  _xblockexpression = _xifexpression_1;
+                }
+                _xifexpression = _xblockexpression;
               } else {
                 _xifexpression = path_3.toFile().toURI().toURL();
               }

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/macro/JdtBasedProcessorProvider.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/macro/JdtBasedProcessorProvider.java
@@ -177,7 +177,11 @@ public class JdtBasedProcessorProvider extends ProcessorInstanceForJvmTypeProvid
                 {
                   final java.net.URI locationUri = library.getLocationURI();
                   URL _xifexpression_1 = null;
-                  boolean _equals = Objects.equal(EFS.SCHEME_FILE, locationUri);
+                  String _scheme = null;
+                  if (locationUri!=null) {
+                    _scheme=locationUri.getScheme();
+                  }
+                  boolean _equals = Objects.equal(EFS.SCHEME_FILE, _scheme);
                   if (_equals) {
                     java.net.URI _rawLocationURI = library.getRawLocationURI();
                     URL _uRL_1 = null;


### PR DESCRIPTION
prevent JdtBasedProcessorProvider from exploding when using non efs filesystems
https://github.com/eclipse/xtext-xtend/issues/50

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>