### PR TITLE
[#361] 'Redundant modifier' validation rule on interfaces/constructors.

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/XtendValidationTest.java
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/XtendValidationTest.java
@@ -3029,7 +3029,7 @@ public class XtendValidationTest extends AbstractXtendTestCase {
 	
 	@Test public void testAnonymousClassNotOverridingEquals() throws Exception {
 		XtendFile file = file(
-			"public interface Foo {"+
+			"interface Foo {"+
 			"	override equals(Object obj);"+
 			"}"+
 			"class Bar{"+

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/ModifierValidator.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/ModifierValidator.java
@@ -15,9 +15,13 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtend.core.xtend.XtendAnnotationType;
 import org.eclipse.xtend.core.xtend.XtendClass;
+import org.eclipse.xtend.core.xtend.XtendConstructor;
+import org.eclipse.xtend.core.xtend.XtendEnum;
 import org.eclipse.xtend.core.xtend.XtendField;
 import org.eclipse.xtend.core.xtend.XtendFunction;
+import org.eclipse.xtend.core.xtend.XtendInterface;
 import org.eclipse.xtend.core.xtend.XtendMember;
 import org.eclipse.xtend.core.xtend.XtendTypeDeclaration;
 import org.eclipse.xtext.validation.Check;
@@ -77,7 +81,14 @@ public class ModifierValidator {
 					if("private".equals(modifier) && member instanceof XtendField) {
 						redundantModifierWarning("private", memberName, member, i);
 					}
-					if("public".equals(modifier) && (member instanceof XtendClass || member instanceof XtendFunction)) {
+					if("public".equals(modifier) && (
+							member instanceof XtendAnnotationType ||
+							member instanceof XtendClass ||
+							member instanceof XtendEnum ||
+							member instanceof XtendInterface ||
+							member instanceof XtendConstructor ||
+							member instanceof XtendFunction
+					)) {
 						redundantModifierWarning("public", memberName, member, i);
 					}
 				}

--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
@@ -4737,4 +4737,107 @@ class QuickfixTest extends AbstractXtendUITestCase {
 			}
 		''')
 	}
+	
+	@Test
+	def void redundantModifiers_40(){
+		// Xtend interface having a 'public' modifier
+		create('Foo.xtend', '''
+			publ|ic interface Foo {}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix(
+// TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
+		''' interface Foo {}
+		''')
+	}
+	
+	@Test
+	def void redundantModifiers_41(){
+		// Xtend class having a constructor with 'public' modifier
+		create('Foo.xtend', '''
+			class Foo {
+				pu|blic new(){}
+			}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix('''
+ллл TODO: improve formatting after Quickfix application
+			class Foo { new(){}
+			}
+		''')
+	}
+	
+	@Test
+	def void redundantModifiers_42(){
+		// Xtend class having an inner interface with 'public' modifier
+		create('Foo.xtend', '''
+			class Foo {
+				pu|blic interface Bar {
+					def m() {}
+				}
+			}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix('''
+ллл TODO: improve formatting after Quickfix application
+			class Foo { interface Bar {
+					def m() {}
+				}
+			}
+		''')
+	}
+	
+	@Test
+	def void redundantModifiers_43(){
+		// Xtend interface having a method with 'public' modifier
+		create('Foo.xtend', '''
+			interface Foo {
+				pu|blic def m() {}
+				}
+			}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix('''
+			interface Foo {
+				def m() {}
+				}
+			}
+		''')
+	}
+	
+	@Test
+	def void redundantModifiers_44(){
+		// Xtend annotation having a method with 'public' modifier
+		create('Foo.xtend', '''
+			pub|lic annotation Foo {
+			}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix('''
+ллл TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
+			 annotation Foo {
+			}
+		''')
+	}
+	
+	@Test
+	def void redundantModifiers_45(){
+		// Xtend enum having a method with 'public' modifier
+		create('Foo.xtend', '''
+			pub|lic enum Foo {
+			}
+		''')
+		.assertIssueCodes(REDUNDANT_MODIFIER)
+		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertModelAfterQuickfix('''
+ллл TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
+			 enum Foo {
+			}
+		''')
+	}
 }

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
@@ -8521,4 +8521,129 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder_1.newLine();
     _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
   }
+  
+  @Test
+  public void redundantModifiers_40() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("publ|ic interface Foo {}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append(" ");
+    _builder_1.append("interface Foo {}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void redundantModifiers_41() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("pu|blic new(){}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Foo { new(){}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void redundantModifiers_42() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("pu|blic interface Bar {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("def m() {}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Foo { interface Bar {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("def m() {}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void redundantModifiers_43() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("interface Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("pu|blic def m() {}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("interface Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def m() {}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void redundantModifiers_44() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("pub|lic annotation Foo {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append(" ");
+    _builder_1.append("annotation Foo {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void redundantModifiers_45() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("pub|lic enum Foo {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append(" ");
+    _builder_1.append("enum Foo {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
 }


### PR DESCRIPTION
- Extend the Xtend ModifierValidator to recognize the 'public' modifier
on interfaces and constructors as 'Redundant modifier'.
- Implement corresponding QuickfixTest test cases.
- Adapt the input data of the already existing test cases in order not
to break them.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>