### PR TITLE
[#383] Fixed FileSystemSupport.getPath() to work with multiple projects

### DIFF
--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/AbstractFileSystemSupport.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/AbstractFileSystemSupport.xtend
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
 package org.eclipse.xtend.core.macro
 
 import com.google.common.io.ByteStreams
@@ -292,7 +299,18 @@ abstract class AbstractFileSystemSupport implements MutableFileSystemSupport {
 	}
 
 	protected def getPath(URI absoluteURI, URI baseURI, Path basePath) {
-		val relativeURI = absoluteURI.deresolve(baseURI)
+		val URI relativeURI = 
+		if (baseURI.isPlatformResource && absoluteURI.isPlatformResource) {
+			if (baseURI.segment(1) != absoluteURI.segment(1)) {
+				val p = new org.eclipse.core.runtime.Path(absoluteURI.toPlatformString(true));
+				URI.createURI(".."+p.toString)
+			} else {	
+				absoluteURI.deresolve(baseURI)
+			}
+		} else {
+			absoluteURI.deresolve(baseURI)
+		}
+		 
 		if (relativeURI.empty || relativeURI == absoluteURI)
 			return null
 		

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/AbstractFileSystemSupport.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/AbstractFileSystemSupport.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2015, 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.xtend.core.macro;
 
 import com.google.common.base.Objects;
@@ -459,7 +466,30 @@ public abstract class AbstractFileSystemSupport implements MutableFileSystemSupp
   protected Path getPath(final URI absoluteURI, final URI baseURI, final Path basePath) {
     Path _xblockexpression = null;
     {
-      final URI relativeURI = absoluteURI.deresolve(baseURI);
+      URI _xifexpression = null;
+      if ((baseURI.isPlatformResource() && absoluteURI.isPlatformResource())) {
+        URI _xifexpression_1 = null;
+        String _segment = baseURI.segment(1);
+        String _segment_1 = absoluteURI.segment(1);
+        boolean _notEquals = (!Objects.equal(_segment, _segment_1));
+        if (_notEquals) {
+          URI _xblockexpression_1 = null;
+          {
+            String _platformString = absoluteURI.toPlatformString(true);
+            final org.eclipse.core.runtime.Path p = new org.eclipse.core.runtime.Path(_platformString);
+            String _string = p.toString();
+            String _plus = (".." + _string);
+            _xblockexpression_1 = URI.createURI(_plus);
+          }
+          _xifexpression_1 = _xblockexpression_1;
+        } else {
+          _xifexpression_1 = absoluteURI.deresolve(baseURI);
+        }
+        _xifexpression = _xifexpression_1;
+      } else {
+        _xifexpression = absoluteURI.deresolve(baseURI);
+      }
+      final URI relativeURI = _xifexpression;
       if ((relativeURI.isEmpty() || Objects.equal(relativeURI, absoluteURI))) {
         return null;
       }

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/macros/EclipseFileSystemTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/macros/EclipseFileSystemTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,8 @@ import com.google.inject.Provider
 import java.util.Set
 import org.eclipse.core.resources.IProject
 import org.eclipse.core.resources.ResourcesPlugin
+import org.eclipse.emf.common.util.URI
+import org.eclipse.xtend.core.macro.AbstractFileSystemSupport
 import org.eclipse.xtend.ide.macro.EclipseFileSystemSupportImpl
 import org.eclipse.xtend.ide.tests.XtendIDEInjectorProvider
 import org.eclipse.xtend.lib.macro.file.Path
@@ -104,6 +106,27 @@ class EclipseFileSystemTest extends JavaIoFileSystemTest {
 			// expected
 		}
 		assertFalse(file.exists)
+	}
+	
+	@Test def void testIssue383() {
+		if (fs instanceof AbstractFileSystemSupport) {
+			val afs = fs as AbstractFileSystemSupport
+			val px = createProject("px")
+			createProject("py")
+			val rs = resourceSetProvider.get(px)
+			val rx = rs.createResource(URI.createPlatformResourceURI("px/foo/xxxx", true))
+			val rxb = rs.createResource(URI.createPlatformResourceURI("px/bar/yyyy", true))
+			val ry = rs.createResource(URI.createPlatformResourceURI("py/bar/xxxx", true))
+			var pathx = afs.getPath(rx)
+			assertEquals("/px/foo/xxxx", pathx.toString)
+			var pathxb = afs.getPath(rxb)
+			assertEquals("/px/bar/yyyy", pathxb.toString)
+			var pathy = afs.getPath(ry)
+			assertEquals("/py/bar/xxxx", pathy.toString)
+			
+		} else {
+			fail("fs is no AbstractFileSystemSupport")
+		}
 	}
 
 }

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/macros/EclipseFileSystemTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/macros/EclipseFileSystemTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,10 @@ import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.xtend.core.macro.AbstractFileSystemSupport;
 import org.eclipse.xtend.ide.macro.EclipseFileSystemSupportImpl;
 import org.eclipse.xtend.ide.tests.XtendIDEInjectorProvider;
 import org.eclipse.xtend.ide.tests.macros.JavaIoFileSystemTest;
@@ -136,6 +140,27 @@ public class EclipseFileSystemTest extends JavaIoFileSystemTest {
       Assert.assertFalse(this.fs.exists(file));
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testIssue383() {
+    if ((this.fs instanceof AbstractFileSystemSupport)) {
+      final AbstractFileSystemSupport afs = ((AbstractFileSystemSupport) this.fs);
+      final IProject px = this.createProject("px");
+      this.createProject("py");
+      final ResourceSet rs = this.resourceSetProvider.get(px);
+      final Resource rx = rs.createResource(URI.createPlatformResourceURI("px/foo/xxxx", true));
+      final Resource rxb = rs.createResource(URI.createPlatformResourceURI("px/bar/yyyy", true));
+      final Resource ry = rs.createResource(URI.createPlatformResourceURI("py/bar/xxxx", true));
+      Path pathx = afs.getPath(rx);
+      Assert.assertEquals("/px/foo/xxxx", pathx.toString());
+      Path pathxb = afs.getPath(rxb);
+      Assert.assertEquals("/px/bar/yyyy", pathxb.toString());
+      Path pathy = afs.getPath(ry);
+      Assert.assertEquals("/py/bar/xxxx", pathy.toString());
+    } else {
+      Assert.fail("fs is no AbstractFileSystemSupport");
     }
   }
 }


### PR DESCRIPTION
[#383] Fixed FileSystemSupport.getPath() to work with multiple projects

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>