### PR TITLE
[#340] Fix test by ensure that preconditions are met.

### DIFF
--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/editor/DirtyStateEditorValidationTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/editor/DirtyStateEditorValidationTest.xtend
@@ -22,7 +22,6 @@ import org.junit.After
 import org.junit.Test
 
 import static org.eclipse.xtend.ide.tests.WorkbenchTestHelper.*
-import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
 
 /**
  * @author Sven Efftinge - Initial contribution and API
@@ -96,7 +95,7 @@ class DirtyStateEditorValidationTest extends AbstractXtendUITestCase {
 				}
 			}
 		''')
-		IResourcesSetupUtil.reallyWaitForAutoBuild
+		waitForBuild(null)
 		val markers = file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE)
 		if (markers.length > 0) {
 			fail(markers.map[getAttribute(IMarker.MESSAGE)].join('\n'))

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/editor/DirtyStateEditorValidationTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/editor/DirtyStateEditorValidationTest.java
@@ -24,7 +24,6 @@ import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
 import org.eclipse.xtext.ui.refactoring.ui.SyncUtil;
-import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
 import org.eclipse.xtext.validation.CheckMode;
@@ -164,7 +163,7 @@ public class DirtyStateEditorValidationTest extends AbstractXtendUITestCase {
       _builder_1.append("}");
       _builder_1.newLine();
       final IFile file = this.helper.createFileImpl("projectB/src/otherpack/OtherClass.xtend", _builder_1.toString());
-      IResourcesSetupUtil.reallyWaitForAutoBuild();
+      this._syncUtil.waitForBuild(null);
       final IMarker[] markers = file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
       int _length = markers.length;
       boolean _greaterThan = (_length > 0);


### PR DESCRIPTION
The test validates that the editors synchronize between one another even
if the file is not saved. But it has to assume that the build is run
before the editors are opened. Seems on CLI the autobuild is not run
fast enough and in result the "waitForAutobuild" is passed before the
build has even started. But this autobuild is not the intention of the
test, it is part of the setup. Hence we just initiate a build manually
just as the other test cases do, too. And wait for this build to finish.
Afterwards the testss succeed on CLI as well as in eclipse.

Change-Id: I13b8362a7fca8d54d532a1b789f1a3456a8a042f
Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>