### PR TITLE
[validator] Enable overriding of the implicit modifier validation.

### DIFF
--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/ModifierValidator.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/ModifierValidator.java
@@ -28,6 +28,7 @@ import org.eclipse.xtext.validation.Check;
 
 /**
  * @author Jan Koehnlein - Initial contribution and API
+ * @author Stephane Galland - Add the functions "*ByDefault".
  */
 public class ModifierValidator {
 
@@ -78,17 +79,16 @@ public class ModifierValidator {
 						error("The " + memberName +" can only set one of public / package / protected / private", 
 								member, i);
 					visibilitySeen = true;
-					if("private".equals(modifier) && member instanceof XtendField) {
+					if("private".equals(modifier) && isPrivateByDefault(member)) {
 						unnecessaryModifierIssue("private", memberName, member, i);
 					}
-					if("public".equals(modifier) && (
-							member instanceof XtendAnnotationType ||
-							member instanceof XtendClass ||
-							member instanceof XtendEnum ||
-							member instanceof XtendInterface ||
-							member instanceof XtendConstructor ||
-							member instanceof XtendFunction
-					)) {
+					if("protected".equals(modifier) && isProtectedByDefault(member)) {
+						unnecessaryModifierIssue("protected", memberName, member, i);
+					}
+					if("package".equals(modifier) && isPackageByDefault(member)) {
+						unnecessaryModifierIssue("package", memberName, member, i);
+					}
+					if("public".equals(modifier) && isPublicByDefault(member)) {
 						unnecessaryModifierIssue("public", memberName, member, i);
 					}
 				}
@@ -163,5 +163,65 @@ public class ModifierValidator {
 		validator.acceptError(message, source, XTEND_MEMBER__MODIFIERS, index, IssueCodes.INVALID_MODIFIER);
 	}
 
+	/** Replies if the default visibility modifier for the given member is "private".
+	 * If this function replies {@code true}, the "private" modifier is assumed to be the default one for the given member.
+	 * This function may be used for printing out an "unnecessary modifier" warning when the "private" modifier is explicitly
+	 * attached to the given member.
+	 *
+	 * <p>This function is defined for being overridden by subclasses.
+	 *
+	 * @param member the member to test.
+	 * @return {@code true} if the "private" modifier is the modifier by default for the given member.
+	 */
+	protected boolean isPrivateByDefault(XtendMember member) {
+		return member instanceof XtendField;
+	}
+
+	/** Replies if the default visibility modifier for the given member is "protected".
+	 * If this function replies {@code true}, the "protected" modifier is assumed to be the default one for the given member.
+	 * This function may be used for printing out an "unnecessary modifier" warning when the "protected" modifier is explicitly
+	 * attached to the given member.
+	 *
+	 * <p>This function is defined for being overridden by subclasses.
+	 *
+	 * @param member the member to test.
+	 * @return {@code true} if the "protected" modifier is the modifier by default for the given member.
+	 */
+	protected boolean isProtectedByDefault(XtendMember member) {
+		return false;
+	}
+
+	/** Replies if the default visibility modifier for the given member is "package".
+	 * If this function replies {@code true}, the "package" modifier is assumed to be the default one for the given member.
+	 * This function may be used for printing out an "unnecessary modifier" warning when the "package" modifier is explicitly
+	 * attached to the given member.
+	 *
+	 * <p>This function is defined for being overridden by subclasses.
+	 *
+	 * @param member the member to test.
+	 * @return {@code true} if the "package" modifier is the modifier by default for the given member.
+	 */
+	protected boolean isPackageByDefault(XtendMember member) {
+		return false;
+	}
+
+	/** Replies if the default visibility modifier for the given member is "public".
+	 * If this function replies {@code true}, the "public" modifier is assumed to be the default one for the given member.
+	 * This function may be used for printing out an "unnecessary modifier" warning when the "public" modifier is explicitly
+	 * attached to the given member.
+	 *
+	 * <p>This function is defined for being overridden by subclasses.
+	 *
+	 * @param member the member to test.
+	 * @return {@code true} if the "public" modifier is the modifier by default for the given member.
+	 */
+	protected boolean isPublicByDefault(XtendMember member) {
+		return member instanceof XtendAnnotationType ||
+			member instanceof XtendClass ||
+			member instanceof XtendEnum ||
+			member instanceof XtendInterface ||
+			member instanceof XtendConstructor ||
+			member instanceof XtendFunction;
+	}
 
 }


### PR DESCRIPTION
In a specific DSL extending Xtend, the implicit modifiers may be
different than the ones that are hardcoded into Xtend. This patch add
protected functions in order to enable the overriding of the modifier
validator.

Signed-off-by: Stéphane Galland <galland@arakhne.org>