### PR TITLE
[#361] Rename the 'Redundant modifier' to 'Unnecessary modifier'.

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/ModifierValidationTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/ModifierValidationTest.xtend
@@ -31,7 +31,7 @@ class ModifierValidationTest extends AbstractXtendTestCase {
 		clazz('''abstract class Foo{}''').assertNoErrors
 		clazz('''dispatch class Foo{}''').assertError(XTEND_CLASS, INVALID_MODIFIER)
 		clazz('''final class Foo{}''').assertNoErrors
-		clazz('''public class Foo{}''').assertWarning(XTEND_CLASS, REDUNDANT_MODIFIER)
+		clazz('''public class Foo{}''').assertWarning(XTEND_CLASS, UNNECESSARY_MODIFIER)
 	}
 	
 	@Test def void testNestedClassAllowedModifiers() {
@@ -130,7 +130,7 @@ class ModifierValidationTest extends AbstractXtendTestCase {
 		abstractFunction('''static def int foo();''').assertError(XTEND_FUNCTION, INVALID_MODIFIER)
 		function('''dispatch def foo (int i){}''').assertNoErrors
 		function('''final def foo() {}''').assertNoErrors
-		function('''public def foo() {}''').assertWarning(XTEND_FUNCTION, REDUNDANT_MODIFIER)
+		function('''public def foo() {}''').assertWarning(XTEND_FUNCTION, UNNECESSARY_MODIFIER)
 	}
 
 	@Test def void testMethodInInterfaceAllowedModifiers() {
@@ -145,8 +145,8 @@ class ModifierValidationTest extends AbstractXtendTestCase {
 		memberInInterface('''final def foo() {}''').assertError(XTEND_FUNCTION, INVALID_MODIFIER)
 		memberInInterface('''strictfp def foo() {}''').assertError(XTEND_FUNCTION, INVALID_MODIFIER)
 		memberInInterface('''synchronized def foo() {}''').assertError(XTEND_FUNCTION, INVALID_MODIFIER)
-		memberInInterface('''override def foo() {}''').assertWarning(XTEND_FUNCTION, REDUNDANT_MODIFIER)
-		memberInInterface('''def override foo() {}''').assertWarning(XTEND_FUNCTION, REDUNDANT_MODIFIER)
+		memberInInterface('''override def foo() {}''').assertWarning(XTEND_FUNCTION, UNNECESSARY_MODIFIER)
+		memberInInterface('''def override foo() {}''').assertWarning(XTEND_FUNCTION, UNNECESSARY_MODIFIER)
 	}
 	
 	@Test def void testConstructorAllowedModifiers() {
@@ -175,8 +175,8 @@ class ModifierValidationTest extends AbstractXtendTestCase {
 		field('''final volatile int foo = 42''').assertError(XTEND_FIELD, INVALID_MODIFIER)
 		field('''volatile transient int foo''').assertNoErrors
 		field('''private transient volatile int foo''').assertNoErrors
-		field('''private int foo''').assertWarning(XTEND_FIELD, REDUNDANT_MODIFIER)
-		field('''private val foo=42''').assertWarning(XTEND_FIELD, REDUNDANT_MODIFIER)
+		field('''private int foo''').assertWarning(XTEND_FIELD, UNNECESSARY_MODIFIER)
+		field('''private val foo=42''').assertWarning(XTEND_FIELD, UNNECESSARY_MODIFIER)
 	}
 	
 	@Test def void testFieldInInterfaceAllowedModifiers() {
@@ -271,8 +271,8 @@ class ModifierValidationTest extends AbstractXtendTestCase {
 		field('''var final int i=42''').assertError(XTEND_FIELD, INVALID_MODIFIER)
 		field('''final val int i=42''').assertNoErrors
 		field('''val final int i=42''').assertNoErrors
-		field('''final val int i=42''').assertWarning(XTEND_FIELD, REDUNDANT_MODIFIER)
-		field('''val final int i=42''').assertWarning(XTEND_FIELD, REDUNDANT_MODIFIER)
+		field('''final val int i=42''').assertWarning(XTEND_FIELD, UNNECESSARY_MODIFIER)
+		field('''val final int i=42''').assertWarning(XTEND_FIELD, UNNECESSARY_MODIFIER)
 	}
 	
 	def protected memberInInterface(String model) {

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/ModifierValidationTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/ModifierValidationTest.java
@@ -56,7 +56,7 @@ public class ModifierValidationTest extends AbstractXtendTestCase {
       this._validationTestHelper.assertNoErrors(this.clazz(_builder_7.toString()));
       StringConcatenation _builder_8 = new StringConcatenation();
       _builder_8.append("public class Foo{}");
-      this._validationTestHelper.assertWarning(this.clazz(_builder_8.toString()), XtendPackage.Literals.XTEND_CLASS, IssueCodes.REDUNDANT_MODIFIER);
+      this._validationTestHelper.assertWarning(this.clazz(_builder_8.toString()), XtendPackage.Literals.XTEND_CLASS, IssueCodes.UNNECESSARY_MODIFIER);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -344,7 +344,7 @@ public class ModifierValidationTest extends AbstractXtendTestCase {
       this._validationTestHelper.assertNoErrors(this.function(_builder_10.toString()));
       StringConcatenation _builder_11 = new StringConcatenation();
       _builder_11.append("public def foo() {}");
-      this._validationTestHelper.assertWarning(this.function(_builder_11.toString()), XtendPackage.Literals.XTEND_FUNCTION, IssueCodes.REDUNDANT_MODIFIER);
+      this._validationTestHelper.assertWarning(this.function(_builder_11.toString()), XtendPackage.Literals.XTEND_FUNCTION, IssueCodes.UNNECESSARY_MODIFIER);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -387,10 +387,10 @@ public class ModifierValidationTest extends AbstractXtendTestCase {
     this._validationTestHelper.assertError(this.memberInInterface(_builder_10.toString()), XtendPackage.Literals.XTEND_FUNCTION, IssueCodes.INVALID_MODIFIER);
     StringConcatenation _builder_11 = new StringConcatenation();
     _builder_11.append("override def foo() {}");
-    this._validationTestHelper.assertWarning(this.memberInInterface(_builder_11.toString()), XtendPackage.Literals.XTEND_FUNCTION, IssueCodes.REDUNDANT_MODIFIER);
+    this._validationTestHelper.assertWarning(this.memberInInterface(_builder_11.toString()), XtendPackage.Literals.XTEND_FUNCTION, IssueCodes.UNNECESSARY_MODIFIER);
     StringConcatenation _builder_12 = new StringConcatenation();
     _builder_12.append("def override foo() {}");
-    this._validationTestHelper.assertWarning(this.memberInInterface(_builder_12.toString()), XtendPackage.Literals.XTEND_FUNCTION, IssueCodes.REDUNDANT_MODIFIER);
+    this._validationTestHelper.assertWarning(this.memberInInterface(_builder_12.toString()), XtendPackage.Literals.XTEND_FUNCTION, IssueCodes.UNNECESSARY_MODIFIER);
   }
   
   @Test
@@ -472,10 +472,10 @@ public class ModifierValidationTest extends AbstractXtendTestCase {
       this._validationTestHelper.assertNoErrors(this.field(_builder_11.toString()));
       StringConcatenation _builder_12 = new StringConcatenation();
       _builder_12.append("private int foo");
-      this._validationTestHelper.assertWarning(this.field(_builder_12.toString()), XtendPackage.Literals.XTEND_FIELD, IssueCodes.REDUNDANT_MODIFIER);
+      this._validationTestHelper.assertWarning(this.field(_builder_12.toString()), XtendPackage.Literals.XTEND_FIELD, IssueCodes.UNNECESSARY_MODIFIER);
       StringConcatenation _builder_13 = new StringConcatenation();
       _builder_13.append("private val foo=42");
-      this._validationTestHelper.assertWarning(this.field(_builder_13.toString()), XtendPackage.Literals.XTEND_FIELD, IssueCodes.REDUNDANT_MODIFIER);
+      this._validationTestHelper.assertWarning(this.field(_builder_13.toString()), XtendPackage.Literals.XTEND_FIELD, IssueCodes.UNNECESSARY_MODIFIER);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -737,10 +737,10 @@ public class ModifierValidationTest extends AbstractXtendTestCase {
       this._validationTestHelper.assertNoErrors(this.field(_builder_3.toString()));
       StringConcatenation _builder_4 = new StringConcatenation();
       _builder_4.append("final val int i=42");
-      this._validationTestHelper.assertWarning(this.field(_builder_4.toString()), XtendPackage.Literals.XTEND_FIELD, IssueCodes.REDUNDANT_MODIFIER);
+      this._validationTestHelper.assertWarning(this.field(_builder_4.toString()), XtendPackage.Literals.XTEND_FIELD, IssueCodes.UNNECESSARY_MODIFIER);
       StringConcatenation _builder_5 = new StringConcatenation();
       _builder_5.append("val final int i=42");
-      this._validationTestHelper.assertWarning(this.field(_builder_5.toString()), XtendPackage.Literals.XTEND_FIELD, IssueCodes.REDUNDANT_MODIFIER);
+      this._validationTestHelper.assertWarning(this.field(_builder_5.toString()), XtendPackage.Literals.XTEND_FIELD, IssueCodes.UNNECESSARY_MODIFIER);
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/IssueCodes.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/IssueCodes.java
@@ -108,6 +108,6 @@ public final class IssueCodes {
 	/**
 	 * @since 2.14
 	 */
-	public static final String REDUNDANT_MODIFIER = ISSUE_CODE_PREFIX +  "redundant_modifier";
+	public static final String UNNECESSARY_MODIFIER = ISSUE_CODE_PREFIX +  "unnecessary_modifier";
 	
 }

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/ModifierValidator.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/ModifierValidator.java
@@ -79,7 +79,7 @@ public class ModifierValidator {
 								member, i);
 					visibilitySeen = true;
 					if("private".equals(modifier) && member instanceof XtendField) {
-						redundantModifierWarning("private", memberName, member, i);
+						unnecessaryModifierIssue("private", memberName, member, i);
 					}
 					if("public".equals(modifier) && (
 							member instanceof XtendAnnotationType ||
@@ -89,7 +89,7 @@ public class ModifierValidator {
 							member instanceof XtendConstructor ||
 							member instanceof XtendFunction
 					)) {
-						redundantModifierWarning("public", memberName, member, i);
+						unnecessaryModifierIssue("public", memberName, member, i);
 					}
 				}
 			} 
@@ -124,9 +124,9 @@ public class ModifierValidator {
 				if(finalSeen) {
 					/*
 					 * Independent of the order of the keywords (such as 'final val' or 'val final'), 
-					 * the 'final' keyword should be marked with the warning marker
+					 * the 'final' keyword should be marked with the issue marker
 					 */
-					redundantModifierWarning("final", memberName, member, finalKeywordIndex);
+					unnecessaryModifierIssue("final", memberName, member, finalKeywordIndex);
 				}
 				finalSeen = true;
 			} else if(equal(modifier, "var")) {
@@ -142,17 +142,17 @@ public class ModifierValidator {
 				if(defSeen) {
 					/*
 					 * Independent of the order of the keywords (such as 'override def' or 'def override'), 
-					 * the 'def' keyword should be marked with the warning marker
+					 * the 'def' keyword should be marked with the issue marker
 					 */
-					redundantModifierWarning("def", memberName, member, defKeywordIndex);
+					unnecessaryModifierIssue("def", memberName, member, defKeywordIndex);
 				}
 				defSeen = true;
 			}
 		}
 	}
 
-	protected void redundantModifierWarning(String modifier, String memberName, EObject source, int index) {
-		issue("The "+ modifier + " modifier is redundant on " + memberName, source, index, IssueCodes.REDUNDANT_MODIFIER, modifier);
+	protected void unnecessaryModifierIssue(String modifier, String memberName, EObject source, int index) {
+		issue("The "+ modifier + " modifier is unnecessary on " + memberName, source, index, IssueCodes.UNNECESSARY_MODIFIER, modifier);
 	}
 	
 	protected void issue(String message, EObject source, int index, String code, String... issueData) {

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendConfigurableIssueCodes.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendConfigurableIssueCodes.java
@@ -36,7 +36,7 @@ public class XtendConfigurableIssueCodes extends XbaseConfigurableIssueCodes {
 		iAcceptor.accept(create(IssueCodes.IMPLICIT_RETURN, SeverityConverter.SEVERITY_IGNORE));
 		iAcceptor.accept(create(IssueCodes.ORPHAN_ELMENT, SeverityConverter.SEVERITY_IGNORE));
 		iAcceptor.accept(create(IssueCodes.WRONG_FILE, SeverityConverter.SEVERITY_WARNING));
-		iAcceptor.accept(create(IssueCodes.REDUNDANT_MODIFIER, SeverityConverter.SEVERITY_WARNING));
+		iAcceptor.accept(create(IssueCodes.UNNECESSARY_MODIFIER, SeverityConverter.SEVERITY_WARNING));
 		// overwrite xbase default
 		iAcceptor.accept(create(org.eclipse.xtext.validation.IssueCodes.COPY_JAVA_PROBLEMS, SeverityConverter.SEVERITY_ERROR));
 	}

--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
@@ -3766,13 +3766,13 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 
 	@Test
-	def void redundantModifiers_01(){
+	def void unnecessaryModifier_01(){
 		// Xtend class having a 'public' modifier
 		create('Foo.xtend', '''
 			publ|ic class Foo {}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix(
 			// TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
 			''' class Foo {}
@@ -3780,14 +3780,14 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_02(){
+	def void unnecessaryModifier_02(){
 		// Xtend class having a 'public' modifier
 		create('Foo.xtend', '''
 			package a
 			publ|ic class Foo {}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			package a
 ллл			TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
@@ -3796,15 +3796,15 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_03(){
+	def void unnecessaryModifier_03(){
 		// Xtend class having a 'public' modifier
 		create('Foo.xtend', '''
 			package a
 			class A {}
 			publ|ic class B {}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			package a
 			class A {}
@@ -3814,15 +3814,15 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_04(){
+	def void unnecessaryModifier_04(){
 		// Xtend field having a 'private' modifier
 		create('Foo.xtend', '''
 			class Foo {
 				pri|vate int a = 10
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				int a = 10
@@ -3831,15 +3831,15 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_05(){
+	def void unnecessaryModifier_05(){
 		// Xtend function having a 'public' modifier
 		create('Foo.xtend', '''
 			class Foo {
 				p|ublic def m() {}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				def m() {}
@@ -3848,15 +3848,15 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_06(){
+	def void unnecessaryModifier_06(){
 		// Xtend function having a 'public' modifier
 		create('Foo.xtend', '''
 			class Foo {
 				def p|ublic   m() {}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				def m() {}
@@ -3865,15 +3865,15 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_07(){
+	def void unnecessaryModifier_07(){
 		// Xtend field having both 'final' and 'val' modifiers
 		create('Foo.xtend', '''
 			class Foo {
 				f|inal val a = 1
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				val a = 1
@@ -3882,15 +3882,15 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_08(){
+	def void unnecessaryModifier_08(){
 		// Xtend field having both 'final' and 'val' modifiers
 		create('Foo.xtend', '''
 			class Foo {
 				val f|inal a = 1
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				val a = 1
@@ -3899,15 +3899,15 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_09(){
+	def void unnecessaryModifier_09(){
 		// Xtend field having both 'final' and 'val' modifiers
 		create('Foo.xtend', '''
 			class Foo {
 				package val f|inal a = 1
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				package val a = 1
@@ -3916,15 +3916,15 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_10(){
+	def void unnecessaryModifier_10(){
 		// Xtend field having both 'final' and 'val' modifiers
 		create('Foo.xtend', '''
 			class Foo {
 				public static val f|inal a = 1
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				public static val a = 1
@@ -3933,7 +3933,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_11(){
+	def void unnecessaryModifier_11(){
 		// Xtend function having both 'def' and 'override' modifiers
 		create('Foo.xtend', '''
 			class A {
@@ -3943,8 +3943,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				override de|f m() {}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class A {
 				def m(){}
@@ -3956,7 +3956,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_12(){
+	def void unnecessaryModifier_12(){
 		// Xtend function having both 'def' and 'override' modifiers
 		create('Foo.xtend', '''
 			class A {
@@ -3966,8 +3966,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				de|f override m() {}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class A {
 				def m() {}
@@ -3979,7 +3979,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_13(){
+	def void unnecessaryModifier_13(){
 		// Xtend function having 'public', 'def' and 'override' modifiers
 		create('Foo.xtend', '''
 			class A {
@@ -3989,8 +3989,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				pub|lic def override m() {}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class A {
 				def m(){}
@@ -4002,7 +4002,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_14(){
+	def void unnecessaryModifier_14(){
 		// Xtend function having 'public', 'def' and 'override' modifiers
 		create('Foo.xtend', '''
 			class A {
@@ -4012,8 +4012,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				public d|ef override m() {}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class A {
 				def m(){}
@@ -4025,7 +4025,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_15(){
+	def void unnecessaryModifier_15(){
 		// Xtend extension field without name having a 'private' modifier
 		create('Foo.xtend', '''
 			import java.text.DateFormat
@@ -4040,8 +4040,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			import java.text.DateFormat
 			import java.text.SimpleDateFormat
@@ -4058,7 +4058,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_16(){
+	def void unnecessaryModifier_16(){
 		create('Foo.xtend', '''
 			import java.text.SimpleDateFormat
 			
@@ -4066,8 +4066,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				var priv|ate SimpleDateFormat dateFormat = new SimpleDateFormat
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			import java.text.SimpleDateFormat
 			
@@ -4079,7 +4079,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	
 	@Ignore("Javadoc will be not preserved after applying the quickfix")
 	@Test
-	def void redundantModifiers_17(){
+	def void unnecessaryModifier_17(){
 		// Xtend class with javadoc having a 'public' modifier
 		create('Foo.xtend', '''
 			/**
@@ -4087,8 +4087,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 			 */
 			publ|ic class Foo {}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			/**
 			 * javadoc
@@ -4100,7 +4100,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	
 	@Ignore("Javadoc will be not preserved after applying the quickfix")
 	@Test
-	def void redundantModifiers_18(){
+	def void unnecessaryModifier_18(){
 		// Xtend class with javadoc having a 'public' modifier
 		create('Foo.xtend', '''
 			package a
@@ -4110,8 +4110,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 			 */
 			publ|ic class Foo {}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			package a
 			
@@ -4125,7 +4125,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	
 	@Ignore("Javadoc will be not preserved after applying the quickfix")
 	@Test
-	def void redundantModifiers_19(){
+	def void unnecessaryModifier_19(){
 		// Xtend class with javadoc having a 'public' modifier
 		create('Foo.xtend', '''
 			package a
@@ -4136,8 +4136,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 			 */
 			publ|ic class B {}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			package a
 			class A {}
@@ -4152,7 +4152,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	
 	@Ignore("Javadoc will be not preserved after applying the quickfix")
 	@Test
-	def void redundantModifiers_20(){
+	def void unnecessaryModifier_20(){
 		// Xtend field with javadoc having a 'private' modifier
 		create('Foo.xtend', '''
 			class Foo {
@@ -4162,8 +4162,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				pri|vate int a = 10
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				/**
@@ -4175,7 +4175,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_21(){
+	def void unnecessaryModifier_21(){
 		// Xtend function with javadoc having a 'public' modifier
 		create('Foo.xtend', '''
 			class Foo {
@@ -4185,8 +4185,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				p|ublic def m() {}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				/**
@@ -4198,7 +4198,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_22(){
+	def void unnecessaryModifier_22(){
 		// Xtend function with javadoc having a 'public' modifier
 		create('Foo.xtend', '''
 			class Foo {
@@ -4208,8 +4208,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				def p|ublic   m() {}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				/**
@@ -4221,7 +4221,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_23(){
+	def void unnecessaryModifier_23(){
 		// Xtend field with javadoc having both 'final' and 'val' modifiers
 		create('Foo.xtend', '''
 			class Foo {
@@ -4231,8 +4231,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				f|inal val a = 1
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				/**
@@ -4244,7 +4244,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_24(){
+	def void unnecessaryModifier_24(){
 		// Xtend field with javadoc having both 'final' and 'val' modifiers
 		create('Foo.xtend', '''
 			class Foo {
@@ -4254,8 +4254,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				val f|inal a = 1
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				/**
@@ -4267,7 +4267,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_25(){
+	def void unnecessaryModifier_25(){
 		// Xtend field with javadoc having both 'final' and 'val' modifiers
 		create('Foo.xtend', '''
 			class Foo {
@@ -4277,8 +4277,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				package val f|inal a = 1
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				/**
@@ -4290,7 +4290,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_26(){
+	def void unnecessaryModifier_26(){
 		// Xtend field with javadoc having both 'final' and 'val' modifiers
 		create('Foo.xtend', '''
 			class Foo {
@@ -4300,8 +4300,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				public static val f|inal a = 1
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				/**
@@ -4313,7 +4313,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_27(){
+	def void unnecessaryModifier_27(){
 		// Xtend function with javadoc having both 'def' and 'override' modifiers
 		create('Foo.xtend', '''
 			class A {
@@ -4326,8 +4326,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				override de|f m() {}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class A {
 				def m(){}
@@ -4342,7 +4342,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_28(){
+	def void unnecessaryModifier_28(){
 		// Xtend function with javadoc having both 'def' and 'override' modifiers
 		create('Foo.xtend', '''
 			class A {
@@ -4355,8 +4355,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				de|f override m() {}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class A {
 				def m() {}
@@ -4371,7 +4371,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_29(){
+	def void unnecessaryModifier_29(){
 		// Xtend function with javadoc having 'public', 'def' and 'override' modifiers
 		create('Foo.xtend', '''
 			class A {
@@ -4384,8 +4384,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				pub|lic def override m() {}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class A {
 				def m(){}
@@ -4400,7 +4400,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_30(){
+	def void unnecessaryModifier_30(){
 		// Xtend function with javadoc having 'public', 'def' and 'override' modifiers
 		create('Foo.xtend', '''
 			class A {
@@ -4413,8 +4413,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				public d|ef override m() {}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class A {
 				def m(){}
@@ -4430,7 +4430,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	
 	@Ignore("Javadoc will be not preserved after applying the quickfix")
 	@Test
-	def void redundantModifiers_31(){
+	def void unnecessaryModifier_31(){
 		// Xtend extension field without name with javadoc having a 'private' modifier
 		create('Foo.xtend', '''
 			import java.text.DateFormat
@@ -4448,8 +4448,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			import java.text.DateFormat
 			import java.text.SimpleDateFormat
@@ -4469,7 +4469,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_32(){
+	def void unnecessaryModifier_32(){
 		create('Foo.xtend', '''
 			import java.text.SimpleDateFormat
 			
@@ -4480,8 +4480,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				var priv|ate SimpleDateFormat dateFormat = new SimpleDateFormat
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			import java.text.SimpleDateFormat
 			
@@ -4495,7 +4495,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_33(){
+	def void unnecessaryModifier_33(){
 		// Xtend function in anonymous class with javadoc having 'public' modifier
 		create('Foo.xtend', '''
 			class Foo {
@@ -4510,8 +4510,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				
@@ -4528,7 +4528,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_34(){
+	def void unnecessaryModifier_34(){
 		// Xtend function in anonymous class with javadoc having both 'def' and 'override' modifiers
 		create('Foo.xtend', '''
 			class Foo {
@@ -4543,8 +4543,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				
@@ -4561,7 +4561,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_35(){
+	def void unnecessaryModifier_35(){
 		// Xtend function in anonymous class with javadoc having 'public', 'def' and 'override' modifiers
 		create('Foo.xtend', '''
 			class Foo {
@@ -4576,8 +4576,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				
@@ -4594,7 +4594,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_36(){
+	def void unnecessaryModifier_36(){
 		// Xtend function in anonymous class with javadoc having 'public', 'def' and 'override' modifiers
 		create('Foo.xtend', '''
 			class Foo {
@@ -4609,8 +4609,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				
@@ -4628,7 +4628,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	
 	@Ignore("Javadoc will be not preserved after applying the quickfix")
 	@Test
-	def void redundantModifiers_37(){
+	def void unnecessaryModifier_37(){
 		// Xtend field in anonymous class with javadoc having 'private' modifier
 		create('Foo.xtend', '''
 			class Foo {
@@ -4645,8 +4645,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				
@@ -4665,7 +4665,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_38(){
+	def void unnecessaryModifier_38(){
 		// Xtend field in anonymous class with javadoc having both 'final' and 'val' modifiers
 		create('Foo.xtend', '''
 			class Foo {
@@ -4682,8 +4682,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				
@@ -4702,7 +4702,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_39(){
+	def void unnecessaryModifier_39(){
 		// Xtend field in anonymous class with javadoc having both 'val' and 'final' modifiers
 		create('Foo.xtend', '''
 			class Foo {
@@ -4719,8 +4719,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			class Foo {
 				
@@ -4739,13 +4739,13 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_40(){
+	def void unnecessaryModifier_40(){
 		// Xtend interface having a 'public' modifier
 		create('Foo.xtend', '''
 			publ|ic interface Foo {}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix(
 // TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
 		''' interface Foo {}
@@ -4753,15 +4753,15 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_41(){
+	def void unnecessaryModifier_41(){
 		// Xtend class having a constructor with 'public' modifier
 		create('Foo.xtend', '''
 			class Foo {
 				pu|blic new(){}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 ллл TODO: improve formatting after Quickfix application
 			class Foo { new(){}
@@ -4770,7 +4770,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_42(){
+	def void unnecessaryModifier_42(){
 		// Xtend class having an inner interface with 'public' modifier
 		create('Foo.xtend', '''
 			class Foo {
@@ -4779,8 +4779,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 ллл TODO: improve formatting after Quickfix application
 			class Foo { interface Bar {
@@ -4791,7 +4791,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_43(){
+	def void unnecessaryModifier_43(){
 		// Xtend interface having a method with 'public' modifier
 		create('Foo.xtend', '''
 			interface Foo {
@@ -4799,8 +4799,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 				}
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			interface Foo {
 				def m() {}
@@ -4810,14 +4810,14 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_44(){
+	def void unnecessaryModifier_44(){
 		// Xtend annotation having a method with 'public' modifier
 		create('Foo.xtend', '''
 			pub|lic annotation Foo {
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 ллл TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
 			 annotation Foo {
@@ -4826,14 +4826,14 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void redundantModifiers_45(){
+	def void unnecessaryModifier_45(){
 		// Xtend enum having a method with 'public' modifier
 		create('Foo.xtend', '''
 			pub|lic enum Foo {
 			}
 		''')
-		.assertIssueCodes(REDUNDANT_MODIFIER)
-		.assertResolutionLabels("Remove the redundant modifier.")
+		.assertIssueCodes(UNNECESSARY_MODIFIER)
+		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 ллл TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
 			 enum Foo {

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
@@ -6855,11 +6855,11 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_01() {
+  public void unnecessaryModifier_01() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("publ|ic class Foo {}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append(" ");
     _builder_1.append("class Foo {}");
@@ -6868,13 +6868,13 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_02() {
+  public void unnecessaryModifier_02() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package a");
     _builder.newLine();
     _builder.append("publ|ic class Foo {}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("package a");
     _builder_1.newLine();
@@ -6885,7 +6885,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_03() {
+  public void unnecessaryModifier_03() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package a");
     _builder.newLine();
@@ -6893,7 +6893,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("publ|ic class B {}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("package a");
     _builder_1.newLine();
@@ -6906,7 +6906,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_04() {
+  public void unnecessaryModifier_04() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -6915,7 +6915,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -6928,7 +6928,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_05() {
+  public void unnecessaryModifier_05() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -6937,7 +6937,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -6950,7 +6950,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_06() {
+  public void unnecessaryModifier_06() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -6959,7 +6959,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -6972,7 +6972,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_07() {
+  public void unnecessaryModifier_07() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -6981,7 +6981,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -6994,7 +6994,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_08() {
+  public void unnecessaryModifier_08() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -7003,7 +7003,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -7016,7 +7016,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_09() {
+  public void unnecessaryModifier_09() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -7025,7 +7025,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -7038,7 +7038,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_10() {
+  public void unnecessaryModifier_10() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -7047,7 +7047,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -7060,7 +7060,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_11() {
+  public void unnecessaryModifier_11() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class A {");
     _builder.newLine();
@@ -7076,7 +7076,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class A {");
     _builder_1.newLine();
@@ -7096,7 +7096,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_12() {
+  public void unnecessaryModifier_12() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class A {");
     _builder.newLine();
@@ -7112,7 +7112,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class A {");
     _builder_1.newLine();
@@ -7132,7 +7132,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_13() {
+  public void unnecessaryModifier_13() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class A {");
     _builder.newLine();
@@ -7148,7 +7148,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class A {");
     _builder_1.newLine();
@@ -7168,7 +7168,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_14() {
+  public void unnecessaryModifier_14() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class A {");
     _builder.newLine();
@@ -7184,7 +7184,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class A {");
     _builder_1.newLine();
@@ -7204,7 +7204,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_15() {
+  public void unnecessaryModifier_15() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("import java.text.DateFormat");
     _builder.newLine();
@@ -7231,7 +7231,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.text.DateFormat");
     _builder_1.newLine();
@@ -7262,7 +7262,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_16() {
+  public void unnecessaryModifier_16() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("import java.text.SimpleDateFormat");
     _builder.newLine();
@@ -7274,7 +7274,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.text.SimpleDateFormat");
     _builder_1.newLine();
@@ -7291,7 +7291,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   
   @Ignore("Javadoc will be not preserved after applying the quickfix")
   @Test
-  public void redundantModifiers_17() {
+  public void unnecessaryModifier_17() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("/**");
     _builder.newLine();
@@ -7303,7 +7303,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("publ|ic class Foo {}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("/**");
     _builder_1.newLine();
@@ -7321,7 +7321,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   
   @Ignore("Javadoc will be not preserved after applying the quickfix")
   @Test
-  public void redundantModifiers_18() {
+  public void unnecessaryModifier_18() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package a");
     _builder.newLine();
@@ -7336,7 +7336,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("publ|ic class Foo {}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("package a");
     _builder_1.newLine();
@@ -7357,7 +7357,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   
   @Ignore("Javadoc will be not preserved after applying the quickfix")
   @Test
-  public void redundantModifiers_19() {
+  public void unnecessaryModifier_19() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package a");
     _builder.newLine();
@@ -7374,7 +7374,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("publ|ic class B {}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("package a");
     _builder_1.newLine();
@@ -7397,7 +7397,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   
   @Ignore("Javadoc will be not preserved after applying the quickfix")
   @Test
-  public void redundantModifiers_20() {
+  public void unnecessaryModifier_20() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -7415,7 +7415,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -7437,7 +7437,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_21() {
+  public void unnecessaryModifier_21() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -7455,7 +7455,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -7477,7 +7477,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_22() {
+  public void unnecessaryModifier_22() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -7495,7 +7495,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -7517,7 +7517,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_23() {
+  public void unnecessaryModifier_23() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -7535,7 +7535,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -7557,7 +7557,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_24() {
+  public void unnecessaryModifier_24() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -7575,7 +7575,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -7597,7 +7597,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_25() {
+  public void unnecessaryModifier_25() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -7615,7 +7615,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -7637,7 +7637,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_26() {
+  public void unnecessaryModifier_26() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -7655,7 +7655,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -7677,7 +7677,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_27() {
+  public void unnecessaryModifier_27() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class A {");
     _builder.newLine();
@@ -7702,7 +7702,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class A {");
     _builder_1.newLine();
@@ -7731,7 +7731,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_28() {
+  public void unnecessaryModifier_28() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class A {");
     _builder.newLine();
@@ -7756,7 +7756,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class A {");
     _builder_1.newLine();
@@ -7785,7 +7785,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_29() {
+  public void unnecessaryModifier_29() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class A {");
     _builder.newLine();
@@ -7810,7 +7810,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class A {");
     _builder_1.newLine();
@@ -7839,7 +7839,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_30() {
+  public void unnecessaryModifier_30() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class A {");
     _builder.newLine();
@@ -7864,7 +7864,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class A {");
     _builder_1.newLine();
@@ -7894,7 +7894,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   
   @Ignore("Javadoc will be not preserved after applying the quickfix")
   @Test
-  public void redundantModifiers_31() {
+  public void unnecessaryModifier_31() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("import java.text.DateFormat");
     _builder.newLine();
@@ -7930,7 +7930,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.text.DateFormat");
     _builder_1.newLine();
@@ -7970,7 +7970,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_32() {
+  public void unnecessaryModifier_32() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("import java.text.SimpleDateFormat");
     _builder.newLine();
@@ -7991,7 +7991,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("import java.text.SimpleDateFormat");
     _builder_1.newLine();
@@ -8016,7 +8016,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_33() {
+  public void unnecessaryModifier_33() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -8048,7 +8048,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -8084,7 +8084,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_34() {
+  public void unnecessaryModifier_34() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -8116,7 +8116,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -8152,7 +8152,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_35() {
+  public void unnecessaryModifier_35() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -8184,7 +8184,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -8220,7 +8220,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_36() {
+  public void unnecessaryModifier_36() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -8252,7 +8252,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -8289,7 +8289,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   
   @Ignore("Javadoc will be not preserved after applying the quickfix")
   @Test
-  public void redundantModifiers_37() {
+  public void unnecessaryModifier_37() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -8326,7 +8326,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -8367,7 +8367,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_38() {
+  public void unnecessaryModifier_38() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -8404,7 +8404,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -8445,7 +8445,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_39() {
+  public void unnecessaryModifier_39() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -8482,7 +8482,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
@@ -8523,11 +8523,11 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_40() {
+  public void unnecessaryModifier_40() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("publ|ic interface Foo {}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append(" ");
     _builder_1.append("interface Foo {}");
@@ -8536,7 +8536,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_41() {
+  public void unnecessaryModifier_41() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -8545,7 +8545,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo { new(){}");
     _builder_1.newLine();
@@ -8555,7 +8555,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_42() {
+  public void unnecessaryModifier_42() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("class Foo {");
     _builder.newLine();
@@ -8570,7 +8570,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo { interface Bar {");
     _builder_1.newLine();
@@ -8586,7 +8586,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_43() {
+  public void unnecessaryModifier_43() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("interface Foo {");
     _builder.newLine();
@@ -8598,7 +8598,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("interface Foo {");
     _builder_1.newLine();
@@ -8614,13 +8614,13 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_44() {
+  public void unnecessaryModifier_44() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("pub|lic annotation Foo {");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append(" ");
     _builder_1.append("annotation Foo {");
@@ -8631,13 +8631,13 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
-  public void redundantModifiers_45() {
+  public void unnecessaryModifier_45() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("pub|lic enum Foo {");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.REDUNDANT_MODIFIER).assertResolutionLabels("Remove the redundant modifier.");
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append(" ");
     _builder_1.append("enum Foo {");

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/XtendQuickfixProvider.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/XtendQuickfixProvider.java
@@ -651,8 +651,8 @@ public class XtendQuickfixProvider extends XbaseQuickfixProvider {
 		});
 	}
 	
-	@Fix(IssueCodes.REDUNDANT_MODIFIER)
-	public void removeRedundantModifier(final Issue issue, IssueResolutionAcceptor acceptor) {
+	@Fix(IssueCodes.UNNECESSARY_MODIFIER)
+	public void removeUnnecessaryModifier(final Issue issue, IssueResolutionAcceptor acceptor) {
 		String[] issueData = issue.getData();
 		if(issueData==null || issueData.length==0) {
 			return;
@@ -662,8 +662,8 @@ public class XtendQuickfixProvider extends XbaseQuickfixProvider {
 		
 		// use the same label, description and image
 		// to be able to use the quickfixes (issue resolution) in batch mode
-		String label = "Remove the redundant modifier.";
-		String description = "The modifier is unnecessary and should be removed.";
+		String label = "Remove the unnecessary modifier.";
+		String description = "The modifier is unnecessary and could be removed.";
 		String image = "fix_indent.gif";
 		acceptor.acceptMulti(issue, label, description, image, new IMultiModification<XtendMember>() {
 			@Override

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/validator/preferences/XtendValidatorConfigurationBlock.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/validator/preferences/XtendValidatorConfigurationBlock.java
@@ -57,7 +57,7 @@ public class XtendValidatorConfigurationBlock extends XbaseValidationConfigurati
 	protected void fillUnusedCodeSection(ComboBoxBuilder builder) {
 		super.fillUnusedCodeSection(builder);
 		builder.addJavaDelegatingComboBox(UNUSED_PRIVATE_MEMBER, "Unused private member:")
-			.addComboBox(REDUNDANT_MODIFIER, "Redundant modifier:");
+			.addComboBox(UNNECESSARY_MODIFIER, "Unnecessary modifier:");
 	}
 
 	@Override


### PR DESCRIPTION
- Since the validation rule mostly targets visibility modifiers matching
the defaults, using the 'Unnecessary modifier' notation is more suitable
than the 'Redundant modifier' notation.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>