### PR TITLE
Change to protected the visibility of the getOutermostType function.

### DIFF
--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendValidator.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendValidator.java
@@ -163,6 +163,7 @@ import com.google.inject.Inject;
  * @author Sebastian Zarnekow
  * @author Sven Efftinge
  * @author Holger Schill
+ * @author Stephane Galland
  */
 @ComposedChecks(validators = { AnnotationValidation.class })
 public class XtendValidator extends XbaseWithAnnotationsValidator {
@@ -1701,7 +1702,10 @@ public class XtendValidator extends XbaseWithAnnotationsValidator {
 		}
 	}
 
-	private EObject getOutermostType(XtendMember member) {
+	/** Replies the outer-most type of the given member.
+	 * @return the container of {@code XtendTypeDeclaration} type if it exists, or the direct container.
+	 */
+	protected final EObject getOutermostType(XtendMember member) {
 		XtendTypeDeclaration result = EcoreUtil2.getContainerOfType(member, XtendTypeDeclaration.class);
 		if (result == null) {
 			return member.eContainer();


### PR DESCRIPTION
In order to be used by the DSL validator, the `getOutermostType` function's visibility should be changed to `protected`.

Signed-off-by: Stéphane Galland <galland@arakhne.org>