### PR TITLE
[eclipse/xtext-core#710] Workaround for exception.

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendRichStringFormatterTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/formatting/XtendRichStringFormatterTest.xtend
@@ -307,5 +307,58 @@ class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
 			}
 		''')
 	}
+
+	@Test def indentThreeTabsLineInIf() {
+		assertFormatted('''
+			class Generator {
+				def generate() {
+					```
+						<<IF true>>
+							
+						<<ENDIF>>
+					```
+				}
+			}
+		'''.decode, '''
+			class Generator {
+				def generate() {
+					```
+						<<IF true>>
+						
+						<<ENDIF>>
+					```
+				}
+			}
+		'''.decode)
+	}
+	
+	// TODO this test case is not 100% correct ... one additional tab should be generated for the blank line.
+	// But the formatter code is to complicated. Was not able to generate the correct indentation. But as it is now
+	// the test at least ensures that there is no exception generated.
+	// See: https://github.com/eclipse/xtext-core/issues/710
+	@Test def indentEmptyLineInIf() {
+		assertFormatted('''
+			class Generator {
+				def generate() {
+					```
+						<<IF true>>
+						
+						<<ENDIF>>
+					```
+				}
+			}
+		'''.decode, '''
+			class Generator {
+				def generate() {
+					```
+						<<IF true>>
+			
+						<<ENDIF>>
+					```
+				}
+			}
+		'''.decode)
+	}
+	
 }
 	 

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/richstring/RichStringProcessorTest.java
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/richstring/RichStringProcessorTest.java
@@ -1025,6 +1025,115 @@ public class RichStringProcessorTest extends AbstractRichStringTest {
 		Assert.assertEquals(expected, events);
 	}
 	
+	@Test public void testProcessorEvents2() throws Exception {
+		String events = recordRichStringProcessorEvents(
+				"'''\n" +
+				" «IF true»\n" +
+				" «ENDIF»\n" +
+				"'''");
+		String expected = 
+				"announceNextLiteral()\n"+
+				"acceptTemplateText()\n"+
+				"acceptTemplateLineBreak()\n"+
+				"acceptTemplateText( )\n"+
+				"acceptIfCondition()\n"+
+				"announceNextLiteral()\n"+
+				"acceptTemplateText()\n"+
+				"acceptTemplateLineBreak()\n"+
+				"acceptTemplateText( )\n"+
+				"acceptEndIf()\n"+
+				"announceNextLiteral()\n"+
+				"acceptTemplateText()\n"+
+				"acceptTemplateLineBreak()\n"+
+				"acceptTemplateText()";
+		Assert.assertEquals(expected, events);
+	}
+	
+	@Test public void testProcessorEvents3() throws Exception {
+		String events = recordRichStringProcessorEvents(
+				"'''\n" +
+				"«IF true»\n" +
+				"«ENDIF»\n" +
+				"'''");
+		String expected = 
+				"announceNextLiteral()\n"+
+				"acceptTemplateText()\n"+
+				"acceptTemplateLineBreak()\n"+
+				"acceptTemplateText()\n"+
+				"acceptIfCondition()\n"+
+				"announceNextLiteral()\n"+
+				"acceptTemplateText()\n"+
+				"acceptTemplateLineBreak()\n"+
+				"acceptTemplateText()\n"+
+				"acceptEndIf()\n"+
+				"announceNextLiteral()\n"+
+				"acceptTemplateText()\n"+
+				"acceptTemplateLineBreak()\n"+
+				"acceptTemplateText()";
+		Assert.assertEquals(expected, events);
+	}
+	
+	@Test public void testProcessorEvents4() throws Exception {
+		String events = recordRichStringProcessorEvents(
+				"\t'''\n" +
+				"\t«IF true»\n" +
+				"\t\n" +
+				"\t«ENDIF»\n" +
+				"\t'''");
+		String expected = 
+				"announceNextLiteral()\n"+
+				"acceptTemplateText()\n"+
+				"acceptTemplateLineBreak()\n"+
+				"acceptTemplateText(\t)\n"+
+				"acceptIfCondition()\n"+
+				"announceNextLiteral()\n"+
+				"acceptTemplateText()\n"+
+				"acceptTemplateLineBreak()\n"+
+				"acceptTemplateText(\t)\n"+
+				"acceptSemanticText()\n"+
+				"acceptTemplateText()\n"+
+				"acceptSemanticText()\n"+
+				"acceptSemanticText()\n"+
+				"acceptSemanticLineBreak()\n"+
+				"acceptTemplateText(	)\n"+
+				"acceptEndIf()\n"+
+				"announceNextLiteral()\n"+
+				"acceptTemplateText()\n"+
+				"acceptTemplateLineBreak()\n"+
+				"acceptTemplateText(\t)";
+		Assert.assertEquals(expected, events);
+//		System.out.println(events);
+	}
+	
+	@Test public void testProcessorEvents5() throws Exception {
+		String events = recordRichStringProcessorEvents(
+				"\t'''\n" +
+						"\t«IF true»\n" +
+						"\n" +
+						"\t«ENDIF»\n" +
+				"\t'''");
+		String expected = 
+				"announceNextLiteral()\n"+
+				"acceptTemplateText()\n"+
+				"acceptTemplateLineBreak()\n"+
+				"acceptTemplateText(\t)\n"+
+				"acceptIfCondition()\n"+
+				"announceNextLiteral()\n"+
+				"acceptTemplateText()\n"+
+				"acceptTemplateLineBreak()\n"+
+				"acceptSemanticText()\n"+
+				"acceptSemanticText()\n"+
+				"acceptSemanticLineBreak()\n"+
+				"acceptTemplateText(	)\n"+
+				"acceptEndIf()\n"+
+				"announceNextLiteral()\n"+
+				"acceptTemplateText()\n"+
+				"acceptTemplateLineBreak()\n"+
+				"acceptTemplateText(\t)";
+		Assert.assertEquals(expected, events);
+//		System.out.println(events);
+	}
+	
 	@Ignore("https://bugs.eclipse.org/bugs/show_bug.cgi?id=394277")
 	@Test public void testProcessorEventsBug394277_01() throws Exception {
 		String events = recordRichStringProcessorEvents(

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendRichStringFormatterTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/formatting/XtendRichStringFormatterTest.java
@@ -597,4 +597,113 @@ public class XtendRichStringFormatterTest extends AbstractXtendFormatterTest {
     _builder.newLine();
     this.assertFormattedRichString(_builder);
   }
+  
+  @Test
+  public void indentThreeTabsLineInIf() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Generator {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def generate() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("```");
+    _builder.newLine();
+    _builder.append("\t\t\t");
+    _builder.append("<<IF true>>");
+    _builder.newLine();
+    _builder.append("\t\t\t\t");
+    _builder.newLine();
+    _builder.append("\t\t\t");
+    _builder.append("<<ENDIF>>");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("```");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Generator {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def generate() {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("```");
+    _builder_1.newLine();
+    _builder_1.append("\t\t\t");
+    _builder_1.append("<<IF true>>");
+    _builder_1.newLine();
+    _builder_1.append("\t\t\t");
+    _builder_1.newLine();
+    _builder_1.append("\t\t\t");
+    _builder_1.append("<<ENDIF>>");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("```");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertFormatted(this.decode(_builder), this.decode(_builder_1));
+  }
+  
+  @Test
+  public void indentEmptyLineInIf() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Generator {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def generate() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("```");
+    _builder.newLine();
+    _builder.append("\t\t\t");
+    _builder.append("<<IF true>>");
+    _builder.newLine();
+    _builder.append("\t\t\t");
+    _builder.newLine();
+    _builder.append("\t\t\t");
+    _builder.append("<<ENDIF>>");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("```");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Generator {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def generate() {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("```");
+    _builder_1.newLine();
+    _builder_1.append("\t\t\t");
+    _builder_1.append("<<IF true>>");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("\t\t\t");
+    _builder_1.append("<<ENDIF>>");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("```");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertFormatted(this.decode(_builder), this.decode(_builder_1));
+  }
 }

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/formatting2/RichStringFormatter.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/formatting2/RichStringFormatter.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -38,6 +38,7 @@ import org.eclipse.xtext.xbase.XExpression
 import org.eclipse.xtext.xbase.XbasePackage
 
 import static org.eclipse.xtext.formatting2.FormatterPreferenceKeys.*
+import org.eclipse.emf.ecore.plugin.EcorePlugin
 
 /**
  * cases to distinguish:
@@ -47,6 +48,7 @@ import static org.eclipse.xtext.formatting2.FormatterPreferenceKeys.*
  *  4. multi-line with only whitespace after opening ''' and before closing ''': one level of extra indentation between ''' and '''
  * 
  * @author Moritz Eysholdt - Initial implementation and API
+ * @author Arne Deutsch - Workaround for exception thrown for blank lines
  */
 @FinalFieldsConstructor class RichStringFormatter {
 
@@ -101,7 +103,16 @@ import static org.eclipse.xtext.formatting2.FormatterPreferenceKeys.*
 							TemplateWhitespace: doc.formatter.getPreference(indentation)
 						}
 					].join
-					doc.setSpace(offset, length, text)
+					// TODO The if statement is a workaround. Without it an exception is generated in case a blank line
+					// without any whitespace is placed e.g. between an «IF». This way the indentation is not correct
+					// but at least the file is formatted. There is a test case in XtendRichStringFormatterTest that
+					// needs to be adapted as soon as the root cause of the issue is found.
+					// See: https://github.com/eclipse/xtext-core/issues/710
+					if (length >= 0) {
+						doc.setSpace(offset, length, text)
+					} else {
+						EcorePlugin.INSTANCE.log(new RuntimeException("Programmatic error: length == " + length));
+					}
 				}
 			}
 		}

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/Chunk.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/Chunk.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/Line.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/Line.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/LineModel.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/LineModel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/RichStringFormatter.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/RichStringFormatter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.plugin.EcorePlugin;
 import org.eclipse.xtend.core.formatting2.Chunk;
 import org.eclipse.xtend.core.formatting2.Line;
 import org.eclipse.xtend.core.formatting2.RichStringToLineModel;
@@ -60,6 +61,7 @@ import org.eclipse.xtext.xbase.lib.StringExtensions;
  *  4. multi-line with only whitespace after opening ''' and before closing ''': one level of extra indentation between ''' and '''
  * 
  * @author Moritz Eysholdt - Initial implementation and API
+ * @author Arne Deutsch - Workaround for exception thrown for blank lines
  */
 @FinalFieldsConstructor
 @SuppressWarnings("all")
@@ -167,7 +169,12 @@ public class RichStringFormatter {
             return _switchResult;
           };
           final String text = IterableExtensions.join(ListExtensions.<Chunk, CharSequence>map(line.getChunks(), _function));
-          this.setSpace(doc, offset, length, text);
+          if ((length >= 0)) {
+            this.setSpace(doc, offset, length, text);
+          } else {
+            RuntimeException _runtimeException = new RuntimeException(("Programmatic error: length == " + Integer.valueOf(length)));
+            EcorePlugin.INSTANCE.log(_runtimeException);
+          }
         }
       }
     }

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/RichStringToLineModel.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/RichStringToLineModel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/SemanticText.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/SemanticText.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/SemanticWhitespace.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/SemanticWhitespace.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/TemplateWhitespace.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/formatting2/TemplateWhitespace.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
@@ -4841,7 +4841,6 @@ class QuickfixTest extends AbstractXtendUITestCase {
 		''')
 	}
 	
-	@Ignore("java.lang.IllegalArgumentException: length must be >= 0")
 	@Test
 	def void unnecessaryModifier_46(){
 		// Xtend function having both 'def' and 'override' modifiers
@@ -4869,7 +4868,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 					val e = «tripleQuotes»
 						«ifLiteral»
 							a
-			
+						
 							b
 						«endifLiteral»
 					«tripleQuotes»

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
@@ -8647,7 +8647,6 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
   }
   
-  @Ignore("java.lang.IllegalArgumentException: length must be >= 0")
   @Test
   public void unnecessaryModifier_46() {
     final String tripleQuotes = "\'\'\'";
@@ -8701,6 +8700,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder_1.append("\t\t\t\t");
     _builder_1.append("a");
     _builder_1.newLine();
+    _builder_1.append("\t\t\t");
     _builder_1.newLine();
     _builder_1.append("\t\t\t\t");
     _builder_1.append("b");


### PR DESCRIPTION
Implement a workaround to avoid exception. Formatting is not 100%
correct but at least the formatting is done at all (one missing tab).

Added test case to verify that no exception is raised.

Also added TODO comments explaining what and why it was done.

Enabled and fixed added QuickfixTest.

Signed-off-by: Arne Deutsch <Arne.Deutsch@itemis.de>