### PR TITLE
[eclipse/xtext-eclipse#782] fixed javadoc links in javadoc of types. fixed javadoc links to constructors

### DIFF
--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/hover/XtendHoverDocumentationProviderTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/hover/XtendHoverDocumentationProviderTest.xtend
@@ -395,6 +395,104 @@ class XtendHoverDocumentationProviderTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
+	def void testLinkToMethodHoverUnQualifiedOnType() {
+		val xtendFile = parseHelper.parse('''
+		package testpackage
+		/**
+		 * see {@link #bar(int)}
+		 */
+		class Foo {
+			def bar(int n){}
+		}
+		''',resourceSet)
+		val clazz = xtendFile.getXtendTypes.filter(typeof(XtendClass)).head
+		val docu = documentationProvider.getDocumentation(clazz)
+		assertEquals('''see <code><a href="eclipse-xtext-doc:__synthetic0.xtend%23/1/@members.1">#bar(int)</a></code>'''.toString, docu)
+	}
+	
+	@Test
+	def void testLinkToMethodHoverQualifiedOnType() {
+		val xtendFile = parseHelper.parse('''
+		package testpackage
+		/**
+		 * see {@link Foo#bar(int)}
+		 */
+		class Foo {
+			def bar(int n) {}
+		}
+		''',resourceSet)
+		val clazz = xtendFile.getXtendTypes.filter(typeof(XtendClass)).head
+		val docu = documentationProvider.getDocumentation(clazz)
+		assertEquals('''see <code><a href="eclipse-xtext-doc:__synthetic0.xtend%23/1/@members.1">Foo#bar(int)</a></code>'''.toString, docu)
+	}
+	
+	@Test
+	def void testLinkToConstructorHoverUnQualifiedOnType() {
+		val xtendFile = parseHelper.parse('''
+		package testpackage
+		/**
+		 * see {@link #Foo(int)}
+		 */
+		class Foo {
+			def new(int n){}
+		}
+		''',resourceSet)
+		val clazz = xtendFile.getXtendTypes.filter(typeof(XtendClass)).head
+		val docu = documentationProvider.getDocumentation(clazz)
+		assertEquals('''see <code><a href="eclipse-xtext-doc:__synthetic0.xtend%23/1/@members.0">#Foo(int)</a></code>'''.toString, docu)
+	}
+	
+	@Test
+	def void testLinkToConstructorHoverQualifiedOnType() {
+		val xtendFile = parseHelper.parse('''
+		package testpackage
+		/**
+		 * see {@link Foo#Foo(int)}
+		 */
+		class Foo {
+			new(int n){}
+		}
+		''',resourceSet)
+		val clazz = xtendFile.getXtendTypes.filter(typeof(XtendClass)).head
+		val docu = documentationProvider.getDocumentation(clazz)
+		assertEquals('''see <code><a href="eclipse-xtext-doc:__synthetic0.xtend%23/1/@members.0">Foo#Foo(int)</a></code>'''.toString, docu)
+	}
+	
+	@Test
+	def void testLinkToConstructorHoverUnQualifiedOnMethod() {
+		val xtendFile = parseHelper.parse('''
+		package testpackage
+		class Foo {
+			new(int n){}
+			/**
+			 * see {@link #Foo(int)}
+			 */
+			def void bla(){}
+		}
+		''',resourceSet)
+		val clazz = xtendFile.getXtendTypes.filter(typeof(XtendClass)).head
+		val docu = documentationProvider.getDocumentation(clazz.members.filter(XtendFunction).head)
+		assertEquals('''see <code><a href="eclipse-xtext-doc:__synthetic0.xtend%23/1/@members.0">#Foo(int)</a></code>'''.toString, docu)
+	}
+	
+	@Test
+	def void testLinkToConstructorHoverQualifiedOnMethod() {
+		val xtendFile = parseHelper.parse('''
+		package testpackage
+		class Foo {
+			new(int n){}
+			/**
+			 * see {@link #Foo(int)}
+			 */
+			def void bla(){}
+		}
+		''',resourceSet)
+		val clazz = xtendFile.getXtendTypes.filter(typeof(XtendClass)).head
+		val docu = documentationProvider.getDocumentation(clazz.members.filter(XtendFunction).head)
+		assertEquals('''see <code><a href="eclipse-xtext-doc:__synthetic0.xtend%23/1/@members.0">#Foo(int)</a></code>'''.toString, docu)
+	}
+	
+	@Test
     def bug380551(){
         val xtendFile = parseHelper.parse('''
         package testpackage

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/hover/XtendHoverDocumentationProviderTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/hover/XtendHoverDocumentationProviderTest.java
@@ -771,6 +771,206 @@ public class XtendHoverDocumentationProviderTest extends AbstractXtendUITestCase
   }
   
   @Test
+  public void testLinkToMethodHoverUnQualifiedOnType() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("package testpackage");
+      _builder.newLine();
+      _builder.append("/**");
+      _builder.newLine();
+      _builder.append(" ");
+      _builder.append("* see {@link #bar(int)}");
+      _builder.newLine();
+      _builder.append(" ");
+      _builder.append("*/");
+      _builder.newLine();
+      _builder.append("class Foo {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("def bar(int n){}");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      final XtendFile xtendFile = this.parseHelper.parse(_builder, this.getResourceSet());
+      final XtendClass clazz = IterableExtensions.<XtendClass>head(Iterables.<XtendClass>filter(xtendFile.getXtendTypes(), XtendClass.class));
+      final String docu = this.documentationProvider.getDocumentation(clazz);
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("see <code><a href=\"eclipse-xtext-doc:__synthetic0.xtend%23/1/@members.1\">#bar(int)</a></code>");
+      Assert.assertEquals(_builder_1.toString(), docu);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testLinkToMethodHoverQualifiedOnType() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("package testpackage");
+      _builder.newLine();
+      _builder.append("/**");
+      _builder.newLine();
+      _builder.append(" ");
+      _builder.append("* see {@link Foo#bar(int)}");
+      _builder.newLine();
+      _builder.append(" ");
+      _builder.append("*/");
+      _builder.newLine();
+      _builder.append("class Foo {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("def bar(int n) {}");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      final XtendFile xtendFile = this.parseHelper.parse(_builder, this.getResourceSet());
+      final XtendClass clazz = IterableExtensions.<XtendClass>head(Iterables.<XtendClass>filter(xtendFile.getXtendTypes(), XtendClass.class));
+      final String docu = this.documentationProvider.getDocumentation(clazz);
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("see <code><a href=\"eclipse-xtext-doc:__synthetic0.xtend%23/1/@members.1\">Foo#bar(int)</a></code>");
+      Assert.assertEquals(_builder_1.toString(), docu);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testLinkToConstructorHoverUnQualifiedOnType() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("package testpackage");
+      _builder.newLine();
+      _builder.append("/**");
+      _builder.newLine();
+      _builder.append(" ");
+      _builder.append("* see {@link #Foo(int)}");
+      _builder.newLine();
+      _builder.append(" ");
+      _builder.append("*/");
+      _builder.newLine();
+      _builder.append("class Foo {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("def new(int n){}");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      final XtendFile xtendFile = this.parseHelper.parse(_builder, this.getResourceSet());
+      final XtendClass clazz = IterableExtensions.<XtendClass>head(Iterables.<XtendClass>filter(xtendFile.getXtendTypes(), XtendClass.class));
+      final String docu = this.documentationProvider.getDocumentation(clazz);
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("see <code><a href=\"eclipse-xtext-doc:__synthetic0.xtend%23/1/@members.0\">#Foo(int)</a></code>");
+      Assert.assertEquals(_builder_1.toString(), docu);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testLinkToConstructorHoverQualifiedOnType() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("package testpackage");
+      _builder.newLine();
+      _builder.append("/**");
+      _builder.newLine();
+      _builder.append(" ");
+      _builder.append("* see {@link Foo#Foo(int)}");
+      _builder.newLine();
+      _builder.append(" ");
+      _builder.append("*/");
+      _builder.newLine();
+      _builder.append("class Foo {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("new(int n){}");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      final XtendFile xtendFile = this.parseHelper.parse(_builder, this.getResourceSet());
+      final XtendClass clazz = IterableExtensions.<XtendClass>head(Iterables.<XtendClass>filter(xtendFile.getXtendTypes(), XtendClass.class));
+      final String docu = this.documentationProvider.getDocumentation(clazz);
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("see <code><a href=\"eclipse-xtext-doc:__synthetic0.xtend%23/1/@members.0\">Foo#Foo(int)</a></code>");
+      Assert.assertEquals(_builder_1.toString(), docu);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testLinkToConstructorHoverUnQualifiedOnMethod() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("package testpackage");
+      _builder.newLine();
+      _builder.append("class Foo {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("new(int n){}");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("/**");
+      _builder.newLine();
+      _builder.append("\t ");
+      _builder.append("* see {@link #Foo(int)}");
+      _builder.newLine();
+      _builder.append("\t ");
+      _builder.append("*/");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("def void bla(){}");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      final XtendFile xtendFile = this.parseHelper.parse(_builder, this.getResourceSet());
+      final XtendClass clazz = IterableExtensions.<XtendClass>head(Iterables.<XtendClass>filter(xtendFile.getXtendTypes(), XtendClass.class));
+      final String docu = this.documentationProvider.getDocumentation(IterableExtensions.<XtendFunction>head(Iterables.<XtendFunction>filter(clazz.getMembers(), XtendFunction.class)));
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("see <code><a href=\"eclipse-xtext-doc:__synthetic0.xtend%23/1/@members.0\">#Foo(int)</a></code>");
+      Assert.assertEquals(_builder_1.toString(), docu);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void testLinkToConstructorHoverQualifiedOnMethod() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("package testpackage");
+      _builder.newLine();
+      _builder.append("class Foo {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("new(int n){}");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("/**");
+      _builder.newLine();
+      _builder.append("\t ");
+      _builder.append("* see {@link #Foo(int)}");
+      _builder.newLine();
+      _builder.append("\t ");
+      _builder.append("*/");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("def void bla(){}");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      final XtendFile xtendFile = this.parseHelper.parse(_builder, this.getResourceSet());
+      final XtendClass clazz = IterableExtensions.<XtendClass>head(Iterables.<XtendClass>filter(xtendFile.getXtendTypes(), XtendClass.class));
+      final String docu = this.documentationProvider.getDocumentation(IterableExtensions.<XtendFunction>head(Iterables.<XtendFunction>filter(clazz.getMembers(), XtendFunction.class)));
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("see <code><a href=\"eclipse-xtext-doc:__synthetic0.xtend%23/1/@members.0\">#Foo(int)</a></code>");
+      Assert.assertEquals(_builder_1.toString(), docu);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
   public void bug380551() {
     try {
       StringConcatenation _builder = new StringConcatenation();

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/hover/XtendHoverDocumentationProvider.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/hover/XtendHoverDocumentationProvider.java
@@ -42,13 +42,14 @@ public class XtendHoverDocumentationProvider extends XbaseHoverDocumentationProv
 
 	@Override
 	protected JvmDeclaredType getDeclaringType(EObject eObject) {
-		if (eObject instanceof XtendFunction) {
-			JvmOperation jvmOperation = associations.getDirectlyInferredOperation((XtendFunction) eObject);
-			if (jvmOperation != null) {
-				return super.getDeclaringType(jvmOperation);
-			}
+		if (eObject instanceof JvmDeclaredType) {
+			return (JvmDeclaredType) eObject;
 		}
-		return super.getDeclaringType(eObject);
+		EObject primaryJvmElement = associations.getPrimaryJvmElement(eObject);
+		if (primaryJvmElement != null) {
+			return super.getDeclaringType(primaryJvmElement);
+		}
+		return null;
 	}
 
 


### PR DESCRIPTION
[eclipse/xtext-eclipse#782] fixed javadoc links in javadoc of types. fixed javadoc links to constructors

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>