### PR TITLE
[460455] Add OrganizeImportsTest for avoiding fully qualifying names.

### DIFF
--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/imports/OrganizeImportsTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/imports/OrganizeImportsTest.xtend
@@ -627,9 +627,9 @@ class OrganizeImportsTest extends AbstractXtendUITestCase {
 			}
 		''')
 	}
+	
 	/**
 	 * @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=460455
-	 * @Ignore ("TODO Fix ConflictResolver")
 	 */
 	@Test def void testInnerClass_02 () {
 		'''
@@ -645,6 +645,9 @@ class OrganizeImportsTest extends AbstractXtendUITestCase {
 				interface Innerfaze {
 				}
 			}
+			
+			interface Innerfaze {
+			}
 		'''.assertIsOrganizedTo('''
 			package p
 			
@@ -657,6 +660,9 @@ class OrganizeImportsTest extends AbstractXtendUITestCase {
 			
 				interface Innerfaze {
 				}
+			}
+			
+			interface Innerfaze {
 			}
 		''')
 	}

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/imports/OrganizeImportsTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/imports/OrganizeImportsTest.java
@@ -1145,7 +1145,6 @@ public class OrganizeImportsTest extends AbstractXtendUITestCase {
   
   /**
    * @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=460455
-   * @Ignore ("TODO Fix ConflictResolver")
    */
   @Test
   public void testInnerClass_02() {
@@ -1177,6 +1176,11 @@ public class OrganizeImportsTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
+    _builder.newLine();
+    _builder.append("interface Innerfaze {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("package p");
     _builder_1.newLine();
@@ -1202,6 +1206,11 @@ public class OrganizeImportsTest extends AbstractXtendUITestCase {
     _builder_1.newLine();
     _builder_1.append("\t");
     _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("interface Innerfaze {");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();


### PR DESCRIPTION
- Test case for https://github.com/eclipse/xtext-extras/pull/243
- Activate/Adapt OrganizeImportsTest test case to verify that the import
organizer does not fully qualify type names if two types (one as inner
type, one as top-level type) with the same name exists.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>