### PR TITLE
[#504] Provide Quickfixes to change JUnit methods' return type to void.

### DIFF
--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
@@ -3793,7 +3793,127 @@ class QuickfixTest extends AbstractXtendUITestCase {
 			}
 		''')
 	}
-
+	
+	@Test
+	def void junitTestMethodReturnType() {
+		create('Foo.xtend', '''
+			import org.junit.Test
+			class Foo {
+				@Test def <|>test001() {
+				}
+			}
+		''')
+		.assertIssueCodes(INVALID_RETURN_TYPE_IN_CASE_OF_JUNIT_ANNOTATION)
+		.assertResolutionLabels("Change return type to void.")
+		.assertModelAfterQuickfix('''
+			import org.junit.Test
+			class Foo {
+				@Test def void test001() {
+				}
+			}
+		''')
+	}
+	
+	@Test
+	def void junitTestMethodIntReturnType() {
+		create('Foo.xtend', '''
+			import org.junit.Test
+			class Foo {
+				@Test def int <|>test001() {
+				}
+			}
+		''')
+		.assertIssueCodes(INVALID_RETURN_TYPE_IN_CASE_OF_JUNIT_ANNOTATION)
+		.assertResolutionLabels("Change return type to void.")
+		.assertModelAfterQuickfix('''
+			import org.junit.Test
+			class Foo {
+				@Test def void test001() {
+				}
+			}
+		''')
+	}
+	
+	@Test
+	def void junitBeforeMethodReturnType() {
+		create('Foo.xtend', '''
+			import org.junit.Before
+			class Foo {
+				@Before def <|>before() {
+				}
+			}
+		''')
+		.assertIssueCodes(INVALID_RETURN_TYPE_IN_CASE_OF_JUNIT_ANNOTATION)
+		.assertResolutionLabels("Change return type to void.")
+		.assertModelAfterQuickfix('''
+			import org.junit.Before
+			class Foo {
+				@Before def void before() {
+				}
+			}
+		''')
+	}
+	
+	@Test
+	def void junitAfterMethodReturnType() {
+		create('Foo.xtend', '''
+			import org.junit.After
+			class Foo {
+				@After def <|>after() {
+				}
+			}
+		''')
+		.assertIssueCodes(INVALID_RETURN_TYPE_IN_CASE_OF_JUNIT_ANNOTATION)
+		.assertResolutionLabels("Change return type to void.")
+		.assertModelAfterQuickfix('''
+			import org.junit.After
+			class Foo {
+				@After def void after() {
+				}
+			}
+		''')
+	}
+	
+	@Test
+	def void junitBeforeClassMethodReturnType() {
+		create('Foo.xtend', '''
+			import org.junit.BeforeClass
+			class Foo {
+				@BeforeClass def static <|>beforeClass() {
+				}
+			}
+		''')
+		.assertIssueCodes(INVALID_RETURN_TYPE_IN_CASE_OF_JUNIT_ANNOTATION)
+		.assertResolutionLabels("Change return type to void.")
+		.assertModelAfterQuickfix('''
+			import org.junit.BeforeClass
+			class Foo {
+				@BeforeClass def static void beforeClass() {
+				}
+			}
+		''')
+	}
+	
+	@Test
+	def void junitAfterClassMethodReturnType() {
+		create('Foo.xtend', '''
+			import org.junit.AfterClass
+			class Foo {
+				@AfterClass def static <|>afterClass() {
+				}
+			}
+		''')
+		.assertIssueCodes(INVALID_RETURN_TYPE_IN_CASE_OF_JUNIT_ANNOTATION)
+		.assertResolutionLabels("Change return type to void.")
+		.assertModelAfterQuickfix('''
+			import org.junit.AfterClass
+			class Foo {
+				@AfterClass def static void afterClass() {
+				}
+			}
+		''')
+	}
+	
 	@Test
 	def void unnecessaryModifier_01(){
 		// Xtend class having a 'public' modifier

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
@@ -6904,6 +6904,198 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
+  public void junitTestMethodReturnType() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.junit.Test");
+    _builder.newLine();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("@Test def <|>test001() {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.INVALID_RETURN_TYPE_IN_CASE_OF_JUNIT_ANNOTATION).assertResolutionLabels("Change return type to void.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import org.junit.Test");
+    _builder_1.newLine();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("@Test def void test001() {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void junitTestMethodIntReturnType() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.junit.Test");
+    _builder.newLine();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("@Test def int <|>test001() {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.INVALID_RETURN_TYPE_IN_CASE_OF_JUNIT_ANNOTATION).assertResolutionLabels("Change return type to void.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import org.junit.Test");
+    _builder_1.newLine();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("@Test def void test001() {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void junitBeforeMethodReturnType() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.junit.Before");
+    _builder.newLine();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("@Before def <|>before() {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.INVALID_RETURN_TYPE_IN_CASE_OF_JUNIT_ANNOTATION).assertResolutionLabels("Change return type to void.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import org.junit.Before");
+    _builder_1.newLine();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("@Before def void before() {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void junitAfterMethodReturnType() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.junit.After");
+    _builder.newLine();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("@After def <|>after() {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.INVALID_RETURN_TYPE_IN_CASE_OF_JUNIT_ANNOTATION).assertResolutionLabels("Change return type to void.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import org.junit.After");
+    _builder_1.newLine();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("@After def void after() {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void junitBeforeClassMethodReturnType() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.junit.BeforeClass");
+    _builder.newLine();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("@BeforeClass def static <|>beforeClass() {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.INVALID_RETURN_TYPE_IN_CASE_OF_JUNIT_ANNOTATION).assertResolutionLabels("Change return type to void.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import org.junit.BeforeClass");
+    _builder_1.newLine();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("@BeforeClass def static void beforeClass() {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void junitAfterClassMethodReturnType() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.junit.AfterClass");
+    _builder.newLine();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("@AfterClass def static <|>afterClass() {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.INVALID_RETURN_TYPE_IN_CASE_OF_JUNIT_ANNOTATION).assertResolutionLabels("Change return type to void.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import org.junit.AfterClass");
+    _builder_1.newLine();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("@AfterClass def static void afterClass() {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
   public void unnecessaryModifier_01() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("publ|ic class Foo {}");

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/XtendQuickfixProvider.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/XtendQuickfixProvider.java
@@ -54,6 +54,7 @@ import org.eclipse.xtext.common.types.JvmType;
 import org.eclipse.xtext.common.types.JvmTypeReference;
 import org.eclipse.xtext.common.types.TypesPackage;
 import org.eclipse.xtext.common.types.access.jdt.IJavaProjectProvider;
+import org.eclipse.xtext.common.types.util.TypeReferences;
 import org.eclipse.xtext.diagnostics.Diagnostic;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.ILeafNode;
@@ -124,6 +125,9 @@ public class XtendQuickfixProvider extends XbaseQuickfixProvider {
 	@Inject private IBatchTypeResolver batchTypeResolver;
 	
 	@Inject private ProjectUtil projectUtil; 
+	
+	@Inject
+	private TypeReferences typeReferences;
 	
 	private static final Set<String> LINKING_ISSUE_CODES = newHashSet(
 			Diagnostic.LINKING_DIAGNOSTIC,
@@ -669,6 +673,20 @@ public class XtendQuickfixProvider extends XbaseQuickfixProvider {
 			ctx.setUpdateCrossReferences(false);
 			ctx.setUpdateRelatedFiles(false);
 			ctx.addModification(element, ele -> ele.getModifiers().remove(modifier));
+		});
+	}
+	
+	@Fix(IssueCodes.INVALID_RETURN_TYPE_IN_CASE_OF_JUNIT_ANNOTATION)
+	public void changeJUnitMethodReturnTypeToVoid(final Issue issue, IssueResolutionAcceptor acceptor) {
+		// use the same label, description and image
+		// to be able to use the quickfixes (issue resolution) in batch mode
+		String label = "Change return type to void.";
+		String description = "Change the return type to void to be recognized by JUnit.";
+		String image = "fix_indent.gif";
+		acceptor.acceptMulti(issue, label, description, image, (ICompositeModification<XtendFunction>) (element, ctx) -> {
+			ctx.setUpdateCrossReferences(false);
+			ctx.setUpdateRelatedFiles(false);
+			ctx.addModification(element, ele -> ele.setReturnType(typeReferences.getTypeForName(Void.TYPE, ele)));
 		});
 	}
 	


### PR DESCRIPTION
- Extend the XtendQuickfixProvider to provide Quickfixes to change the
return type of an Xtend method to void (also executable in batch mode).
- Implement corresponding Xtend QuickfixTest test cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>