### PR TITLE
[#516] Improve the checkJUnitMethodReturnType Xtend validation rule.

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/JUnitMethodReturnTypeValidationTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/JUnitMethodReturnTypeValidationTest.xtend
@@ -8,14 +8,17 @@
 package org.eclipse.xtend.core.tests.validation
 
 import javax.inject.Inject
+import org.eclipse.emf.ecore.EClass
 import org.eclipse.xtend.core.tests.AbstractXtendTestCase
 import org.eclipse.xtend.core.xtend.XtendFile
 import org.eclipse.xtext.testing.util.ParseHelper
 import org.eclipse.xtext.testing.validation.ValidationTestHelper
 import org.junit.Test
 
-import static org.eclipse.xtend.core.xtend.XtendPackage.Literals.*
 import static org.eclipse.xtend.core.validation.IssueCodes.INVALID_RETURN_TYPE_IN_CASE_OF_JUNIT_ANNOTATION
+import static org.eclipse.xtend.core.xtend.XtendPackage.Literals.*
+import static org.eclipse.xtext.diagnostics.Diagnostic.LINKING_DIAGNOSTIC
+import static org.eclipse.xtext.xbase.XbasePackage.Literals.*
 
 class JUnitMethodReturnTypeValidationTest extends AbstractXtendTestCase {
 
@@ -423,14 +426,35 @@ class JUnitMethodReturnTypeValidationTest extends AbstractXtendTestCase {
 			}
 		'''.hasOneValidationIssue("JUnit method afterClass() must be void but is Object.")
 	}
+	
+	@Test def test033() {
+		/**
+		 * Ensure that the 'JUnit Method Return Type Validation Check'
+		 * does not report a follow up issue of an unknown return type.
+		 */
+		'''
+			import org.junit.Test
+			
+			class Foo {
+				
+				@Test def test() {
+					foo
+				}
+			}
+		'''.hasOneValidationIssue(XFEATURE_CALL, LINKING_DIAGNOSTIC, "The method or field foo is undefined")
+	}
 
 	private def void hasNoValidationIssue(CharSequence it) {
 		assertNumberOfValidationIssues(0)
 	}
 
 	private def hasOneValidationIssue(CharSequence it, String message) {
+		it.hasOneValidationIssue(XTEND_FUNCTION, INVALID_RETURN_TYPE_IN_CASE_OF_JUNIT_ANNOTATION, message)
+	}
+
+	private def hasOneValidationIssue(CharSequence it, EClass objectType, String issueCode, String message) {
 		assertNumberOfValidationIssues(1).
-		assertError(XTEND_FUNCTION, INVALID_RETURN_TYPE_IN_CASE_OF_JUNIT_ANNOTATION, message)
+		assertError(objectType, issueCode, message)
 	}
 
 	private def assertNumberOfValidationIssues(CharSequence it, int expectedNumberOfIssues) {

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/JUnitMethodReturnTypeValidationTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/JUnitMethodReturnTypeValidationTest.java
@@ -8,13 +8,16 @@
 package org.eclipse.xtend.core.tests.validation;
 
 import javax.inject.Inject;
+import org.eclipse.emf.ecore.EClass;
 import org.eclipse.xtend.core.tests.AbstractXtendTestCase;
 import org.eclipse.xtend.core.validation.IssueCodes;
 import org.eclipse.xtend.core.xtend.XtendFile;
 import org.eclipse.xtend.core.xtend.XtendPackage;
 import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.diagnostics.Diagnostic;
 import org.eclipse.xtext.testing.util.ParseHelper;
 import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.eclipse.xtext.xbase.XbasePackage;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.junit.Assert;
@@ -757,12 +760,40 @@ public class JUnitMethodReturnTypeValidationTest extends AbstractXtendTestCase {
     this.hasOneValidationIssue(_builder, "JUnit method afterClass() must be void but is Object.");
   }
   
+  @Test
+  public void test033() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.junit.Test");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("@Test def test() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("foo");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.hasOneValidationIssue(_builder, XbasePackage.Literals.XFEATURE_CALL, Diagnostic.LINKING_DIAGNOSTIC, "The method or field foo is undefined");
+  }
+  
   private void hasNoValidationIssue(final CharSequence it) {
     this.assertNumberOfValidationIssues(it, 0);
   }
   
   private void hasOneValidationIssue(final CharSequence it, final String message) {
-    this._validationTestHelper.assertError(this.assertNumberOfValidationIssues(it, 1), XtendPackage.Literals.XTEND_FUNCTION, IssueCodes.INVALID_RETURN_TYPE_IN_CASE_OF_JUNIT_ANNOTATION, message);
+    this.hasOneValidationIssue(it, XtendPackage.Literals.XTEND_FUNCTION, IssueCodes.INVALID_RETURN_TYPE_IN_CASE_OF_JUNIT_ANNOTATION, message);
+  }
+  
+  private void hasOneValidationIssue(final CharSequence it, final EClass objectType, final String issueCode, final String message) {
+    this._validationTestHelper.assertError(this.assertNumberOfValidationIssues(it, 1), objectType, issueCode, message);
   }
   
   private XtendFile assertNumberOfValidationIssues(final CharSequence it, final int expectedNumberOfIssues) {

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendValidator.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendValidator.java
@@ -134,6 +134,7 @@ import org.eclipse.xtext.xbase.typesystem.override.ResolvedFeatures;
 import org.eclipse.xtext.xbase.typesystem.references.ITypeReferenceOwner;
 import org.eclipse.xtext.xbase.typesystem.references.LightweightTypeReference;
 import org.eclipse.xtext.xbase.typesystem.references.StandardTypeReferenceOwner;
+import org.eclipse.xtext.xbase.typesystem.references.UnknownTypeReference;
 import org.eclipse.xtext.xbase.typesystem.util.ContextualVisibilityHelper;
 import org.eclipse.xtext.xbase.typesystem.util.IVisibilityHelper;
 import org.eclipse.xtext.xbase.typesystem.util.RecursionGuard;
@@ -341,7 +342,7 @@ public class XtendValidator extends XbaseWithAnnotationsValidator {
 		 */
 		if(hasJUnitAnnotation(operation)) {
 			LightweightTypeReference actualType = determineReturnType(operation);
-			if(actualType !=null && !actualType.isPrimitiveVoid()) {
+			if(actualType !=null && !actualType.isUnknown() && !actualType.isPrimitiveVoid()) {
 				String message = String.format("JUnit method %s() must be void but is %s.", function.getName(), actualType.getHumanReadableName());
 				EAttribute location = XTEND_FUNCTION__NAME;
 				error(message, function, location, INVALID_RETURN_TYPE_IN_CASE_OF_JUNIT_ANNOTATION);


### PR DESCRIPTION
- Modify the checkJUnitMethodReturnType Xtend validation rule to ensure
that the 'JUnit Method Return Type Validation Check' doesn't report any
follow up issues in case of an unknown return type.
- Implement corresponding JUnitMethodReturnTypeValidationTest test case.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>