### PR TITLE
[#370] Provider quickfixes to remove redundant Xtend member modifiers.

### DIFF
--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/ModifierValidator.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/ModifierValidator.java
@@ -142,11 +142,11 @@ public class ModifierValidator {
 	}
 
 	protected void redundantModifierWarning(String modifier, String memberName, EObject source, int index) {
-		issue("The "+ modifier + " modifier is redundant on " + memberName, source, index, IssueCodes.REDUNDANT_MODIFIER);
+		issue("The "+ modifier + " modifier is redundant on " + memberName, source, index, IssueCodes.REDUNDANT_MODIFIER, modifier);
 	}
 	
-	protected void issue(String message, EObject source, int index, String code) {
-		validator.addIssue(message, source, XTEND_MEMBER__MODIFIERS, index, code);
+	protected void issue(String message, EObject source, int index, String code, String... issueData) {
+		validator.addIssue(message, source, XTEND_MEMBER__MODIFIERS, index, code, issueData);
 	}
 	
 	protected void error(String message, EObject source, int index) {

--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
@@ -3765,4 +3765,262 @@ class QuickfixTest extends AbstractXtendUITestCase {
 		.assertResolutionLabels("Add cast to Foo.")
 	}
 
+	@Test
+	def void redundantModifiers_01(){
+		// Xtend class having a 'public' modifier
+		create('Foo.xtend', '''
+			publ|ic class Foo {}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix(
+			// TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
+			''' class Foo {}
+		''')
+	}
+	
+	@Test
+	def void redundantModifiers_02(){
+		// Xtend class having a 'public' modifier
+		create('Foo.xtend', '''
+			package a
+			publ|ic class Foo {}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix('''
+			package a
+ллл			TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
+			 class Foo {}
+		''')
+	}
+	
+	@Test
+	def void redundantModifiers_03(){
+		// Xtend class having a 'public' modifier
+		create('Foo.xtend', '''
+			package a
+			class A {}
+			publ|ic class B {}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix('''
+			package a
+			class A {}
+ллл			TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
+			 class B {}
+		''')
+	}
+	
+	@Test
+	def void redundantModifiers_04(){
+		// Xtend field having a 'private' modifier
+		create('Foo.xtend', '''
+			class Foo {
+				pri|vate int a = 10
+			}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix('''
+			class Foo {
+				int a = 10
+			}
+		''')
+	}
+	
+	@Test
+	def void redundantModifiers_05(){
+		// Xtend function having a 'public' modifier
+		create('Foo.xtend', '''
+			class Foo {
+				p|ublic def m() {}
+			}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix('''
+			class Foo {
+				def m() {}
+			}
+		''')
+	}
+	
+	@Test
+	def void redundantModifiers_06(){
+		// Xtend function having a 'public' modifier
+		create('Foo.xtend', '''
+			class Foo {
+				def p|ublic   m() {}
+			}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix('''
+			class Foo {
+				def m() {}
+			}
+		''')
+	}
+	
+	@Test
+	def void redundantModifiers_07(){
+		// Xtend field having both 'final' and 'val' modifiers
+		create('Foo.xtend', '''
+			class Foo {
+				f|inal val a = 1
+			}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix('''
+			class Foo {
+				val a = 1
+			}
+		''')
+	}
+	
+	@Test
+	def void redundantModifiers_08(){
+		// Xtend field having both 'final' and 'val' modifiers
+		create('Foo.xtend', '''
+			class Foo {
+				val f|inal a = 1
+			}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix('''
+			class Foo {
+				val a = 1
+			}
+		''')
+	}
+	
+	@Test
+	def void redundantModifiers_09(){
+		// Xtend field having both 'final' and 'val' modifiers
+		create('Foo.xtend', '''
+			class Foo {
+				package val f|inal a = 1
+			}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix('''
+			class Foo {
+				package val a = 1
+			}
+		''')
+	}
+	
+	@Test
+	def void redundantModifiers_10(){
+		// Xtend field having both 'final' and 'val' modifiers
+		create('Foo.xtend', '''
+			class Foo {
+				public static val f|inal a = 1
+			}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix('''
+			class Foo {
+				public static val a = 1
+			}
+		''')
+	}
+	
+	@Test
+	def void redundantModifiers_11(){
+		// Xtend function having both 'def' and 'override' modifiers
+		create('Foo.xtend', '''
+			class A {
+				def m(){}
+			}
+			class B extends A {
+				override de|f m() {}
+			}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix('''
+			class A {
+				def m(){}
+			}
+			class B extends A {
+				override m() {}
+			}
+		''')
+	}
+	
+	@Test
+	def void redundantModifiers_12(){
+		// Xtend function having both 'def' and 'override' modifiers
+		create('Foo.xtend', '''
+			class A {
+				def m() {}
+			}
+			class B extends A {
+				de|f override m() {}
+			}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix('''
+			class A {
+				def m() {}
+			}
+			class B extends A {
+				override m() {}
+			}
+		''')
+	}
+	
+	@Test
+	def void redundantModifiers_13(){
+		// Xtend function having 'public', 'def' and 'override' modifiers
+		create('Foo.xtend', '''
+			class A {
+				def m(){}
+			}
+			class B extends A {
+				pub|lic def override m() {}
+			}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix('''
+			class A {
+				def m(){}
+			}
+			class B extends A {
+				def override m() {}
+			}
+		''')
+	}
+	
+	@Test
+	def void redundantModifiers_14(){
+		// Xtend function having 'public', 'def' and 'override' modifiers
+		create('Foo.xtend', '''
+			class A {
+				def m(){}
+			}
+			class B extends A {
+				public d|ef override m() {}
+			}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix('''
+			class A {
+				def m(){}
+			}
+			class B extends A {
+				public override m() {}
+			}
+		''')
+	}
 }

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
@@ -6853,4 +6853,353 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     this.builder.create("Foo.xtend", _builder).assertIssueCodes(IssueCodes.FEATURE_NOT_VISIBLE).assertResolutionLabels("Add cast to Foo.");
   }
+  
+  @Test
+  public void redundantModifiers_01() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("publ|ic class Foo {}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append(" ");
+    _builder_1.append("class Foo {}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void redundantModifiers_02() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package a");
+    _builder.newLine();
+    _builder.append("publ|ic class Foo {}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("package a");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("class Foo {}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void redundantModifiers_03() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package a");
+    _builder.newLine();
+    _builder.append("class A {}");
+    _builder.newLine();
+    _builder.append("publ|ic class B {}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("package a");
+    _builder_1.newLine();
+    _builder_1.append("class A {}");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("class B {}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void redundantModifiers_04() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("pri|vate int a = 10");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("int a = 10");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void redundantModifiers_05() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("p|ublic def m() {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def m() {}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void redundantModifiers_06() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def p|ublic   m() {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def m() {}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void redundantModifiers_07() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("f|inal val a = 1");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("val a = 1");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void redundantModifiers_08() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("val f|inal a = 1");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("val a = 1");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void redundantModifiers_09() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("package val f|inal a = 1");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("package val a = 1");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void redundantModifiers_10() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("public static val f|inal a = 1");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("public static val a = 1");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void redundantModifiers_11() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class A {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def m(){}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("class B extends A {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("override de|f m() {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class A {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def m(){}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("class B extends A {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("override m() {}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void redundantModifiers_12() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class A {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def m() {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("class B extends A {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("de|f override m() {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class A {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def m() {}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("class B extends A {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("override m() {}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void redundantModifiers_13() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class A {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def m(){}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("class B extends A {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("pub|lic def override m() {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class A {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def m(){}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("class B extends A {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def override m() {}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void redundantModifiers_14() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class A {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def m(){}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("class B extends A {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("public d|ef override m() {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class A {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def m(){}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("class B extends A {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("public override m() {}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
 }

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/XtendQuickfixProvider.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/XtendQuickfixProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -37,6 +37,7 @@ import org.eclipse.xtend.core.xtend.XtendExecutable;
 import org.eclipse.xtend.core.xtend.XtendField;
 import org.eclipse.xtend.core.xtend.XtendFile;
 import org.eclipse.xtend.core.xtend.XtendFunction;
+import org.eclipse.xtend.core.xtend.XtendMember;
 import org.eclipse.xtend.core.xtend.XtendPackage;
 import org.eclipse.xtend.core.xtend.XtendTypeDeclaration;
 import org.eclipse.xtend.ide.buildpath.XtendLibClasspathAdder;
@@ -62,6 +63,7 @@ import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
 import org.eclipse.xtext.ui.editor.model.edit.IModification;
 import org.eclipse.xtext.ui.editor.model.edit.IModificationContext;
+import org.eclipse.xtext.ui.editor.model.edit.IMultiModification;
 import org.eclipse.xtext.ui.editor.model.edit.ISemanticModification;
 import org.eclipse.xtext.ui.editor.quickfix.Fix;
 import org.eclipse.xtext.ui.editor.quickfix.IssueResolution;
@@ -645,6 +647,28 @@ public class XtendQuickfixProvider extends XbaseQuickfixProvider {
 				ReplacingAppendable appendable = appendableFactory.create(context.getXtextDocument(), (XtextResource) element.eResource(), node.getOffset(), 0);
 				appendable.append("return ");
 				appendable.commitChanges();
+			}
+		});
+	}
+	
+	@Fix(IssueCodes.REDUNDANT_MODIFIER)
+	public void removeRedundantModifier(final Issue issue, IssueResolutionAcceptor acceptor) {
+		String[] issueData = issue.getData();
+		if(issueData==null || issueData.length==0) {
+			return;
+		}
+		
+		String modifier = issueData[0];
+		
+		// use the same label, description and image
+		// to be able to use the quickfixes (issue resolution) in batch mode
+		String label = "Remove the redundant modifier.";
+		String description = "The modifier is unnecessary and should be removed.";
+		String image = "fix_indent.gif";
+		acceptor.acceptMulti(issue, label, description, image, new IMultiModification<XtendMember>() {
+			@Override
+			public void apply(XtendMember element) {
+				element.getModifiers().remove(modifier);
 			}
 		});
 	}


### PR DESCRIPTION
- Extend the ModifierValidator to pass the redundant modifier as issue
data from the validator to the quickfix provider.
- Extend the XtendQuickfixProvider to provide quickfixes to remove the
redundant Xtend member modifier.
- Implement corresponding Xtend QuickfixTest test cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>