### PR TITLE
[https://github.com/eclipse/xtext-eclipse/issues/654] Xtend test cases.

### DIFF
--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/editor/XtendEditorDoubleClickTextSelectionTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/editor/XtendEditorDoubleClickTextSelectionTest.xtend
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.ide.tests.editor
+
+import org.eclipse.xtend.ide.tests.XtendIDEInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractEditorDoubleClickTextSelectionTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(XtextRunner)
+@InjectWith(XtendIDEInjectorProvider)
+class XtendEditorDoubleClickTextSelectionTest extends AbstractEditorDoubleClickTextSelectionTest {
+
+	@Test def selection_in_javadoc_001() {
+		'''
+			class Foo {
+				
+				/**
+				 * @par|am s
+				 * @return
+				 */
+				def m(String s) {}
+			}
+		'''.assertSelectedTextAfterDoubleClicking('''@param''')
+	}
+
+	@Test def selection_in_javadoc_002() {
+		'''
+			class Foo {
+				
+				/**
+				 * @param s
+				 * @ret|urn
+				 */
+				def m(String s) {}
+			}
+		'''.assertSelectedTextAfterDoubleClicking('''@return''')
+	}
+
+	@Test def selection_in_rich_string_001() {
+		val tripleQuotes = "'''"
+		
+		'''
+			class Foo {
+				
+				val a = «tripleQuotes»te|xt«tripleQuotes»
+				
+			}
+		'''.assertSelectedTextAfterDoubleClicking('''text''')
+	}
+}

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/editor/XtendEditorDoubleClickTextSelectionTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/editor/XtendEditorDoubleClickTextSelectionTest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.ide.tests.editor;
+
+import org.eclipse.xtend.ide.tests.XtendIDEInjectorProvider;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractEditorDoubleClickTextSelectionTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(XtextRunner.class)
+@InjectWith(XtendIDEInjectorProvider.class)
+@SuppressWarnings("all")
+public class XtendEditorDoubleClickTextSelectionTest extends AbstractEditorDoubleClickTextSelectionTest {
+  @Test
+  public void selection_in_javadoc_001() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append("\t ");
+    _builder.append("* @par|am s");
+    _builder.newLine();
+    _builder.append("\t ");
+    _builder.append("* @return");
+    _builder.newLine();
+    _builder.append("\t ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def m(String s) {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("@param");
+    this.assertSelectedTextAfterDoubleClicking(_builder, _builder_1.toString());
+  }
+  
+  @Test
+  public void selection_in_javadoc_002() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append("\t ");
+    _builder.append("* @param s");
+    _builder.newLine();
+    _builder.append("\t ");
+    _builder.append("* @ret|urn");
+    _builder.newLine();
+    _builder.append("\t ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def m(String s) {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("@return");
+    this.assertSelectedTextAfterDoubleClicking(_builder, _builder_1.toString());
+  }
+  
+  @Test
+  public void selection_in_rich_string_001() {
+    final String tripleQuotes = "\'\'\'";
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("val a = ");
+    _builder.append(tripleQuotes, "\t");
+    _builder.append("te|xt");
+    _builder.append(tripleQuotes, "\t");
+    _builder.newLineIfNotEmpty();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("text");
+    this.assertSelectedTextAfterDoubleClicking(_builder, _builder_1.toString());
+  }
+}


### PR DESCRIPTION
- Implement XtendEditorDoubleClickTextSelectionTest test cases based on
the AbstractEditorDoubleClickTextSelectionTest abstract test case to
test the customized XtendDoubleClickStrategyProvider behaviour.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>