### PR TITLE
[#468] Marked Mojos as Threadsafe and introduced a lock to ensure singlethreaded execution

### DIFF
--- a/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/AbstractXtendMojo.java
+++ b/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/AbstractXtendMojo.java
@@ -9,6 +9,8 @@ import com.google.inject.Inject;
 
 public abstract class AbstractXtendMojo extends AbstractMojo {
 
+	private static final Object lock = new Object();
+
 	@Inject
 	protected MavenLog4JConfigurator log4jConfigurator;
 
@@ -35,8 +37,10 @@ public abstract class AbstractXtendMojo extends AbstractMojo {
 		if (isSkipped()) {
 			getLog().info("skipped.");
 		} else {
-			log4jConfigurator.configureLog4j(getLog());
-			internalExecute();
+			synchronized(lock) {
+				log4jConfigurator.configureLog4j(getLog());
+				internalExecute();
+			}
 		}
 	}
 

--- a/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/XtendCompile.java
+++ b/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/XtendCompile.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Sets;
  * @goal compile
  * @phase generate-sources
  * @requiresDependencyResolution compile
+ * @threadSafe true
  */
 public class XtendCompile extends AbstractXtendCompilerMojo {
 	/**

--- a/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/XtendInstallDebugInfo.java
+++ b/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/XtendInstallDebugInfo.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Multimap;
  * @goal xtend-install-debug-info
  * @phase process-classes
  * @requiresDependencyResolution compile
+ * @threadSafe true
  */
 public class XtendInstallDebugInfo extends AbstractXtendInstallDebugInfoMojo {
 

--- a/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/XtendTestCompile.java
+++ b/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/XtendTestCompile.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Sets;
  * @goal testCompile
  * @phase generate-test-sources
  * @requiresDependencyResolution test
+ * @threadSafe true
  */
 public class XtendTestCompile extends AbstractXtendCompilerMojo {
 	/**

--- a/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/XtendTestInstallDebugInfo.java
+++ b/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/XtendTestInstallDebugInfo.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Multimap;
  * @goal xtend-test-install-debug-info
  * @phase process-test-classes
  * @requiresDependencyResolution compile
+ * @threadSafe true
  */
 public class XtendTestInstallDebugInfo extends AbstractXtendInstallDebugInfoMojo {
 	@Override


### PR DESCRIPTION
[#468] Marked Mojos as Threadsafe and introduced a lock to ensure singlethreaded execution

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>