### PR TITLE
[#361] Implement "Redundant modifiers" Xtend validation rule.

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/performance/XtendFileGenerator.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/performance/XtendFileGenerator.xtend
@@ -273,7 +273,7 @@ class XtendFileGenerator {
 			
 			import java.math.BigDecimal;
 			
-			public class Amount {
+			class Amount {
 				
 				BigDecimal value
 			
@@ -289,19 +289,19 @@ class XtendFileGenerator {
 					return value.setScale(2, BigDecimal::ROUND_HALF_UP).toString();
 				}
 				
-				def public Amount operator_plus(Amount other) {
+				def Amount operator_plus(Amount other) {
 					return new Amount(this.value.add(other.value));
 				}
 				
-				def public Amount operator_minus(Amount other) {
+				def Amount operator_minus(Amount other) {
 					return new Amount(this.value.subtract(other.value));
 				}
 				
-				def public Amount operator_multiply(int factor) {
+				def Amount operator_multiply(int factor) {
 					return new Amount(this.value.multiply(new BigDecimal(factor)));
 				}
 				
-				def public Amount operator_divide(int divisor) {
+				def Amount operator_divide(int divisor) {
 					return new Amount(this.value.divide(new BigDecimal(divisor)));
 				}
 				
@@ -313,7 +313,7 @@ class XtendFileGenerator {
 		"xtend/tutorial/util/Circle.xtend" -> '''
 			package xtend.tutorial.util;
 			
-			public class Circle extends Shape {
+			class Circle extends Shape {
 				public int diameter;
 			
 				new(int diameter) {
@@ -331,23 +331,23 @@ class XtendFileGenerator {
 			
 			import static java.util.Collections.*;
 			
-			public class NetNode {
-				private String name;
-				private Iterable<NetNode> references = emptySet();
+			class NetNode {
+				String name;
+				Iterable<NetNode> references = emptySet();
 				
-				def public String getName() {
+				def String getName() {
 					return name;
 				}
 				
-				def public void setName(String name) {
+				def void setName(String name) {
 					this.name = name;
 				}
 				
-				def public Iterable<NetNode> getReferences() {
+				def Iterable<NetNode> getReferences() {
 					return references;
 				}
 				
-				def public void setReferences(Iterable<NetNode> references) {
+				def void setReferences(Iterable<NetNode> references) {
 					this.references = references;
 				}
 				
@@ -361,11 +361,11 @@ class XtendFileGenerator {
 			
 			import java.util.Set;
 			
-			public class Person {
+			class Person {
 				
-				private String forename;
-				private String name;
-				private Set<Person> friends;
+				String forename;
+				String name;
+				Set<Person> friends;
 				
 				new(String forename, String name) {
 					super();
@@ -376,27 +376,27 @@ class XtendFileGenerator {
 				new() {
 				}
 				
-				def public Set<Person> getFriends() {
+				def Set<Person> getFriends() {
 					return friends;
 				}
 				
-				def public void setFriends(Set<Person> friends) {
+				def void setFriends(Set<Person> friends) {
 					this.friends = friends;
 				}
 			
-				def public String getForename() {
+				def String getForename() {
 					return forename;
 				}
 				
-				def public void setForename(String forename) {
+				def void setForename(String forename) {
 					this.forename = forename;
 				}
 				
-				def public String getName() {
+				def String getName() {
 					return name;
 				}
 				
-				def public void setName(String name) {
+				def void setName(String name) {
 					this.name = name;
 				}
 				
@@ -408,7 +408,7 @@ class XtendFileGenerator {
 		"xtend/tutorial/util/Rectangle.xtend" -> '''
 			package xtend.tutorial.util;
 			
-			public class Rectangle extends Shape {
+			class Rectangle extends Shape {
 				
 				public int height;
 				public int width;
@@ -426,7 +426,7 @@ class XtendFileGenerator {
 		"xtend/tutorial/util/Shape.xtend" -> '''
 			package xtend.tutorial.util;
 			
-			public class Shape {
+			class Shape {
 			}
 		'''
 	}

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/ModifierValidationTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/ModifierValidationTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -31,6 +31,7 @@ class ModifierValidationTest extends AbstractXtendTestCase {
 		clazz('''abstract class Foo{}''').assertNoErrors
 		clazz('''dispatch class Foo{}''').assertError(XTEND_CLASS, INVALID_MODIFIER)
 		clazz('''final class Foo{}''').assertNoErrors
+		clazz('''public class Foo{}''').assertWarning(XTEND_CLASS, REDUNDANT_MODIFIER)
 	}
 	
 	@Test def void testNestedClassAllowedModifiers() {
@@ -129,6 +130,7 @@ class ModifierValidationTest extends AbstractXtendTestCase {
 		abstractFunction('''static def int foo();''').assertError(XTEND_FUNCTION, INVALID_MODIFIER)
 		function('''dispatch def foo (int i){}''').assertNoErrors
 		function('''final def foo() {}''').assertNoErrors
+		function('''public def foo() {}''').assertWarning(XTEND_FUNCTION, REDUNDANT_MODIFIER)
 	}
 
 	@Test def void testMethodInInterfaceAllowedModifiers() {
@@ -143,6 +145,8 @@ class ModifierValidationTest extends AbstractXtendTestCase {
 		memberInInterface('''final def foo() {}''').assertError(XTEND_FUNCTION, INVALID_MODIFIER)
 		memberInInterface('''strictfp def foo() {}''').assertError(XTEND_FUNCTION, INVALID_MODIFIER)
 		memberInInterface('''synchronized def foo() {}''').assertError(XTEND_FUNCTION, INVALID_MODIFIER)
+		memberInInterface('''override def foo() {}''').assertWarning(XTEND_FUNCTION, REDUNDANT_MODIFIER)
+		memberInInterface('''def override foo() {}''').assertWarning(XTEND_FUNCTION, REDUNDANT_MODIFIER)
 	}
 	
 	@Test def void testConstructorAllowedModifiers() {
@@ -171,6 +175,8 @@ class ModifierValidationTest extends AbstractXtendTestCase {
 		field('''final volatile int foo = 42''').assertError(XTEND_FIELD, INVALID_MODIFIER)
 		field('''volatile transient int foo''').assertNoErrors
 		field('''private transient volatile int foo''').assertNoErrors
+		field('''private int foo''').assertWarning(XTEND_FIELD, REDUNDANT_MODIFIER)
+		field('''private val foo=42''').assertWarning(XTEND_FIELD, REDUNDANT_MODIFIER)
 	}
 	
 	@Test def void testFieldInInterfaceAllowedModifiers() {
@@ -265,6 +271,8 @@ class ModifierValidationTest extends AbstractXtendTestCase {
 		field('''var final int i=42''').assertError(XTEND_FIELD, INVALID_MODIFIER)
 		field('''final val int i=42''').assertNoErrors
 		field('''val final int i=42''').assertNoErrors
+		field('''final val int i=42''').assertWarning(XTEND_FIELD, REDUNDANT_MODIFIER)
+		field('''val final int i=42''').assertWarning(XTEND_FIELD, REDUNDANT_MODIFIER)
 	}
 	
 	def protected memberInInterface(String model) {

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/ValidationBug437678Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/ValidationBug437678Test.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -208,7 +208,7 @@ class ValidationBug437678Test extends AbstractXtendTestCase {
 	@Test def void test_13() {
 		val file = parser.parse('''
 			class C {
-				private static val privateField = 1
+				static val privateField = 1
 				private static def privateMethod() { 2 }
 				def static m() {
 					privateField + privateMethod

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/performance/XtendFileGenerator.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/performance/XtendFileGenerator.java
@@ -972,7 +972,7 @@ public class XtendFileGenerator {
     _builder.append("import java.math.BigDecimal;");
     _builder.newLine();
     _builder.newLine();
-    _builder.append("public class Amount {");
+    _builder.append("class Amount {");
     _builder.newLine();
     _builder.append("\t");
     _builder.newLine();
@@ -1014,7 +1014,7 @@ public class XtendFileGenerator {
     _builder.append("\t");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def public Amount operator_plus(Amount other) {");
+    _builder.append("def Amount operator_plus(Amount other) {");
     _builder.newLine();
     _builder.append("\t\t");
     _builder.append("return new Amount(this.value.add(other.value));");
@@ -1025,7 +1025,7 @@ public class XtendFileGenerator {
     _builder.append("\t");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def public Amount operator_minus(Amount other) {");
+    _builder.append("def Amount operator_minus(Amount other) {");
     _builder.newLine();
     _builder.append("\t\t");
     _builder.append("return new Amount(this.value.subtract(other.value));");
@@ -1036,7 +1036,7 @@ public class XtendFileGenerator {
     _builder.append("\t");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def public Amount operator_multiply(int factor) {");
+    _builder.append("def Amount operator_multiply(int factor) {");
     _builder.newLine();
     _builder.append("\t\t");
     _builder.append("return new Amount(this.value.multiply(new BigDecimal(factor)));");
@@ -1047,7 +1047,7 @@ public class XtendFileGenerator {
     _builder.append("\t");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def public Amount operator_divide(int divisor) {");
+    _builder.append("def Amount operator_divide(int divisor) {");
     _builder.newLine();
     _builder.append("\t\t");
     _builder.append("return new Amount(this.value.divide(new BigDecimal(divisor)));");
@@ -1067,7 +1067,7 @@ public class XtendFileGenerator {
     _builder.append("package xtend.tutorial.util;");
     _builder.newLine();
     _builder.newLine();
-    _builder.append("public class Circle extends Shape {");
+    _builder.append("class Circle extends Shape {");
     _builder.newLine();
     _builder.append("\t");
     _builder.append("public int diameter;");
@@ -1100,18 +1100,18 @@ public class XtendFileGenerator {
     _builder.append("import static java.util.Collections.*;");
     _builder.newLine();
     _builder.newLine();
-    _builder.append("public class NetNode {");
+    _builder.append("class NetNode {");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("private String name;");
+    _builder.append("String name;");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("private Iterable<NetNode> references = emptySet();");
+    _builder.append("Iterable<NetNode> references = emptySet();");
     _builder.newLine();
     _builder.append("\t");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def public String getName() {");
+    _builder.append("def String getName() {");
     _builder.newLine();
     _builder.append("\t\t");
     _builder.append("return name;");
@@ -1122,7 +1122,7 @@ public class XtendFileGenerator {
     _builder.append("\t");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def public void setName(String name) {");
+    _builder.append("def void setName(String name) {");
     _builder.newLine();
     _builder.append("\t\t");
     _builder.append("this.name = name;");
@@ -1133,7 +1133,7 @@ public class XtendFileGenerator {
     _builder.append("\t");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def public Iterable<NetNode> getReferences() {");
+    _builder.append("def Iterable<NetNode> getReferences() {");
     _builder.newLine();
     _builder.append("\t\t");
     _builder.append("return references;");
@@ -1144,7 +1144,7 @@ public class XtendFileGenerator {
     _builder.append("\t");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def public void setReferences(Iterable<NetNode> references) {");
+    _builder.append("def void setReferences(Iterable<NetNode> references) {");
     _builder.newLine();
     _builder.append("\t\t");
     _builder.append("this.references = references;");
@@ -1167,18 +1167,18 @@ public class XtendFileGenerator {
     _builder.append("import java.util.Set;");
     _builder.newLine();
     _builder.newLine();
-    _builder.append("public class Person {");
+    _builder.append("class Person {");
     _builder.newLine();
     _builder.append("\t");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("private String forename;");
+    _builder.append("String forename;");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("private String name;");
+    _builder.append("String name;");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("private Set<Person> friends;");
+    _builder.append("Set<Person> friends;");
     _builder.newLine();
     _builder.append("\t");
     _builder.newLine();
@@ -1208,7 +1208,7 @@ public class XtendFileGenerator {
     _builder.append("\t");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def public Set<Person> getFriends() {");
+    _builder.append("def Set<Person> getFriends() {");
     _builder.newLine();
     _builder.append("\t\t");
     _builder.append("return friends;");
@@ -1219,7 +1219,7 @@ public class XtendFileGenerator {
     _builder.append("\t");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def public void setFriends(Set<Person> friends) {");
+    _builder.append("def void setFriends(Set<Person> friends) {");
     _builder.newLine();
     _builder.append("\t\t");
     _builder.append("this.friends = friends;");
@@ -1229,7 +1229,7 @@ public class XtendFileGenerator {
     _builder.newLine();
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def public String getForename() {");
+    _builder.append("def String getForename() {");
     _builder.newLine();
     _builder.append("\t\t");
     _builder.append("return forename;");
@@ -1240,7 +1240,7 @@ public class XtendFileGenerator {
     _builder.append("\t");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def public void setForename(String forename) {");
+    _builder.append("def void setForename(String forename) {");
     _builder.newLine();
     _builder.append("\t\t");
     _builder.append("this.forename = forename;");
@@ -1251,7 +1251,7 @@ public class XtendFileGenerator {
     _builder.append("\t");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def public String getName() {");
+    _builder.append("def String getName() {");
     _builder.newLine();
     _builder.append("\t\t");
     _builder.append("return name;");
@@ -1262,7 +1262,7 @@ public class XtendFileGenerator {
     _builder.append("\t");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("def public void setName(String name) {");
+    _builder.append("def void setName(String name) {");
     _builder.newLine();
     _builder.append("\t\t");
     _builder.append("this.name = name;");
@@ -1282,7 +1282,7 @@ public class XtendFileGenerator {
     _builder.append("package xtend.tutorial.util;");
     _builder.newLine();
     _builder.newLine();
-    _builder.append("public class Rectangle extends Shape {");
+    _builder.append("class Rectangle extends Shape {");
     _builder.newLine();
     _builder.append("\t");
     _builder.newLine();
@@ -1320,7 +1320,7 @@ public class XtendFileGenerator {
     _builder.append("package xtend.tutorial.util;");
     _builder.newLine();
     _builder.newLine();
-    _builder.append("public class Shape {");
+    _builder.append("class Shape {");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/ModifierValidationTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/ModifierValidationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -54,6 +54,9 @@ public class ModifierValidationTest extends AbstractXtendTestCase {
       StringConcatenation _builder_7 = new StringConcatenation();
       _builder_7.append("final class Foo{}");
       this._validationTestHelper.assertNoErrors(this.clazz(_builder_7.toString()));
+      StringConcatenation _builder_8 = new StringConcatenation();
+      _builder_8.append("public class Foo{}");
+      this._validationTestHelper.assertWarning(this.clazz(_builder_8.toString()), XtendPackage.Literals.XTEND_CLASS, IssueCodes.REDUNDANT_MODIFIER);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -339,6 +342,9 @@ public class ModifierValidationTest extends AbstractXtendTestCase {
       StringConcatenation _builder_10 = new StringConcatenation();
       _builder_10.append("final def foo() {}");
       this._validationTestHelper.assertNoErrors(this.function(_builder_10.toString()));
+      StringConcatenation _builder_11 = new StringConcatenation();
+      _builder_11.append("public def foo() {}");
+      this._validationTestHelper.assertWarning(this.function(_builder_11.toString()), XtendPackage.Literals.XTEND_FUNCTION, IssueCodes.REDUNDANT_MODIFIER);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -379,6 +385,12 @@ public class ModifierValidationTest extends AbstractXtendTestCase {
     StringConcatenation _builder_10 = new StringConcatenation();
     _builder_10.append("synchronized def foo() {}");
     this._validationTestHelper.assertError(this.memberInInterface(_builder_10.toString()), XtendPackage.Literals.XTEND_FUNCTION, IssueCodes.INVALID_MODIFIER);
+    StringConcatenation _builder_11 = new StringConcatenation();
+    _builder_11.append("override def foo() {}");
+    this._validationTestHelper.assertWarning(this.memberInInterface(_builder_11.toString()), XtendPackage.Literals.XTEND_FUNCTION, IssueCodes.REDUNDANT_MODIFIER);
+    StringConcatenation _builder_12 = new StringConcatenation();
+    _builder_12.append("def override foo() {}");
+    this._validationTestHelper.assertWarning(this.memberInInterface(_builder_12.toString()), XtendPackage.Literals.XTEND_FUNCTION, IssueCodes.REDUNDANT_MODIFIER);
   }
   
   @Test
@@ -458,6 +470,12 @@ public class ModifierValidationTest extends AbstractXtendTestCase {
       StringConcatenation _builder_11 = new StringConcatenation();
       _builder_11.append("private transient volatile int foo");
       this._validationTestHelper.assertNoErrors(this.field(_builder_11.toString()));
+      StringConcatenation _builder_12 = new StringConcatenation();
+      _builder_12.append("private int foo");
+      this._validationTestHelper.assertWarning(this.field(_builder_12.toString()), XtendPackage.Literals.XTEND_FIELD, IssueCodes.REDUNDANT_MODIFIER);
+      StringConcatenation _builder_13 = new StringConcatenation();
+      _builder_13.append("private val foo=42");
+      this._validationTestHelper.assertWarning(this.field(_builder_13.toString()), XtendPackage.Literals.XTEND_FIELD, IssueCodes.REDUNDANT_MODIFIER);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -717,6 +735,12 @@ public class ModifierValidationTest extends AbstractXtendTestCase {
       StringConcatenation _builder_3 = new StringConcatenation();
       _builder_3.append("val final int i=42");
       this._validationTestHelper.assertNoErrors(this.field(_builder_3.toString()));
+      StringConcatenation _builder_4 = new StringConcatenation();
+      _builder_4.append("final val int i=42");
+      this._validationTestHelper.assertWarning(this.field(_builder_4.toString()), XtendPackage.Literals.XTEND_FIELD, IssueCodes.REDUNDANT_MODIFIER);
+      StringConcatenation _builder_5 = new StringConcatenation();
+      _builder_5.append("val final int i=42");
+      this._validationTestHelper.assertWarning(this.field(_builder_5.toString()), XtendPackage.Literals.XTEND_FIELD, IssueCodes.REDUNDANT_MODIFIER);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/ValidationBug437678Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/ValidationBug437678Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -453,7 +453,7 @@ public class ValidationBug437678Test extends AbstractXtendTestCase {
       _builder.append("class C {");
       _builder.newLine();
       _builder.append("\t");
-      _builder.append("private static val privateField = 1");
+      _builder.append("static val privateField = 1");
       _builder.newLine();
       _builder.append("\t");
       _builder.append("private static def privateMethod() { 2 }");

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/IssueCodes.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/IssueCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -104,5 +104,10 @@ public final class IssueCodes {
 	public static final String API_TYPE_INFERENCE = ISSUE_CODE_PREFIX +  "api_type_inference";
 	
 	public static final String IMPLICIT_RETURN = ISSUE_CODE_PREFIX +  "implicit_return";
+	
+	/**
+	 * @since 2.14
+	 */
+	public static final String REDUNDANT_MODIFIER = ISSUE_CODE_PREFIX +  "redundant_modifier";
 	
 }


### PR DESCRIPTION
Extend the Xtend modifier validator with "Redundant modifiers" to raise warnings in case of:
- 'final' in combination with 'val'
- 'private' on fields
- 'public' on methods
- 'public' on classes
- 'def' in combination with 'override'
- Implement corresponding ModifierValidationTest test cases.
- Eliminate redundant modifiers from the Xtend test data in order not to break existing test cases.
Signed-off-by: Tamas Miklossy <miklossy@itemis.de>