### PR TITLE
eclipse/xtext-eclipse#539 Make dialog compatible with Eclipse Photon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ With the above configuration, [Sonatype snapshots](https://oss.sonatype.org/cont
 
 Run `mvn -f tycho-pom.xml clean install`.
 
-Note: The [target platform](releng/org.eclipse.xtend.target/org.eclipse.xtend.target.target) used for the Tycho build loads the required Xtext dependencies ([xtext-lib](https://github.com/eclipse/xtext-lib), [xtext-core](https://github.com/eclipse/xtext-core), [xtext-extras](https://github.com/eclipse/xtext-extras)) from their respective p2 repositories on the [Jenkins server](http://services.typefox.io/open-source/jenkins/).
+Note: The [target platform](releng/org.eclipse.xtend.target/org.eclipse.xtend.target-luna.target) used for the Tycho build loads the required Xtext dependencies ([xtext-lib](https://github.com/eclipse/xtext-lib), [xtext-core](https://github.com/eclipse/xtext-core), [xtext-extras](https://github.com/eclipse/xtext-extras)) from their respective p2 repositories on the [Jenkins server](http://services.typefox.io/open-source/jenkins/).
 
 ## How to Work with the Source Code
 
@@ -36,6 +36,6 @@ For
 
 see [xtext/CONTRIBUTING.md](https://github.com/eclipse/xtext/blob/master/CONTRIBUTING.md).
 
-## Continuos Integration
+## Continuous Integration
 
 This project is built by the [xtext-xtend multi-branch job on Jenkins](http://services.typefox.io/open-source/jenkins/job/xtext-xtend/).

--- a/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/swtbot/EclipseAPI.java
+++ b/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/swtbot/EclipseAPI.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.ide.swtbot;
+
+import org.eclipse.xtend.ide.swtbot.api.MainMenuAPI;
+import org.eclipse.xtend.ide.swtbot.lowlevel.XtextSWTWorkbenchBot;
+
+/**
+ * Starter class for all SWTBot tests. Provides static methods to access all parts of the IDE.
+ * 
+ * @author Arne Deutsch - Initial contribution and API
+ */
+public class EclipseAPI {
+
+	private static XtextSWTWorkbenchBot bot = new XtextSWTWorkbenchBot();
+
+	private EclipseAPI() {
+	}
+
+	public static MainMenuAPI mainMenu() {
+		return new MainMenuAPI(bot);
+	}
+
+	public static void closeAllShells() {
+		bot.closeAllShells();
+	}
+
+}

--- a/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/swtbot/api/MainMenuAPI.java
+++ b/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/swtbot/api/MainMenuAPI.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.ide.swtbot.api;
+
+import org.eclipse.xtend.ide.swtbot.api.preferences.PreferencesDialogAPI;
+import org.eclipse.xtend.ide.swtbot.lowlevel.XtextSWTWorkbenchBot;
+
+/**
+ * Main menu of eclipse. Can be used to start all kind of actions, e.g. open the preferences.
+ * 
+ * @author Arne Deutsch - Initial contribution and API
+ */
+public class MainMenuAPI {
+
+	private final XtextSWTWorkbenchBot bot;
+
+	public MainMenuAPI(XtextSWTWorkbenchBot bot) {
+		this.bot = bot;
+	}
+
+	public PreferencesDialogAPI openPreferences() {
+		bot.menu("Window").menu("Preferences").click();
+		return new PreferencesDialogAPI(bot.shell("Preferences"));
+	}
+
+}

--- a/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/swtbot/api/preferences/PreferencesDialogAPI.java
+++ b/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/swtbot/api/preferences/PreferencesDialogAPI.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.ide.swtbot.api.preferences;
+
+import org.eclipse.xtend.ide.swtbot.lowlevel.XtextSWTBotShell;
+
+/**
+ * API to access functionality from the preference dialog through SWTBot.
+ * 
+ * @author Arne Deutsch - Initial contribution and API
+ */
+public class PreferencesDialogAPI {
+
+	private final XtextSWTBotShell shell;
+
+	public PreferencesDialogAPI(XtextSWTBotShell shell) {
+		this.shell = shell;
+	}
+
+	public void cancel() {
+		shell.bot().button("Cancel").click();
+	}
+
+	public XtendFormatterPreferencePageAPI activateXtendFormatterPage() {
+		shell.bot().tree().expandNode("Xtend").select("Formatter");
+		return new XtendFormatterPreferencePageAPI(shell.bot());
+	}
+
+}

--- a/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/swtbot/api/preferences/XtendFormatterPreferenceEditDialogAPI.java
+++ b/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/swtbot/api/preferences/XtendFormatterPreferenceEditDialogAPI.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.ide.swtbot.api.preferences;
+
+import org.eclipse.xtend.ide.swtbot.lowlevel.XtextSWTBotShell;
+
+/**
+ * API to access functionality from the xtend formatter preference edit dialog through SWTBot.
+ * 
+ * @author Arne Deutsch - Initial contribution and API
+ */
+public class XtendFormatterPreferenceEditDialogAPI {
+
+	private final XtextSWTBotShell shell;
+
+	XtendFormatterPreferenceEditDialogAPI(XtextSWTBotShell shell) {
+		this.shell = shell;
+	}
+
+	public void cancel() {
+		shell.bot().button("Cancel").click();
+	}
+
+	public void activateBracesSection() {
+		shell.bot().tabItem("Braces").activate();
+	}
+
+	public void activateWhiteSpaceSection() {
+		shell.bot().tabItem("White Space").activate();
+	}
+
+	public void activateBlankLinesSection() {
+		shell.bot().tabItem("Blank Lines").activate();
+	}
+
+	public void activateNewLinesSection() {
+		shell.bot().tabItem("New Lines").activate();
+	}
+
+	public void activateLineWrappingSection() {
+		shell.bot().tabItem("Line Wrapping").activate();
+	}
+
+}

--- a/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/swtbot/api/preferences/XtendFormatterPreferencePageAPI.java
+++ b/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/swtbot/api/preferences/XtendFormatterPreferencePageAPI.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.ide.swtbot.api.preferences;
+
+import org.eclipse.xtend.ide.swtbot.lowlevel.XtextSWTBot;
+
+/**
+ * API to access functionality from the xtend formatter preference page through SWTBot.
+ * 
+ * @author Arne Deutsch - Initial contribution and API
+ */
+public class XtendFormatterPreferencePageAPI {
+
+	private XtextSWTBot bot;
+
+	XtendFormatterPreferencePageAPI(XtextSWTBot bot) {
+		this.bot = bot;
+	}
+
+	public XtendFormatterPreferenceEditDialogAPI openEditDialog() {
+		bot.button("Edit...").click();
+		return new XtendFormatterPreferenceEditDialogAPI(bot.shellWithRegex("Profile.*"));
+	}
+
+}

--- a/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/swtbot/lowlevel/XtextSWTBot.java
+++ b/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/swtbot/lowlevel/XtextSWTBot.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.ide.swtbot.lowlevel;
+
+import static org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory.*;
+import static org.eclipse.swtbot.swt.finder.waits.Conditions.*;
+
+import java.util.List;
+
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swtbot.swt.finder.SWTBot;
+import org.eclipse.swtbot.swt.finder.waits.WaitForObjectCondition;
+import org.hamcrest.Matcher;
+
+/**
+ * Our own implementation of SWTBot to add new methods to standard implementation.
+ * 
+ * @author Arne Deutsch - Initial contribution and API
+ */
+public class XtextSWTBot extends SWTBot {
+
+	public XtextSWTBot(Shell widget) {
+		super(widget);
+	}
+
+	public XtextSWTBotShell shellWithRegex(String regex) {
+		return new XtextSWTBotShell(shellsWithRegex(regex).get(0));
+	}
+
+	private List<Shell> shellsWithRegex(String regex) {
+		Matcher<Shell> withRegex = withRegex(regex);
+		WaitForObjectCondition<Shell> waitForShell = waitForShell(withRegex);
+		waitUntilWidgetAppears(waitForShell);
+		return waitForShell.getAllMatches();
+	}
+}

--- a/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/swtbot/lowlevel/XtextSWTBotShell.java
+++ b/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/swtbot/lowlevel/XtextSWTBotShell.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.ide.swtbot.lowlevel;
+
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
+
+/**
+ * Our own implementation of SWTBotShell to add new methods to standard implementation.
+ * 
+ * @author Arne Deutsch - Initial contribution and API
+ */
+public class XtextSWTBotShell extends SWTBotShell {
+
+	public XtextSWTBotShell(Shell shell) {
+		super(shell);
+	}
+	
+	@Override
+	public XtextSWTBot bot() {
+		return new XtextSWTBot(widget);
+	}
+
+}

--- a/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/swtbot/lowlevel/XtextSWTWorkbenchBot.java
+++ b/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/swtbot/lowlevel/XtextSWTWorkbenchBot.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.ide.swtbot.lowlevel;
+
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+
+/**
+ * Our own implementation of SWTWorkbenchBot to add new methods to standard implementation.
+ * 
+ * @author Arne Deutsch - Initial contribution and API
+ */
+public class XtextSWTWorkbenchBot extends SWTWorkbenchBot {
+
+	@Override
+	public XtextSWTBotShell shell(String text) {
+		return shell(text, 0);
+	}
+
+	@Override
+	public XtextSWTBotShell shell(String text, int index) {
+		return new XtextSWTBotShell(shells(text).get(index));
+	}
+
+}

--- a/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/tests/AbstractSwtBotTest.java
+++ b/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/tests/AbstractSwtBotTest.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.ide.tests;
+
+import org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable;
+import org.eclipse.swtbot.swt.finder.results.VoidResult;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
+import org.eclipse.xtext.ui.testing.util.TargetPlatformUtil;
+import org.junit.BeforeClass;
+
+/**
+ * @author Arne Deutsch - Initial contribution and API
+ */
+public class AbstractSwtBotTest {
+
+	@BeforeClass
+	public static void initialize() throws Exception {
+		TargetPlatformUtil.setTargetPlatform(AbstractSwtBotTest.class);
+		IResourcesSetupUtil.cleanWorkspace();
+		UIThreadRunnable.syncExec(new VoidResult() {
+			@Override
+			public void run() {
+				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell().forceActive();
+			}
+		});
+	}
+
+}

--- a/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/tests/preferences/FormatterPreferencesTest.java
+++ b/org.eclipse.xtend.ide.swtbot.tests/swtbot/src/org/eclipse/xtend/ide/tests/preferences/FormatterPreferencesTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.ide.tests.preferences;
+
+import static org.eclipse.xtend.ide.swtbot.EclipseAPI.*;
+
+import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
+import org.eclipse.xtend.ide.swtbot.api.preferences.PreferencesDialogAPI;
+import org.eclipse.xtend.ide.swtbot.api.preferences.XtendFormatterPreferenceEditDialogAPI;
+import org.eclipse.xtend.ide.tests.AbstractSwtBotTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests for the foramtter preference page.
+ * 
+ * @author Arne Deutsch - Initial contribution and API
+ */
+@RunWith(SWTBotJunit4ClassRunner.class)
+public class FormatterPreferencesTest extends AbstractSwtBotTest {
+
+	@Before
+	public void setUp() {
+		closeAllShells();
+	}
+
+	@After
+	public void tearDown() {
+		closeAllShells();
+	}
+
+	@Test
+	public void formatterPreferencesEditDialog_CanBeOpenedAndAllSectionsExist() throws Exception {
+		PreferencesDialogAPI preferenceDialog = mainMenu().openPreferences();
+
+		XtendFormatterPreferenceEditDialogAPI editDialog = preferenceDialog.activateXtendFormatterPage().openEditDialog();
+		editDialog.activateBracesSection();
+		editDialog.activateWhiteSpaceSection();
+		editDialog.activateBlankLinesSection();
+		editDialog.activateNewLinesSection();
+		editDialog.activateLineWrappingSection();
+		editDialog.cancel();
+
+		preferenceDialog.cancel();
+	}
+
+}

--- a/org.eclipse.xtend.ide.swtbot.tests/xtend.ide.tests.slow (SWTBot).launch
+++ b/org.eclipse.xtend.ide.swtbot.tests/xtend.ide.tests.slow (SWTBot).launch
@@ -14,12 +14,12 @@
 <booleanAttribute key="includeOptional" value="true"/>
 <stringAttribute key="location" value="${workspace_loc}/../junit-swtbot-workspace"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/org.eclipse.xtend.ide.swtbot.tests/swtbot/xtend-gen"/>
+<listEntry value="/org.eclipse.xtend.ide.swtbot.tests/swtbot/src"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="2"/>
 </listAttribute>
-<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=org.eclipse.xtend.ide.swtbot.tests/swtbot\/xtend-gen"/>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=org.eclipse.xtend.ide.swtbot.tests/swtbot\/src"/>
 <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
 <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
 <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/formatting/preferences/FormatterModifyDialog.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/formatting/preferences/FormatterModifyDialog.java
@@ -7,60 +7,267 @@
  *******************************************************************************/
 package org.eclipse.xtend.ide.formatting.preferences;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jdt.internal.ui.preferences.formatter.IModifyDialogTabPage;
 import org.eclipse.jdt.internal.ui.preferences.formatter.ModifyDialog;
 import org.eclipse.jdt.internal.ui.preferences.formatter.ProfileManager;
 import org.eclipse.jdt.internal.ui.preferences.formatter.ProfileManager.Profile;
 import org.eclipse.jdt.internal.ui.preferences.formatter.ProfileStore;
+import org.eclipse.jdt.internal.ui.wizards.dialogfields.DialogField;
+import org.eclipse.jdt.internal.ui.wizards.dialogfields.IDialogFieldListener;
+import org.eclipse.jdt.internal.ui.wizards.dialogfields.StringDialogField;
+import org.eclipse.jdt.ui.JavaUI;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.IDialogSettings;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.TabFolder;
+import org.eclipse.swt.widgets.TabItem;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.xtend.ide.internal.XtendActivator;
 
 import com.google.inject.Inject;
 import com.google.inject.MembersInjector;
 
 /**
+ * The dialog to configure the Xtend formatter settings.
+ * 
+ * Makes use of internal JDT classes. As result was broken with Eclipse Photon. Reflective calls are needed to maintain backwards
+ * compatibility. Should be replaced with new version in some future Xtend release (as soon as Xtext implements some base classes that Xtend
+ * can reuse).
+ * 
  * @author Dennis Huebner - Initial contribution and API
+ * @author Arne Deutsch - Adapted to work with Eclipse Photon as well as with older eclipse versions.
  */
 @SuppressWarnings("restriction")
 public class FormatterModifyDialog extends ModifyDialog {
 
 	public static class Factory {
-
 		@Inject
 		MembersInjector<FormatterModifyDialog> injector;
 
-		public FormatterModifyDialog create(Shell parentShell, Profile profile, ProfileManager profileManager,
-				ProfileStore profileStore, boolean newProfile, String dialogPreferencesKey, String lastSavePathKey) {
-			FormatterModifyDialog modifyDialog = new FormatterModifyDialog(parentShell, profile, profileManager,
-					profileStore, newProfile, dialogPreferencesKey, lastSavePathKey);
+		public FormatterModifyDialog create(Shell parentShell, Profile profile, ProfileManager profileManager, ProfileStore profileStore,
+				boolean newProfile, String dialogPreferencesKey, String lastSavePathKey) {
+			FormatterModifyDialog modifyDialog = new FormatterModifyDialog(parentShell, profile, profileManager, profileStore, newProfile,
+					dialogPreferencesKey, lastSavePathKey);
 			injector.injectMembers(modifyDialog);
 			return modifyDialog;
 		}
-
 	}
 
 	@Inject
 	private TabFactory tabFactory;
 
-	public FormatterModifyDialog(Shell parentShell, Profile profile, ProfileManager profileManager,
-			ProfileStore profileStore, boolean newProfile, String dialogPreferencesKey, String lastSavePathKey) {
+	// following fields are needed to maintain compatibility to Eclipse Photon
+	/**
+	 * The key to store the number (beginning at 0) of the tab page which had the focus last time.
+	 */
+	private static final String DS_KEY_LAST_FOCUS = "modify_dialog.last_focus"; //$NON-NLS-1$
+	private final List<IModifyDialogTabPage> fTabPages = new ArrayList<>();
+	private final Profile fProfile;
+	private final String fKeyLastFocus;
+	private final IDialogSettings fDialogSettings;
+	private TabFolder fTabFolder;
+
+	public FormatterModifyDialog(Shell parentShell, Profile profile, ProfileManager profileManager, ProfileStore profileStore,
+			boolean newProfile, String dialogPreferencesKey, String lastSavePathKey) {
 		super(parentShell, profile, profileManager, profileStore, newProfile, dialogPreferencesKey, lastSavePathKey);
+		this.fProfile = profile;
+		this.fKeyLastFocus = JavaUI.ID_PLUGIN + dialogPreferencesKey + DS_KEY_LAST_FOCUS;
+		this.fDialogSettings = JavaPlugin.getDefault().getDialogSettings();
+	}
+
+	// @Override intentionally removed to ensure backward compatibility
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	protected void addPages(final Map values) {
+		if (isOldAPIVersion()) {
+			try {
+				// use reflection to not break API
+				Method addTabPage = ModifyDialog.class.getDeclaredMethod("addTabPage", String.class, IModifyDialogTabPage.class);
+				//		addTabPage("Indentation", tabFactory.createIndentationTab(this, values));
+				addTabPage.invoke(this, "Braces", tabFactory.createBracesTab(this, values));
+				addTabPage.invoke(this, "White Space", tabFactory.createWhiteSpaceTab(this, values));
+				addTabPage.invoke(this, "Blank Lines", tabFactory.createBlankLinesTab(this, values));
+				addTabPage.invoke(this, "New Lines", tabFactory.createNewLineTab(this, values));
+				addTabPage.invoke(this, "Line Wrapping", tabFactory.createLineWrapTab(this, values));
+			} catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException
+					| InvocationTargetException e) {
+				XtendActivator.getInstance().getLog().log(new Status(IStatus.ERROR, XtendActivator.PLUGIN_ID, e.getMessage(), e));
+			}
+		} else {
+			addTabPageNewAPI("Braces", tabFactory.createBracesTab(this, values));
+			addTabPageNewAPI("White Space", tabFactory.createWhiteSpaceTab(this, values));
+			addTabPageNewAPI("Blank Lines", tabFactory.createBlankLinesTab(this, values));
+			addTabPageNewAPI("New Lines", tabFactory.createNewLineTab(this, values));
+			addTabPageNewAPI("Line Wrapping", tabFactory.createLineWrapTab(this, values));
+		}
+	}
+
+	// copied from Eclipse Oxygen to support old dialog in Eclipse Photon
+	private final void addTabPageNewAPI(String title, IModifyDialogTabPage tabPage) {
+		final TabItem tabItem = new TabItem(fTabFolder, SWT.NONE);
+		applyDialogFont(tabItem.getControl());
+		tabItem.setText(title);
+		tabItem.setData(tabPage);
+		tabItem.setControl(tabPage.createContents(fTabFolder));
+		fTabPages.add(tabPage);
 	}
 
 	@Override
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	protected void addPages(final Map values) {
-//		addTabPage("Indentation", tabFactory.createIndentationTab(this, values));
-		addTabPage("Braces", tabFactory.createBracesTab(this, values));
-		addTabPage("White Space", tabFactory.createWhiteSpaceTab(this, values));
-		addTabPage("Blank Lines", tabFactory.createBlankLinesTab(this, values));
-		addTabPage("New Lines", tabFactory.createNewLineTab(this, values));
-		addTabPage("Line Wrapping", tabFactory.createLineWrapTab(this, values));
+	public void create() {
+		if (isOldAPIVersion()) {
+			super.create();
+			return;
+		}
+		// copied from Eclipse Oxygen to support old dialog in Eclipse Photon
+		super.create();
+		int lastFocusNr = 0;
+		try {
+			lastFocusNr = fDialogSettings.getInt(fKeyLastFocus);
+			if (lastFocusNr < 0)
+				lastFocusNr = 0;
+			if (lastFocusNr > fTabPages.size() - 1)
+				lastFocusNr = fTabPages.size() - 1;
+		} catch (NumberFormatException x) {
+			lastFocusNr = 0;
+		}
+
+		try {
+			// use reflection to not break API
+			Field fNewProfile = ModifyDialog.class.getDeclaredField("fNewProfile");
+			fNewProfile.setAccessible(true);
+			if (!fNewProfile.getBoolean(this)) {
+				fTabFolder.setSelection(lastFocusNr);
+				((IModifyDialogTabPage) fTabFolder.getSelection()[0].getData()).setInitialFocus();
+			}
+		} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+			XtendActivator.getInstance().getLog().log(new Status(IStatus.ERROR, XtendActivator.PLUGIN_ID, e.getMessage(), e));
+		}
 	}
-	
+
+	@Override
+	@SuppressWarnings("rawtypes")
+	protected Control createDialogArea(Composite parent) {
+		if (isOldAPIVersion()) {
+			return super.createDialogArea(parent);
+		}
+		try {
+			// copied from Eclipse Oxygen to support old dialog in Eclipse Photon
+			final Composite composite = new Composite(parent, SWT.NONE);
+			GridLayout layout = new GridLayout();
+			layout.marginHeight = convertVerticalDLUsToPixels(IDialogConstants.VERTICAL_MARGIN);
+			layout.marginWidth = convertHorizontalDLUsToPixels(IDialogConstants.HORIZONTAL_MARGIN);
+			layout.verticalSpacing = convertVerticalDLUsToPixels(IDialogConstants.VERTICAL_SPACING);
+			layout.horizontalSpacing = convertHorizontalDLUsToPixels(IDialogConstants.HORIZONTAL_SPACING);
+			composite.setLayout(layout);
+			composite.setLayoutData(new GridData(GridData.FILL_BOTH));
+			applyDialogFont(composite);
+
+			Composite nameComposite = new Composite(composite, SWT.NONE);
+			nameComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+			nameComposite.setLayout(new GridLayout(3, false));
+
+			// use reflection to not break API
+			Field fProfileNameField = ModifyDialog.class.getDeclaredField("fProfileNameField");
+			fProfileNameField.setAccessible(true);
+			StringDialogField f = new StringDialogField();
+			fProfileNameField.set(this, f);
+			f.setLabelText("&Profile name:");
+
+			f.setText(fProfile.getName());
+			f.getLabelControl(nameComposite).setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
+			f.getTextControl(nameComposite).setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+			f.setDialogFieldListener(new IDialogFieldListener() {
+				@Override
+				public void dialogFieldChanged(DialogField field) {
+					try {
+						Method doValidate = ModifyDialog.class.getDeclaredMethod("doValidate");
+						doValidate.setAccessible(true);
+						doValidate.invoke(FormatterModifyDialog.this);
+					} catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException
+							| InvocationTargetException e) {
+						XtendActivator.getInstance().getLog().log(new Status(IStatus.ERROR, XtendActivator.PLUGIN_ID, e.getMessage(), e));
+					}
+				}
+			});
+
+			// use reflection to not break API
+			Field fSaveButton = ModifyDialog.class.getDeclaredField("fSaveButton");
+			fSaveButton.setAccessible(true);
+			fSaveButton.set(this, createButton(nameComposite, IDialogConstants.CLIENT_ID + 1, "E&xport...", false));
+
+			fTabFolder = new TabFolder(composite, SWT.NONE);
+			fTabFolder.setFont(composite.getFont());
+			fTabFolder.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+			// use reflection to not break API
+			Field fWorkingValues = ModifyDialog.class.getDeclaredField("fWorkingValues");
+			fWorkingValues.setAccessible(true);
+			addPages((Map) fWorkingValues.get(this));
+
+			applyDialogFont(composite);
+
+			fTabFolder.addSelectionListener(new SelectionListener() {
+				@Override
+				public void widgetDefaultSelected(SelectionEvent e) {
+				}
+
+				@Override
+				public void widgetSelected(SelectionEvent e) {
+					final TabItem tabItem = (TabItem) e.item;
+					final IModifyDialogTabPage page = (IModifyDialogTabPage) tabItem.getData();
+					fDialogSettings.put(fKeyLastFocus, fTabPages.indexOf(page));
+					page.makeVisible();
+				}
+			});
+
+			// use reflection to not break API
+			Method doValidate = ModifyDialog.class.getDeclaredMethod("doValidate");
+			doValidate.setAccessible(true);
+			doValidate.invoke(this);
+
+			PlatformUI.getWorkbench().getHelpSystem().setHelp(composite, getHelpContextId());
+
+			return composite;
+		} catch (NoSuchMethodException | SecurityException | IllegalArgumentException | IllegalAccessException | InvocationTargetException
+				| NoSuchFieldException e) {
+			XtendActivator.getInstance().getLog().log(new Status(IStatus.ERROR, XtendActivator.PLUGIN_ID, e.getMessage(), e));
+			return null;
+		}
+	}
+
 	@Override
 	protected String getHelpContextId() {
 		return null;
+	}
+
+	/**
+	 * Check if the old (<= Eclipse Oxygen) API is used or not.
+	 * 
+	 * @return true if the Eclipse API is Eclipse Oxygen or older, true for Eclipse Photon or newer.
+	 */
+	private boolean isOldAPIVersion() {
+		try {
+			ModifyDialog.class.getDeclaredMethod("addPages", Map.class);
+			return true;
+		} catch (NoSuchMethodException | SecurityException e) {
+			return false;
+		}
 	}
 
 }


### PR DESCRIPTION
Implemented the dialog in a way such that it is compatible with Eclipse
Photon as well as with older Eclipse versions. Some nasty reflection is
needed to maintain backwards compatibility. Should be replaced with
Xtext based implementation in future.

Change-Id: Icecbf625da3fd2244ae507c83c0c90e481b5f38e
Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>