### PR TITLE
[#1238] Restrict org.antlr.runtime version to 3.2.0

### DIFF
--- a/org.eclipse.xtend.ide.common/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.ide.common/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtend.core,
  org.eclipse.xtext.ide;visibility:=reexport,
  org.eclipse.xtext.xbase.ide,
- org.antlr.runtime,
+ org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",
  org.eclipse.core.runtime;bundle-version="3.6.0";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtend.ide.common.contentassist.antlr;x-friends:="org.eclipse.xtend.ide",


### PR DESCRIPTION
Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>