### PR TITLE
[eclipse/xtext#1190] Narrowed the version range for asm to [6.1.1,6.2.0)

### DIFF
--- a/org.eclipse.xtend.caliper.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.caliper.tests/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Require-Bundle: com.google.inject;bundle-version="3.0.0",
  org.eclipse.xtext.xbase.testing,
  org.eclipse.jdt.core;bundle-version="3.6.0",
  org.eclipse.xtend.ide,
- org.objectweb.asm;bundle-version="[6.1.1,7.0.0)"
+ org.objectweb.asm;bundle-version="[6.1.1,6.2.0)"
 Bundle-ClassPath: .,
  lib/com.google.caliper-0.5-rc1.jar,
  lib/com.google.gson_2.1.0.v201203072145.jar

--- a/org.eclipse.xtend.core.tests.java8/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.core.tests.java8/META-INF/MANIFEST.MF
@@ -24,7 +24,7 @@ Require-Bundle: org.eclipse.xtend.core,
  org.eclipse.xtend.lib,
  org.apache.ant;bundle-version="1.8.0",
  org.eclipse.pde.core;bundle-version="3.6.0",
- org.objectweb.asm;bundle-version="[6.1.1,7.0.0)",
+ org.objectweb.asm;bundle-version="[6.1.1,6.2.0)",
  org.eclipse.jdt.core,
  org.eclipse.xtext.testing
 Import-Package: javax.inject;version="1.0.0",

--- a/org.eclipse.xtend.core.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.core.tests/META-INF/MANIFEST.MF
@@ -22,7 +22,7 @@ Require-Bundle: org.eclipse.xtend.core,
  org.eclipse.emf.ecore,
  org.eclipse.xtext.builder,
  org.eclipse.xtend.lib,
- org.objectweb.asm;bundle-version="[6.1.1,7.0.0)",
+ org.objectweb.asm;bundle-version="[6.1.1,6.2.0)",
  org.eclipse.jdt.core,
  org.eclipse.xtext.builder.standalone,
  org.eclipse.xtext.java

--- a/org.eclipse.xtend.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.core/META-INF/MANIFEST.MF
@@ -79,7 +79,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.xtend.lib;bundle-version="2.14.0",
  org.eclipse.xtext.smap,
  org.apache.ant;bundle-version="1.7.1";resolution:=optional;x-installation:=greedy,
- org.objectweb.asm;bundle-version="[6.1.1,7.0.0)";resolution:=optional,
+ org.objectweb.asm;bundle-version="[6.1.1,6.2.0)";resolution:=optional,
  org.eclipse.xtext.xbase.testing;resolution:=optional,
  org.eclipse.xtext.generator;resolution:=optional,
  org.eclipse.emf.mwe2.launch;resolution:=optional

--- a/org.eclipse.xtend.examples/projects/xtend-annotation-examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.examples/projects/xtend-annotation-examples/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.xtend.lib,
  org.eclipse.xtext.xbase.testing,
  org.eclipse.jdt.core,
  org.eclipse.emf.codegen;bundle-version="2.10.0",
- org.objectweb.asm;bundle-version="[6.1.1,7.0.0)";resolution:=optional,
+ org.objectweb.asm;bundle-version="[6.1.1,6.2.0)";resolution:=optional,
  org.eclipse.equinox.common
 Export-Package: extract,
  i18n,


### PR DESCRIPTION
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>