### PR TITLE
[eclipse/xtext-eclipse#463] Removed references to EditorFragment2

### DIFF
--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/GenerateXtend.mwe2
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/GenerateXtend.mwe2
@@ -128,8 +128,6 @@ Workflow {
 				useJdtRefactoring = true
 			}
 			
-			fragment = ui.editor.EditorFragment2 {}
-			
 			fragment = types.TypesGeneratorFragment2 {}
 			fragment = xbase.XbaseGeneratorFragment2 {
 				generateXtendInferrer = false


### PR DESCRIPTION
Adjustments due to the changes in [eclipse/xtext-core#574]:

- removed reference to the EditorFragment2 from Xtend generator.

Signed-off-by: Florian Stolte <fstolte@itemis.de>