### PR TITLE
[eclipse/xtext-eclipse#517] Bind deprecated interfaces.

### DIFF
--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/editor/copyqualifiedname/XtendCopyQualifiedNameServiceTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/editor/copyqualifiedname/XtendCopyQualifiedNameServiceTest.xtend
@@ -14,8 +14,8 @@ import org.eclipse.xtend.core.xtend.XtendFile
 import org.eclipse.xtend.core.xtend.XtendFunction
 import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase
 import org.eclipse.xtend.ide.tests.WorkbenchTestHelper
+import org.eclipse.xtext.naming.ICopyQualifiedNameService
 import org.eclipse.xtext.testing.util.ParseHelper
-import org.eclipse.xtext.ui.editor.copyqualifiedname.CopyQualifiedNameService
 import org.eclipse.xtext.ui.resource.IResourceSetProvider
 import org.eclipse.xtext.xbase.XAbstractFeatureCall
 import org.eclipse.xtext.xbase.XBlockExpression
@@ -34,7 +34,7 @@ class XtendCopyQualifiedNameServiceTest extends AbstractXtendUITestCase {
 	extension ParseHelper<XtendFile> parseHelper
 
 	@Inject
-	CopyQualifiedNameService copyQualifiedNameService
+	ICopyQualifiedNameService copyQualifiedNameService
 
 	@Test def void testJvmOperation() {
 		val xtendFile = '''

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/editor/copyqualifiedname/XtendCopyQualifiedNameServiceTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/editor/copyqualifiedname/XtendCopyQualifiedNameServiceTest.java
@@ -19,8 +19,8 @@ import org.eclipse.xtend.core.xtend.XtendTypeDeclaration;
 import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase;
 import org.eclipse.xtend.ide.tests.WorkbenchTestHelper;
 import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.naming.ICopyQualifiedNameService;
 import org.eclipse.xtext.testing.util.ParseHelper;
-import org.eclipse.xtext.ui.editor.copyqualifiedname.CopyQualifiedNameService;
 import org.eclipse.xtext.ui.resource.IResourceSetProvider;
 import org.eclipse.xtext.xbase.XAbstractFeatureCall;
 import org.eclipse.xtext.xbase.XBlockExpression;
@@ -45,7 +45,7 @@ public class XtendCopyQualifiedNameServiceTest extends AbstractXtendUITestCase {
   private ParseHelper<XtendFile> parseHelper;
   
   @Inject
-  private CopyQualifiedNameService copyQualifiedNameService;
+  private ICopyQualifiedNameService copyQualifiedNameService;
   
   @Test
   public void testJvmOperation() {

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/XtendUiModule.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/XtendUiModule.xtend
@@ -169,6 +169,7 @@ import org.eclipse.xtext.xbase.ui.jvmmodel.refactoring.jdt.JdtRenameRefactoringP
 import org.eclipse.xtext.xbase.ui.refactoring.ExpressionUtil
 import org.eclipse.xtext.xbase.ui.validation.XbaseIssueSeveritiesProvider
 import org.eclipse.xtext.xbase.ui.validation.XbaseUIValidator
+import org.eclipse.xtext.ui.editor.copyqualifiedname.CopyQualifiedNameService
 
 /** 
  * Use this class to register components to be used within the IDE.
@@ -423,7 +424,7 @@ class XtendUiModule extends AbstractXtendUiModule {
 		return EclipseFileSystemSupportImpl
 	}
 
-	override Class<? extends ICopyQualifiedNameService> bindICopyQualifiedNameService() {
+	override Class<? extends CopyQualifiedNameService> bindCopyQualifiedNameService() {
 		return XtendCopyQualifiedNameService
 	}
 

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/XtendUiModule.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/XtendUiModule.java
@@ -109,7 +109,6 @@ import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.Lexer;
 import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator;
 import org.eclipse.xtext.linking.ILinker;
-import org.eclipse.xtext.naming.ICopyQualifiedNameService;
 import org.eclipse.xtext.parser.antlr.LexerProvider;
 import org.eclipse.xtext.service.SingletonBinding;
 import org.eclipse.xtext.ui.codetemplates.ui.highlighting.TemplateBodyHighlighter;
@@ -126,6 +125,7 @@ import org.eclipse.xtext.ui.editor.contentassist.IContextInformationProvider;
 import org.eclipse.xtext.ui.editor.contentassist.IProposalConflictHelper;
 import org.eclipse.xtext.ui.editor.contentassist.ITemplateProposalProvider;
 import org.eclipse.xtext.ui.editor.contentassist.PrefixMatcher;
+import org.eclipse.xtext.ui.editor.copyqualifiedname.CopyQualifiedNameService;
 import org.eclipse.xtext.ui.editor.doubleClicking.DoubleClickStrategyProvider;
 import org.eclipse.xtext.ui.editor.embedded.IEditedResourceProvider;
 import org.eclipse.xtext.ui.editor.findrefs.DelegatingReferenceFinder;
@@ -457,7 +457,7 @@ public class XtendUiModule extends AbstractXtendUiModule {
   }
   
   @Override
-  public Class<? extends ICopyQualifiedNameService> bindICopyQualifiedNameService() {
+  public Class<? extends CopyQualifiedNameService> bindCopyQualifiedNameService() {
     return XtendCopyQualifiedNameService.class;
   }
   


### PR DESCRIPTION
Bind deprecated interfaces in addition to new ones.

Change-Id: Idc44f9c9e27d8250e783f7c6d01fc414309aef43
Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>