### PR TITLE
[eclipse/xtext#1152] Java 9 - Added Automatic-Module-Name header

### DIFF
--- a/org.eclipse.xtend.caliper.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.caliper.tests/META-INF/MANIFEST.MF
@@ -23,3 +23,4 @@ Bundle-ClassPath: .,
 Import-Package: org.apache.log4j;version="1.2.15",
  org.junit;version="4.5.0",
  org.junit.runner;version="4.5.0"
+Automatic-Module-Name: org.eclipse.xtend.caliper.tests

--- a/org.eclipse.xtend.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.examples/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.6.0",
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
+Automatic-Module-Name: org.eclipse.xtend.examples

--- a/org.eclipse.xtend.examples/projects/xtend-annotation-examples-client/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.examples/projects/xtend-annotation-examples-client/META-INF/MANIFEST.MF
@@ -9,4 +9,5 @@ Require-Bundle: org.eclipse.xtend.lib,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
  xtend-annotation-examples;bundle-version="2.4.3"
 Bundle-Vendor: Eclipse Xtext
+Automatic-Module-Name: xtend-annotation-examples-client
 

--- a/org.eclipse.xtend.examples/projects/xtend-annotation-examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.examples/projects/xtend-annotation-examples/META-INF/MANIFEST.MF
@@ -21,4 +21,5 @@ Export-Package: extract,
  lazy,
  observables
 Bundle-Vendor: Eclipse Xtext
+Automatic-Module-Name: xtend-annotation-examples
 

--- a/org.eclipse.xtend.examples/projects/xtend-examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.examples/projects/xtend-examples/META-INF/MANIFEST.MF
@@ -8,3 +8,4 @@ Require-Bundle: org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
  org.eclipse.xtend.lib,
  org.junit;bundle-version="4.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: xtend-examples

--- a/org.eclipse.xtend.ide.swtbot.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.ide.swtbot.tests/META-INF/MANIFEST.MF
@@ -24,3 +24,4 @@ Require-Bundle: org.eclipse.swtbot.eclipse.core;bundle-version="2.1.1",
  org.hamcrest.library;bundle-version="1.3.0",
  org.eclipse.xtend.core,
  org.eclipse.xtext.ui.testing
+Automatic-Module-Name: org.eclipse.xtend.ide.swtbot.tests

--- a/org.eclipse.xtend.ide.tests.data/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.ide.tests.data/META-INF/MANIFEST.MF
@@ -12,3 +12,4 @@ Export-Package: org.eclipse.xtend.core.tests.internal;x-internal:=true,
  org.eclipse.xtend.ide.tests.data.highlighting,
  org.eclipse.xtend.ide.tests.data.quickfix
 Import-Package: org.junit;version="4.5.0"
+Automatic-Module-Name: org.eclipse.xtend.ide.tests.data

--- a/org.eclipse.xtend.ide.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.ide.tests/META-INF/MANIFEST.MF
@@ -44,3 +44,4 @@ Import-Package: org.apache.log4j;version="1.2.15",
  org.junit.runners;version="4.5.0",
  org.junit.runners.model;version="4.5.0"
 Export-Package: org.eclipse.xtend.ide.tests;x-friends:="org.eclipse.xtend.performance.tests"
+Automatic-Module-Name: org.eclipse.xtend.ide.tests

--- a/org.eclipse.xtend.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.ide/META-INF/MANIFEST.MF
@@ -58,4 +58,5 @@ Export-Package: org.eclipse.xtend.ide;x-internal:=true,
  org.eclipse.xtend.ide.validator.preferences;x-internal:=true,
  org.eclipse.xtend.ide.view;x-internal:=true,
  org.eclipse.xtend.ide.wizards;x-internal:=true
+Automatic-Module-Name: org.eclipse.xtend.ide
 

--- a/org.eclipse.xtend.m2e/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.m2e/META-INF/MANIFEST.MF
@@ -16,3 +16,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtend.m2e;x-internal:=true
 Import-Package: org.apache.maven.plugin;provider=m2e;resolution:=optional,
  org.apache.maven.project;provider=m2e;resolution:=optional
+Automatic-Module-Name: org.eclipse.xtend.m2e

--- a/org.eclipse.xtend.performance.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.performance.tests/META-INF/MANIFEST.MF
@@ -22,3 +22,4 @@ Require-Bundle: com.google.inject;bundle-version="3.0.0",
  org.eclipse.xtext.util,
  org.eclipse.emf.mwe2.launch;bundle-version="2.4.0";resolution:=optional,
  org.eclipse.xtext.ui.testing
+Automatic-Module-Name: org.eclipse.xtend.performance.tests

--- a/org.eclipse.xtend.swtbot/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.swtbot/META-INF/MANIFEST.MF
@@ -6,3 +6,4 @@ Bundle-Version: 2.14.0.qualifier
 Bundle-Vendor: Eclipse Xtext
 Fragment-Host: org.eclipse.swtbot.swt.finder;bundle-version="2.1.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: org.eclipse.xtend.swtbot


### PR DESCRIPTION
Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>