### PR TITLE
Refactoring the Xtend IDE rename refactoring test cases.

### DIFF
--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/refactoring/AbstractXtendRenameRefactoringTest.java
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/refactoring/AbstractXtendRenameRefactoringTest.java
@@ -1,0 +1,317 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.ide.tests.refactoring;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ICoreRunnable;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.internal.corext.refactoring.rename.JavaRenameProcessor;
+import org.eclipse.jdt.ui.refactoring.RenameSupport;
+import org.eclipse.jface.text.TextSelection;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.ltk.core.refactoring.participants.ProcessorBasedRefactoring;
+import org.eclipse.ltk.core.refactoring.participants.RefactoringProcessor;
+import org.eclipse.ltk.core.refactoring.participants.RenameRefactoring;
+import org.eclipse.ltk.internal.core.refactoring.resource.RenameResourceProcessor;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.actions.WorkspaceModifyOperation;
+import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase;
+import org.eclipse.xtend.ide.tests.WorkbenchTestHelper;
+import org.eclipse.xtext.common.types.ui.refactoring.participant.CompositeRefactoringProcessor;
+import org.eclipse.xtext.resource.EObjectAtOffsetHelper;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.ui.editor.XtextEditor;
+import org.eclipse.xtext.ui.refactoring.IRenameRefactoringProvider;
+import org.eclipse.xtext.ui.refactoring.impl.AbstractRenameProcessor;
+import org.eclipse.xtext.ui.refactoring.impl.RenameElementProcessor;
+import org.eclipse.xtext.ui.refactoring.ui.IRenameContextFactory;
+import org.eclipse.xtext.ui.refactoring.ui.IRenameElementContext;
+import org.eclipse.xtext.ui.refactoring.ui.SyncUtil;
+import org.eclipse.xtext.ui.resource.IResourceSetProvider;
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
+import org.eclipse.xtext.util.concurrent.IUnitOfWork;
+import org.eclipse.xtext.xbase.lib.Extension;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
+public class AbstractXtendRenameRefactoringTest extends AbstractXtendUITestCase {
+
+	@Inject
+	protected EObjectAtOffsetHelper eObjectAtOffsetHelper;
+
+	@Inject
+	protected IRenameRefactoringProvider renameRefactoringProvider;
+
+	@Inject
+	protected IRenameContextFactory renameContextFactory;
+
+	@Inject @Extension
+	protected WorkbenchTestHelper testHelper;
+
+	@Inject
+	protected IWorkbench workbench;
+
+	@Inject @Extension
+	protected FileAsserts fileAsserts;
+
+	@Inject 
+	protected SyncUtil syncUtil;
+
+	@Inject 
+	protected CompositeRefactoringProcessor.Access compositeRefactoringProcessorAccess;
+
+	@Inject
+	protected IWorkspace workspace;
+
+	@Inject
+	private IResourceSetProvider resourceSetProvider;
+
+	@Inject
+	private Provider<RenameElementProcessor> processorProvider;
+
+	@Override
+	public void tearDown() throws Exception {
+		testHelper.tearDown();
+		super.tearDown();
+	}
+
+	protected void assertDocumentContains(XtextEditor editor, String expectedContent) throws CoreException {
+		String editorContent = editor.getDocument().get();
+		if (!editorContent.contains(expectedContent)) {
+			assertEquals(expectedContent, editorContent);
+		}
+	}
+
+	protected void assertDocumentContainsIgnoreWhitespace(XtextEditor editor, String expectedContent) throws CoreException {
+		String editorContent = editor.getDocument().get();
+		assertTrue("'" + expectedContent + "' not found in \n" + editorContent, 
+				editorContent.replaceAll("\\s*", " ").contains(expectedContent.replaceAll("\\s*",  " ")));
+	}
+
+	protected XtextEditor openEditorSafely(String fileName, String contents) throws Exception {
+		return openEditorSafely(fileName, contents, new NullProgressMonitor());
+	}
+
+	protected XtextEditor openEditorSafely(String fileName, String contents, IProgressMonitor monitor) throws Exception {
+		IFile file = testHelper.createFile(fileName, contents);
+		return openEditorSafely(file, monitor);
+	}
+
+	protected XtextEditor openEditorSafely(IFile file) throws Exception {
+		return openEditorSafely(file, new NullProgressMonitor());
+	}
+
+	protected XtextEditor openEditorSafely(IFile file, IProgressMonitor monitor) throws Exception {
+		syncUtil.waitForBuild(monitor);
+		syncUtil.yieldToQueuedDisplayJobs(monitor);
+		XtextEditor editor = testHelper.openEditor(file);
+		syncUtil.waitForReconciler(editor);
+		syncUtil.yieldToQueuedDisplayJobs(monitor);
+		return editor;
+	}
+
+	protected void renameXtendElement(final XtextEditor editor, final int offset, String newName) throws Exception {
+		renameXtendElement(editor, offset, newName, RefactoringStatus.OK, new NullProgressMonitor());
+	}
+
+	protected void renameXtendElement(final XtextEditor editor, final int offset, String newName, IProgressMonitor monitor) throws Exception {
+		renameXtendElement(editor, offset, newName, RefactoringStatus.OK, monitor);
+	}
+
+	protected void renameXtendElement(final XtextEditor editor, final int offset, final String newName, final int allowedSeverity) throws Exception {
+		renameXtendElement(editor, offset, newName, allowedSeverity, new NullProgressMonitor());
+	}
+
+	protected void renameXtendElement(final XtextEditor editor, final int offset, final String newName, final int allowedSeverity, IProgressMonitor monitor) throws Exception {
+		syncUtil.totalSync(false);
+		new WorkspaceModifyOperation() {
+			@Override
+			protected void execute(IProgressMonitor monitor) throws CoreException, InvocationTargetException,
+					InterruptedException {
+				ProcessorBasedRefactoring renameRefactoring = createXtendRenameRefactoring(editor, offset, newName);
+				assertTrue("Refactoring not applicable", renameRefactoring.isApplicable());
+				RefactoringStatus status = renameRefactoring.checkAllConditions(monitor);
+				assertTrue(status.toString(), status.getSeverity() <= allowedSeverity);
+				Change change = renameRefactoring.createChange(monitor);
+				change.perform(monitor);
+			}
+		}.run(monitor);
+		syncUtil.totalSync(false);
+		assertTrue(compositeRefactoringProcessorAccess.isDisposed());
+	}
+
+	protected RefactoringStatus renameXtendElementWithError(final XtextEditor editor, final int offset, String newName) throws Exception {
+		return renameXtendElementWithError(editor, offset, newName, new NullProgressMonitor());
+	}
+
+	protected RefactoringStatus renameXtendElementWithError(final XtextEditor editor, final int offset, String newName, IProgressMonitor monitor) throws Exception {
+		syncUtil.totalSync(false);
+		ProcessorBasedRefactoring renameRefactoring = createXtendRenameRefactoring(editor, offset, newName);
+		RefactoringStatus status = renameRefactoring.checkAllConditions(monitor);
+		assertFalse("Expected an error", status.isOK());
+		return status;
+	}
+
+	protected ProcessorBasedRefactoring createXtendRenameRefactoring(final XtextEditor editor, final int offset,
+			String newName) {
+		IRenameElementContext renameElementContext = createRenameElementContext(editor, offset);
+		ProcessorBasedRefactoring renameRefactoring = renameRefactoringProvider
+				.getRenameRefactoring(renameElementContext);
+		RefactoringProcessor processor = renameRefactoring.getProcessor();
+		if (processor instanceof AbstractRenameProcessor)
+			((AbstractRenameProcessor) processor).setNewName(newName);
+		else if (processor instanceof JavaRenameProcessor)
+			((JavaRenameProcessor) processor).setNewElementName(newName);
+		return renameRefactoring;
+	}
+
+	protected IRenameElementContext createRenameElementContext(final XtextEditor editor, final int offset) {
+		IRenameElementContext renameElementContext = editor.getDocument().readOnly(
+				new IUnitOfWork<IRenameElementContext, XtextResource>() {
+					@Override
+					public IRenameElementContext exec(XtextResource state) throws Exception {
+						EObject element = eObjectAtOffsetHelper.resolveElementAt(state, offset);
+						return renameContextFactory.createRenameElementContext(element, editor, new TextSelection(
+								offset, 1), state);
+					}
+				});
+		return renameElementContext;
+	}
+
+	protected void renameJavaElement(IType javaElement, String newName) throws CoreException, InterruptedException,
+			InvocationTargetException {
+		syncUtil.totalSync(false);
+		RenameSupport renameSupport = RenameSupport.create(javaElement, newName, RenameSupport.UPDATE_REFERENCES);
+		renameSupport.perform(workbench.getActiveWorkbenchWindow().getShell(), workbench.getActiveWorkbenchWindow());
+		syncUtil.totalSync(false);
+		assertTrue(compositeRefactoringProcessorAccess.isDisposed());
+	}
+
+	protected void renameJavaElement(IMethod javaElement, String newName) throws CoreException, InterruptedException,
+			InvocationTargetException {
+		syncUtil.totalSync(false);
+		RenameSupport renameSupport = RenameSupport.create(javaElement, newName, RenameSupport.UPDATE_REFERENCES);
+		renameSupport.perform(workbench.getActiveWorkbenchWindow().getShell(), workbench.getActiveWorkbenchWindow());
+		syncUtil.totalSync(false);
+		assertTrue(compositeRefactoringProcessorAccess.isDisposed());
+	}
+
+	protected void renameJavaElement(IField javaElement, String newName) throws CoreException, InterruptedException,
+			InvocationTargetException {
+		syncUtil.totalSync(false);
+		RenameSupport renameSupport = RenameSupport.create(javaElement, newName, RenameSupport.UPDATE_REFERENCES);
+		renameSupport.perform(workbench.getActiveWorkbenchWindow().getShell(), workbench.getActiveWorkbenchWindow());
+		syncUtil.totalSync(false);
+		assertTrue(compositeRefactoringProcessorAccess.isDisposed());
+	}
+
+	protected IFile renameTo(IFile file, String newFileName) throws OperationCanceledException, CoreException {
+		return renameTo(file, newFileName, new NullProgressMonitor());
+	}
+
+	protected IFile renameTo(IFile file, String newFileName, IProgressMonitor monitor) throws OperationCanceledException, CoreException {
+		RenameResourceProcessor renameResourceProcessor = new RenameResourceProcessor(file);
+		renameResourceProcessor.setNewResourceName(newFileName);
+		RenameRefactoring renameRefactoring = new RenameRefactoring(renameResourceProcessor);
+		renameRefactoring.checkAllConditions(monitor);
+		Change change = renameRefactoring.createChange(monitor);
+		
+		workspace.run(new ICoreRunnable() {
+
+			@Override
+			public void run(IProgressMonitor monitor) throws CoreException {
+				change.perform(monitor);
+				
+			}
+		}, monitor);
+		
+		IResource newFile = testHelper.getProject().findMember(new Path("src/" + newFileName));
+		assertTrue(newFile.exists());
+		assertTrue(newFile instanceof IFile);
+		return (IFile) newFile;
+	}
+
+	protected void doRename(EObject targetElement, String newName) throws Exception {
+		doRename(targetElement, newName, new NullProgressMonitor());
+	}
+
+	protected void doRename(EObject targetElement, String newName, IProgressMonitor monitor) throws Exception {
+		URI targetElementURI = EcoreUtil.getURI(targetElement);
+		RenameElementProcessor processor = processorProvider.get();
+		processor
+				.initialize(new IRenameElementContext.Impl(targetElementURI, targetElement.eClass(), null, null, null));
+		processor.setNewName(newName);
+		RefactoringStatus initialStatus = processor.checkInitialConditions(monitor);
+		assertTrue(initialStatus.isOK());
+		RefactoringStatus finalStatus = processor.checkFinalConditions(monitor, null);
+		assertTrue(finalStatus.toString(), finalStatus.isOK());
+		final Change change = processor.createChange(monitor);
+		assertNotNull(change);
+		new WorkspaceModifyOperation() {
+			@Override
+			protected void execute(IProgressMonitor monitor) throws CoreException, InvocationTargetException,
+					InterruptedException {
+				change.perform(monitor);
+			}
+		}.run(monitor);
+	}
+
+	protected void performRenameTest(String fileName, String originalContents, String oldName, String newName)
+			throws Exception {
+		IFile file = testHelper.createFile(fileName, originalContents);
+		performRenameTest(file, originalContents, oldName, newName, file);
+	}
+
+	protected void performRenameTestWithReferringFile(String fileName, String newFileName, String originalContents, String referringFileName,
+			String referringFileContents, String oldName, String newName) throws Exception {
+		IFile file = testHelper.createFile(fileName, originalContents);
+		IFile newFile = testHelper.getFile(newFileName);
+		IFile referringFile = testHelper.createFile(referringFileName, referringFileContents);
+		performRenameTest(file, originalContents, oldName, newName, newFile);
+		String referringFileContentsAfterRename = WorkbenchTestHelper.getContentsAsString(referringFile);
+		assertEquals(referringFileContents.replace(oldName, newName), referringFileContentsAfterRename);
+	}
+
+	protected void performRenameTest(IFile file, String originalContents, String oldName, String newName, IFile newFile)
+			throws Exception {
+		IResourcesSetupUtil.waitForBuild();
+		ResourceSet resourceSet = resourceSetProvider.get(file.getProject());
+		XtextResource resource = (XtextResource) resourceSet.getResource(
+				testHelper.uri(file), true);
+		EObject target = eObjectAtOffsetHelper.resolveElementAt(resource, originalContents.indexOf(oldName));
+		doRename(target, newName);
+		String contentsAfterRename = WorkbenchTestHelper.getContentsAsString(newFile);
+		assertEquals(originalContents.replace(oldName, newName), contentsAfterRename);
+	}
+
+	protected IType findJavaType(String typeName) throws Exception {
+		syncUtil.totalSync(false);
+		IJavaProject javaProject = JavaCore.create(testHelper.getProject());
+		IType javaClass = javaProject.findType(typeName);
+		return javaClass;
+	}
+}

--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/refactoring/RefactoringIntegrationTest.java
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/refactoring/RefactoringIntegrationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,55 +7,13 @@
  *******************************************************************************/
 package org.eclipse.xtend.ide.tests.refactoring;
 
-import java.lang.reflect.InvocationTargetException;
-
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.ltk.core.refactoring.Change;
-import org.eclipse.ltk.core.refactoring.RefactoringStatus;
-import org.eclipse.ui.actions.WorkspaceModifyOperation;
-import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase;
-import org.eclipse.xtend.ide.tests.WorkbenchTestHelper;
-import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
-import org.eclipse.xtext.resource.EObjectAtOffsetHelper;
-import org.eclipse.xtext.resource.XtextResource;
-import org.eclipse.xtext.ui.refactoring.impl.RenameElementProcessor;
-import org.eclipse.xtext.ui.refactoring.ui.IRenameElementContext;
-import org.eclipse.xtext.ui.resource.IResourceSetProvider;
 import org.junit.Test;
-
-import com.google.inject.Inject;
-import com.google.inject.Provider;
 
 /**
  * @author Jan Koehnlein - Initial contribution and API
  */
 
-public class RefactoringIntegrationTest extends AbstractXtendUITestCase {
-
-	@Inject
-	private WorkbenchTestHelper testHelper;
-
-	@Inject
-	private Provider<RenameElementProcessor> processorProvider;
-
-	@Inject
-	private EObjectAtOffsetHelper eObjectAtOffsetHelper;
-
-	@Inject
-	private IResourceSetProvider resourceSetProvider;
-
-	@Override
-	public void tearDown() throws Exception {
-		testHelper.tearDown();
-		super.tearDown();
-	}
+public class RefactoringIntegrationTest extends AbstractXtendRenameRefactoringTest {
 
 	@Test public void testRenameVariable() throws Exception {
 		performRenameTest("Foo", "class Foo { def foo() { val bar = 7; bar + 1 }}", "bar", "baz");
@@ -95,54 +53,4 @@ public class RefactoringIntegrationTest extends AbstractXtendUITestCase {
 		performRenameTestWithReferringFile("Foo", "Bar", "class Foo { def Foo foo() {this} }", "Baz", "class Baz { def Foo foo() {new Foo()} }", "Foo",
 				"Bar");
 	}
-
-	protected void performRenameTest(String fileName, String originalContents, String oldName, String newName)
-			throws Exception {
-		IFile file = testHelper.createFile(fileName, originalContents);
-		performRenameTest(file, originalContents, oldName, newName, file);
-	}
-
-	protected void performRenameTestWithReferringFile(String fileName, String newFileName, String originalContents, String referringFileName,
-			String referringFileContents, String oldName, String newName) throws Exception {
-		IFile file = testHelper.createFile(fileName, originalContents);
-		IFile newFile = testHelper.getFile(newFileName);
-		IFile referringFile = testHelper.createFile(referringFileName, referringFileContents);
-		performRenameTest(file, originalContents, oldName, newName, newFile);
-		String refferingFileContentsAfterRename = WorkbenchTestHelper.getContentsAsString(referringFile);
-		assertEquals(referringFileContents.replace(oldName, newName), refferingFileContentsAfterRename);
-	}
-
-	protected void performRenameTest(IFile file, String originalContents, String oldName, String newName, IFile newFile)
-			throws Exception {
-		IResourcesSetupUtil.waitForBuild();
-		ResourceSet resourceSet = resourceSetProvider.get(file.getProject());
-		XtextResource resource = (XtextResource) resourceSet.getResource(
-				testHelper.uri(file), true);
-		EObject target = eObjectAtOffsetHelper.resolveElementAt(resource, originalContents.indexOf(oldName));
-		doRename(target, newName);
-		String contentsAfterRename = WorkbenchTestHelper.getContentsAsString(newFile);
-		assertEquals(originalContents.replace(oldName, newName), contentsAfterRename);
-	}
-
-	protected void doRename(EObject targetElement, String newName) throws Exception {
-		URI targetElementURI = EcoreUtil.getURI(targetElement);
-		RenameElementProcessor processor = processorProvider.get();
-		processor
-				.initialize(new IRenameElementContext.Impl(targetElementURI, targetElement.eClass(), null, null, null));
-		processor.setNewName(newName);
-		RefactoringStatus initialStatus = processor.checkInitialConditions(new NullProgressMonitor());
-		assertTrue(initialStatus.isOK());
-		RefactoringStatus finalStatus = processor.checkFinalConditions(new NullProgressMonitor(), null);
-		assertTrue(finalStatus.toString(), finalStatus.isOK());
-		final Change change = processor.createChange(new NullProgressMonitor());
-		assertNotNull(change);
-		new WorkspaceModifyOperation() {
-			@Override
-			protected void execute(IProgressMonitor monitor) throws CoreException, InvocationTargetException,
-					InterruptedException {
-				change.perform(monitor);
-			}
-		}.run(null);
-	}
-
 }

--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/refactoring/RenameJvmOperationTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/refactoring/RenameJvmOperationTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,44 +7,13 @@
  *******************************************************************************/
 package org.eclipse.xtend.ide.tests.refactoring
 
-import com.google.inject.Inject
-import org.eclipse.jdt.core.IField
-import org.eclipse.jdt.core.IMethod
-import org.eclipse.jdt.core.IType
-import org.eclipse.jdt.core.JavaCore
-import org.eclipse.jdt.ui.refactoring.RenameSupport
-import org.eclipse.ui.IWorkbench
-import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase
-import org.eclipse.xtend.ide.tests.WorkbenchTestHelper
-import org.eclipse.xtext.common.types.ui.refactoring.participant.CompositeRefactoringProcessor
-import org.eclipse.xtext.ui.refactoring.ui.SyncUtil
-import org.junit.Test
 import org.junit.Ignore
+import org.junit.Test
 
 /**
  * @author Anton Kosyakov - Initial contribution and API
  */
-class RenameJvmOperationTest extends AbstractXtendUITestCase {
-
-	@Inject
-	SyncUtil syncUtil
-
-	@Inject
-	IWorkbench workbench
-
-	@Inject
-	extension FileAsserts
-
-	@Inject
-	extension WorkbenchTestHelper testHelper
-
-	@Inject
-	CompositeRefactoringProcessor.Access compositeRefactoringProcessorAccess
-
-	override tearDown() throws Exception {
-		testHelper.tearDown
-		super.tearDown()
-	}
+class RenameJvmOperationTest extends AbstractXtendRenameRefactoringTest {
 
 	@Test def void renameUnusedMethod() {
 		renameUnusedMethod(false)
@@ -826,35 +795,4 @@ class RenameJvmOperationTest extends AbstractXtendUITestCase {
 			''')
 	}
 
-	def findJavaType(String typeName) throws Exception {
-		syncUtil.totalSync(false)
-		JavaCore.create(testHelper.project).findType(typeName)
-	}
-
-	def void renameJavaElement(IType javaElement, String newName) throws Exception {
-		syncUtil.totalSync(false)
-		val renameSupport = RenameSupport.create(javaElement, newName, RenameSupport.UPDATE_REFERENCES)
-		renameSupport.perform(workbench.activeWorkbenchWindow.shell, workbench.activeWorkbenchWindow)
-		syncUtil.totalSync(false)
-		assertTrue(compositeRefactoringProcessorAccess.disposed)
-	}
-
-	def void renameJavaElement(IMethod javaElement, String newName) throws Exception {
-		syncUtil.totalSync(false)
-		val renameSupport = RenameSupport.create(javaElement, newName, RenameSupport.UPDATE_REFERENCES)
-		renameSupport.perform(workbench.activeWorkbenchWindow.shell, workbench.activeWorkbenchWindow)
-		syncUtil.totalSync(false);
-		assertTrue(compositeRefactoringProcessorAccess.disposed)
-	}
-
-	def void renameJavaElement(IField javaElement, String newName) throws Exception {
-		syncUtil.totalSync(false)
-		val renameSupport = RenameSupport.create(javaElement, newName, RenameSupport.UPDATE_REFERENCES)
-		renameSupport.perform(workbench.activeWorkbenchWindow.shell, workbench.activeWorkbenchWindow)
-		syncUtil.totalSync(false);
-		assertTrue(compositeRefactoringProcessorAccess.disposed)
-	}
-
 }
-
-

--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/refactoring/RenameResourceTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/refactoring/RenameResourceTest.xtend
@@ -1,23 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
 package org.eclipse.xtend.ide.tests.refactoring
 
-import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase
 import org.junit.Test
-import org.eclipse.xtend.ide.tests.WorkbenchTestHelper
-import com.google.inject.Inject
-import org.eclipse.ltk.core.refactoring.participants.RenameRefactoring
-import org.eclipse.ltk.internal.core.refactoring.resource.RenameResourceProcessor
-import org.eclipse.core.runtime.NullProgressMonitor
-import org.eclipse.core.resources.IWorkspace
-import org.eclipse.core.resources.IFile
-import org.eclipse.core.runtime.Path
 
-class RenameResourceTest extends AbstractXtendUITestCase {
-	
-	@Inject extension WorkbenchTestHelper
-	
-	@Inject IWorkspace workspace
-	
-	@Inject extension FileAsserts
+class RenameResourceTest extends AbstractXtendRenameRefactoringTest {
 	
 	@Test 
 	def void testRenameClassWithSameName() {
@@ -50,20 +42,5 @@ class RenameResourceTest extends AbstractXtendUITestCase {
 		} finally {
 			getFile('Bar').delete(true, null)
 		}
-	}
-	
-	def protected renameTo(IFile file, String newFileName) {
-		val renameResourceProcessor = new RenameResourceProcessor(file)
-		renameResourceProcessor.setNewResourceName(newFileName)
-		val renameRefactoring = new RenameRefactoring(renameResourceProcessor)
-		renameRefactoring.checkAllConditions(new NullProgressMonitor)
-		val change = renameRefactoring.createChange(new NullProgressMonitor)
-		workspace.run([
-			change.perform(it)
-		], new NullProgressMonitor)
-		val newFile = project.findMember(new Path("src/" + newFileName))
-		assertTrue(newFile.exists)
-		assertTrue(newFile instanceof IFile)
-		newFile as IFile
 	}
 }

--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/refactoring/XImportSectionUpdateOnRenameTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/refactoring/XImportSectionUpdateOnRenameTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,45 +7,14 @@
  *******************************************************************************/
 package org.eclipse.xtend.ide.tests.refactoring
 
-import com.google.inject.Inject
 import org.eclipse.core.runtime.NullProgressMonitor
-import org.eclipse.jdt.core.IField
-import org.eclipse.jdt.core.IMethod
-import org.eclipse.jdt.core.IType
-import org.eclipse.jdt.core.JavaCore
-import org.eclipse.jdt.ui.refactoring.RenameSupport
-import org.eclipse.ui.IWorkbench
-import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase
-import org.eclipse.xtend.ide.tests.WorkbenchTestHelper
-import org.eclipse.xtext.common.types.ui.refactoring.participant.CompositeRefactoringProcessor
-import org.eclipse.xtext.ui.refactoring.ui.SyncUtil
 import org.junit.Ignore
 import org.junit.Test
 
 /**
  * @author Anton Kosyakov - Initial contribution and API
  */
-class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
-
-	@Inject
-	SyncUtil syncUtil
-
-	@Inject
-	IWorkbench workbench
-
-	@Inject
-	extension FileAsserts
-
-	@Inject
-	extension WorkbenchTestHelper testHelper
-
-	@Inject
-	CompositeRefactoringProcessor.Access compositeRefactoringProcessorAccess
-
-	override tearDown() throws Exception {
-		testHelper.tearDown
-		super.tearDown()
-	}
+class XImportSectionUpdateOnRenameTest extends AbstractXtendRenameRefactoringTest {
 
 	@Test def void renameUnusedType() {
 		try {
@@ -899,35 +868,6 @@ class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
 				
 				}
 			''')
-	}
-
-	def findJavaType(String typeName) throws Exception {
-		syncUtil.totalSync(false)
-		JavaCore.create(testHelper.project).findType(typeName)
-	}
-
-	def void renameJavaElement(IType javaElement, String newName) throws Exception {
-		syncUtil.totalSync(false)
-		val renameSupport = RenameSupport.create(javaElement, newName, RenameSupport.UPDATE_REFERENCES)
-		renameSupport.perform(workbench.activeWorkbenchWindow.shell, workbench.activeWorkbenchWindow)
-		syncUtil.totalSync(false)
-		assertTrue(compositeRefactoringProcessorAccess.disposed)
-	}
-
-	def void renameJavaElement(IMethod javaElement, String newName) throws Exception {
-		syncUtil.totalSync(false)
-		val renameSupport = RenameSupport.create(javaElement, newName, RenameSupport.UPDATE_REFERENCES)
-		renameSupport.perform(workbench.activeWorkbenchWindow.shell, workbench.activeWorkbenchWindow)
-		syncUtil.totalSync(false);
-		assertTrue(compositeRefactoringProcessorAccess.disposed)
-	}
-
-	def void renameJavaElement(IField javaElement, String newName) throws Exception {
-		syncUtil.totalSync(false)
-		val renameSupport = RenameSupport.create(javaElement, newName, RenameSupport.UPDATE_REFERENCES)
-		renameSupport.perform(workbench.activeWorkbenchWindow.shell, workbench.activeWorkbenchWindow)
-		syncUtil.totalSync(false);
-		assertTrue(compositeRefactoringProcessorAccess.disposed)
 	}
 
 }

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/refactoring/RenameJvmOperationTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/refactoring/RenameJvmOperationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,22 +7,10 @@
  */
 package org.eclipse.xtend.ide.tests.refactoring;
 
-import com.google.inject.Inject;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.jdt.core.IField;
-import org.eclipse.jdt.core.IMethod;
-import org.eclipse.jdt.core.IType;
-import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.ui.refactoring.RenameSupport;
-import org.eclipse.ui.IWorkbench;
-import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase;
-import org.eclipse.xtend.ide.tests.WorkbenchTestHelper;
-import org.eclipse.xtend.ide.tests.refactoring.FileAsserts;
+import org.eclipse.xtend.ide.tests.refactoring.AbstractXtendRenameRefactoringTest;
 import org.eclipse.xtend2.lib.StringConcatenation;
-import org.eclipse.xtext.common.types.ui.refactoring.participant.CompositeRefactoringProcessor;
-import org.eclipse.xtext.ui.refactoring.ui.SyncUtil;
 import org.eclipse.xtext.xbase.lib.Exceptions;
-import org.eclipse.xtext.xbase.lib.Extension;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -31,30 +19,7 @@ import org.junit.Test;
  * @author Anton Kosyakov - Initial contribution and API
  */
 @SuppressWarnings("all")
-public class RenameJvmOperationTest extends AbstractXtendUITestCase {
-  @Inject
-  private SyncUtil syncUtil;
-  
-  @Inject
-  private IWorkbench workbench;
-  
-  @Inject
-  @Extension
-  private FileAsserts _fileAsserts;
-  
-  @Inject
-  @Extension
-  private WorkbenchTestHelper testHelper;
-  
-  @Inject
-  private CompositeRefactoringProcessor.Access compositeRefactoringProcessorAccess;
-  
-  @Override
-  public void tearDown() throws Exception {
-    this.testHelper.tearDown();
-    super.tearDown();
-  }
-  
+public class RenameJvmOperationTest extends AbstractXtendRenameRefactoringTest {
   @Test
   public void renameUnusedMethod() {
     this.renameUnusedMethod(false);
@@ -113,7 +78,7 @@ public class RenameJvmOperationTest extends AbstractXtendUITestCase {
       _builder_2.newLine();
       _builder_2.append("class Bar {}");
       _builder_2.newLine();
-      this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+      this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -250,7 +215,7 @@ public class RenameJvmOperationTest extends AbstractXtendUITestCase {
       _builder_2.newLine();
       _builder_2.append("}");
       _builder_2.newLine();
-      this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+      this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -438,7 +403,7 @@ public class RenameJvmOperationTest extends AbstractXtendUITestCase {
       _builder_2.newLine();
       _builder_2.append("}");
       _builder_2.newLine();
-      this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+      this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -631,7 +596,7 @@ public class RenameJvmOperationTest extends AbstractXtendUITestCase {
       _builder_2.newLine();
       _builder_2.append("}");
       _builder_2.newLine();
-      this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+      this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -849,7 +814,7 @@ public class RenameJvmOperationTest extends AbstractXtendUITestCase {
       _builder_3.newLine();
       _builder_3.append("}");
       _builder_3.newLine();
-      this._fileAsserts.assertFileContains(xtendFile, _builder_3.toString());
+      this.fileAsserts.assertFileContains(xtendFile, _builder_3.toString());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -965,7 +930,7 @@ public class RenameJvmOperationTest extends AbstractXtendUITestCase {
       _builder_4.newLine();
       _builder_4.append("}");
       _builder_4.newLine();
-      this._fileAsserts.assertFileContains(xtendFile, _builder_4.toString());
+      this.fileAsserts.assertFileContains(xtendFile, _builder_4.toString());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -1074,7 +1039,7 @@ public class RenameJvmOperationTest extends AbstractXtendUITestCase {
       _builder_3.newLine();
       _builder_3.append("}");
       _builder_3.newLine();
-      this._fileAsserts.assertFileContains(xtendFile, _builder_3.toString());
+      this.fileAsserts.assertFileContains(xtendFile, _builder_3.toString());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -1201,7 +1166,7 @@ public class RenameJvmOperationTest extends AbstractXtendUITestCase {
       _builder_4.newLine();
       _builder_4.append("}");
       _builder_4.newLine();
-      this._fileAsserts.assertFileContains(xtendFile, _builder_4.toString());
+      this.fileAsserts.assertFileContains(xtendFile, _builder_4.toString());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -1321,7 +1286,7 @@ public class RenameJvmOperationTest extends AbstractXtendUITestCase {
       _builder_3.newLine();
       _builder_3.append("}");
       _builder_3.newLine();
-      this._fileAsserts.assertFileContains(xtendFile, _builder_3.toString());
+      this.fileAsserts.assertFileContains(xtendFile, _builder_3.toString());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -1439,42 +1404,9 @@ public class RenameJvmOperationTest extends AbstractXtendUITestCase {
       _builder_3.newLine();
       _builder_3.append("}");
       _builder_3.newLine();
-      this._fileAsserts.assertFileContains(xtendFile, _builder_3.toString());
+      this.fileAsserts.assertFileContains(xtendFile, _builder_3.toString());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
-  }
-  
-  public IType findJavaType(final String typeName) throws Exception {
-    IType _xblockexpression = null;
-    {
-      this.syncUtil.totalSync(false);
-      _xblockexpression = JavaCore.create(this.testHelper.getProject()).findType(typeName);
-    }
-    return _xblockexpression;
-  }
-  
-  public void renameJavaElement(final IType javaElement, final String newName) throws Exception {
-    this.syncUtil.totalSync(false);
-    final RenameSupport renameSupport = RenameSupport.create(javaElement, newName, RenameSupport.UPDATE_REFERENCES);
-    renameSupport.perform(this.workbench.getActiveWorkbenchWindow().getShell(), this.workbench.getActiveWorkbenchWindow());
-    this.syncUtil.totalSync(false);
-    Assert.assertTrue(this.compositeRefactoringProcessorAccess.isDisposed());
-  }
-  
-  public void renameJavaElement(final IMethod javaElement, final String newName) throws Exception {
-    this.syncUtil.totalSync(false);
-    final RenameSupport renameSupport = RenameSupport.create(javaElement, newName, RenameSupport.UPDATE_REFERENCES);
-    renameSupport.perform(this.workbench.getActiveWorkbenchWindow().getShell(), this.workbench.getActiveWorkbenchWindow());
-    this.syncUtil.totalSync(false);
-    Assert.assertTrue(this.compositeRefactoringProcessorAccess.isDisposed());
-  }
-  
-  public void renameJavaElement(final IField javaElement, final String newName) throws Exception {
-    this.syncUtil.totalSync(false);
-    final RenameSupport renameSupport = RenameSupport.create(javaElement, newName, RenameSupport.UPDATE_REFERENCES);
-    renameSupport.perform(this.workbench.getActiveWorkbenchWindow().getShell(), this.workbench.getActiveWorkbenchWindow());
-    this.syncUtil.totalSync(false);
-    Assert.assertTrue(this.compositeRefactoringProcessorAccess.isDisposed());
   }
 }

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/refactoring/RenameResourceTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/refactoring/RenameResourceTest.java
@@ -1,45 +1,25 @@
+/**
+ * Copyright (c) 2012, 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.xtend.ide.tests.refactoring;
 
-import com.google.inject.Inject;
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.IWorkspace;
-import org.eclipse.core.resources.IWorkspaceRunnable;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
-import org.eclipse.ltk.core.refactoring.Change;
-import org.eclipse.ltk.core.refactoring.participants.RenameRefactoring;
-import org.eclipse.ltk.internal.core.refactoring.resource.RenameResourceProcessor;
-import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase;
-import org.eclipse.xtend.ide.tests.WorkbenchTestHelper;
-import org.eclipse.xtend.ide.tests.refactoring.FileAsserts;
+import org.eclipse.xtend.ide.tests.refactoring.AbstractXtendRenameRefactoringTest;
 import org.eclipse.xtext.xbase.lib.Exceptions;
-import org.eclipse.xtext.xbase.lib.Extension;
-import org.junit.Assert;
 import org.junit.Test;
 
 @SuppressWarnings("all")
-public class RenameResourceTest extends AbstractXtendUITestCase {
-  @Inject
-  @Extension
-  private WorkbenchTestHelper _workbenchTestHelper;
-  
-  @Inject
-  private IWorkspace workspace;
-  
-  @Inject
-  @Extension
-  private FileAsserts _fileAsserts;
-  
+public class RenameResourceTest extends AbstractXtendRenameRefactoringTest {
   @Test
   public void testRenameClassWithSameName() {
     try {
       try {
-        this._fileAsserts.assertFileContains(this.renameTo(this._workbenchTestHelper.createFile("Foo", "class Foo {}"), "Bar.xtend"), "class Bar {}");
+        this.fileAsserts.assertFileContains(this.renameTo(this.testHelper.createFile("Foo", "class Foo {}"), "Bar.xtend"), "class Bar {}");
       } finally {
-        this._workbenchTestHelper.getFile("Bar.xtend").delete(true, null);
+        this.testHelper.getFile("Bar.xtend").delete(true, null);
       }
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
@@ -50,9 +30,9 @@ public class RenameResourceTest extends AbstractXtendUITestCase {
   public void testDontRenameClassWithDifferenName() {
     try {
       try {
-        this._fileAsserts.assertFileContains(this.renameTo(this._workbenchTestHelper.createFile("Foo", "class FooBar {}"), "Bar.xtend"), "class FooBar {}");
+        this.fileAsserts.assertFileContains(this.renameTo(this.testHelper.createFile("Foo", "class FooBar {}"), "Bar.xtend"), "class FooBar {}");
       } finally {
-        this._workbenchTestHelper.getFile("Bar.xtend").delete(true, null);
+        this.testHelper.getFile("Bar.xtend").delete(true, null);
       }
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
@@ -63,39 +43,10 @@ public class RenameResourceTest extends AbstractXtendUITestCase {
   public void testGuardMissingFileExtension() {
     try {
       try {
-        this._fileAsserts.assertFileContains(this.renameTo(this._workbenchTestHelper.createFile("Foo", "class Foo {}"), "Bar"), "class Foo {}");
+        this.fileAsserts.assertFileContains(this.renameTo(this.testHelper.createFile("Foo", "class Foo {}"), "Bar"), "class Foo {}");
       } finally {
-        this._workbenchTestHelper.getFile("Bar").delete(true, null);
+        this.testHelper.getFile("Bar").delete(true, null);
       }
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
-    }
-  }
-  
-  protected IFile renameTo(final IFile file, final String newFileName) {
-    try {
-      IFile _xblockexpression = null;
-      {
-        final RenameResourceProcessor renameResourceProcessor = new RenameResourceProcessor(file);
-        renameResourceProcessor.setNewResourceName(newFileName);
-        final RenameRefactoring renameRefactoring = new RenameRefactoring(renameResourceProcessor);
-        NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
-        renameRefactoring.checkAllConditions(_nullProgressMonitor);
-        NullProgressMonitor _nullProgressMonitor_1 = new NullProgressMonitor();
-        final Change change = renameRefactoring.createChange(_nullProgressMonitor_1);
-        final IWorkspaceRunnable _function = (IProgressMonitor it) -> {
-          change.perform(it);
-        };
-        NullProgressMonitor _nullProgressMonitor_2 = new NullProgressMonitor();
-        this.workspace.run(_function, _nullProgressMonitor_2);
-        IProject _project = this._workbenchTestHelper.getProject();
-        Path _path = new Path(("src/" + newFileName));
-        final IResource newFile = _project.findMember(_path);
-        Assert.assertTrue(newFile.exists());
-        Assert.assertTrue((newFile instanceof IFile));
-        _xblockexpression = ((IFile) newFile);
-      }
-      return _xblockexpression;
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/refactoring/XImportSectionUpdateOnRenameTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/refactoring/XImportSectionUpdateOnRenameTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,24 +7,11 @@
  */
 package org.eclipse.xtend.ide.tests.refactoring;
 
-import com.google.inject.Inject;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.jdt.core.IField;
-import org.eclipse.jdt.core.IMethod;
-import org.eclipse.jdt.core.IType;
-import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.ui.refactoring.RenameSupport;
-import org.eclipse.ui.IWorkbench;
-import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase;
-import org.eclipse.xtend.ide.tests.WorkbenchTestHelper;
-import org.eclipse.xtend.ide.tests.refactoring.FileAsserts;
+import org.eclipse.xtend.ide.tests.refactoring.AbstractXtendRenameRefactoringTest;
 import org.eclipse.xtend2.lib.StringConcatenation;
-import org.eclipse.xtext.common.types.ui.refactoring.participant.CompositeRefactoringProcessor;
-import org.eclipse.xtext.ui.refactoring.ui.SyncUtil;
 import org.eclipse.xtext.xbase.lib.Exceptions;
-import org.eclipse.xtext.xbase.lib.Extension;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -32,30 +19,7 @@ import org.junit.Test;
  * @author Anton Kosyakov - Initial contribution and API
  */
 @SuppressWarnings("all")
-public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
-  @Inject
-  private SyncUtil syncUtil;
-  
-  @Inject
-  private IWorkbench workbench;
-  
-  @Inject
-  @Extension
-  private FileAsserts _fileAsserts;
-  
-  @Inject
-  @Extension
-  private WorkbenchTestHelper testHelper;
-  
-  @Inject
-  private CompositeRefactoringProcessor.Access compositeRefactoringProcessorAccess;
-  
-  @Override
-  public void tearDown() throws Exception {
-    this.testHelper.tearDown();
-    super.tearDown();
-  }
-  
+public class XImportSectionUpdateOnRenameTest extends AbstractXtendRenameRefactoringTest {
   @Test
   public void renameUnusedType() {
     try {
@@ -87,7 +51,7 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
         _builder_2.newLine();
         _builder_2.append("class Bar {}");
         _builder_2.newLine();
-        this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+        this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
       } finally {
         IFile _file = this.testHelper.getProject().getFile("src/foo/NewFoo.java");
         NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
@@ -130,7 +94,7 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
         _builder_2.newLine();
         _builder_2.append("class Bar {}");
         _builder_2.newLine();
-        this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+        this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
       } finally {
         IFile _file = this.testHelper.getProject().getFile("src/foo/NewFoo.java");
         NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
@@ -179,7 +143,7 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
         _builder_2.newLine();
         _builder_2.append("class Bar {}");
         _builder_2.newLine();
-        this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+        this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
       } finally {
         IFile _file = this.testHelper.getProject().getFile("src/foo/NewFoo.java");
         NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
@@ -228,7 +192,7 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
         _builder_2.newLine();
         _builder_2.append("class Bar {}");
         _builder_2.newLine();
-        this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+        this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
       } finally {
         IFile _file = this.testHelper.getProject().getFile("src/foo/NewFoo.java");
         NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
@@ -277,7 +241,7 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
         _builder_2.newLine();
         _builder_2.append("class Bar {}");
         _builder_2.newLine();
-        this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+        this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
       } finally {
         IFile _file = this.testHelper.getProject().getFile("src/foo/NewFoo.java");
         NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
@@ -326,7 +290,7 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
         _builder_2.newLine();
         _builder_2.append("class Bar {}");
         _builder_2.newLine();
-        this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+        this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
       } finally {
         IFile _file = this.testHelper.getProject().getFile("src/foo/NewFoo.java");
         NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
@@ -374,7 +338,7 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
       _builder_2.newLine();
       _builder_2.append("class Bar {}");
       _builder_2.newLine();
-      this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+      this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -417,7 +381,7 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
       _builder_2.newLine();
       _builder_2.append("class Bar {}");
       _builder_2.newLine();
-      this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+      this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -454,7 +418,7 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
         _builder_2.newLine();
         _builder_2.append("class Bar extends NewFoo {}");
         _builder_2.newLine();
-        this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+        this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
       } finally {
         IFile _file = this.testHelper.getProject().getFile("src/foo/NewFoo.java");
         NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
@@ -504,7 +468,7 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
         _builder_2.newLine();
         _builder_2.append("class Bar extends Inner {}");
         _builder_2.newLine();
-        this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+        this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
       } finally {
         IFile _file = this.testHelper.getProject().getFile("src/foo/NewFoo.java");
         NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
@@ -579,7 +543,7 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
         _builder_2.newLine();
         _builder_2.append("}");
         _builder_2.newLine();
-        this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+        this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
       } finally {
         IFile _file = this.testHelper.getProject().getFile("src/foo/NewFoo.java");
         NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
@@ -654,7 +618,7 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
         _builder_2.newLine();
         _builder_2.append("}");
         _builder_2.newLine();
-        this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+        this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
       } finally {
         IFile _file = this.testHelper.getProject().getFile("src/foo/NewFoo.java");
         NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
@@ -729,7 +693,7 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
         _builder_2.newLine();
         _builder_2.append("}");
         _builder_2.newLine();
-        this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+        this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
       } finally {
         IFile _file = this.testHelper.getProject().getFile("src/foo/NewFoo.java");
         NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
@@ -804,7 +768,7 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
         _builder_2.newLine();
         _builder_2.append("}");
         _builder_2.newLine();
-        this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+        this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
       } finally {
         IFile _file = this.testHelper.getProject().getFile("src/foo/NewFoo.java");
         NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
@@ -882,7 +846,7 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
         _builder_3.newLine();
         _builder_3.append("}");
         _builder_3.newLine();
-        this._fileAsserts.assertFileContains(xtendFile, _builder_3.toString());
+        this.fileAsserts.assertFileContains(xtendFile, _builder_3.toString());
       } finally {
         IFile _file = this.testHelper.getProject().getFile("src/a/B.java");
         NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
@@ -960,7 +924,7 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
         _builder_3.newLine();
         _builder_3.append("}");
         _builder_3.newLine();
-        this._fileAsserts.assertFileContains(xtendFile, _builder_3.toString());
+        this.fileAsserts.assertFileContains(xtendFile, _builder_3.toString());
       } finally {
         IFile _file = this.testHelper.getProject().getFile("src/a/B.java");
         NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
@@ -1038,7 +1002,7 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
         _builder_3.newLine();
         _builder_3.append("}");
         _builder_3.newLine();
-        this._fileAsserts.assertFileContains(xtendFile, _builder_3.toString());
+        this.fileAsserts.assertFileContains(xtendFile, _builder_3.toString());
       } finally {
         IFile _file = this.testHelper.getProject().getFile("src/a/B.java");
         NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
@@ -1116,7 +1080,7 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
         _builder_3.newLine();
         _builder_3.append("}");
         _builder_3.newLine();
-        this._fileAsserts.assertFileContains(xtendFile, _builder_3.toString());
+        this.fileAsserts.assertFileContains(xtendFile, _builder_3.toString());
       } finally {
         IFile _file = this.testHelper.getProject().getFile("src/a/B.java");
         NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
@@ -1190,7 +1154,7 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
       _builder_2.newLine();
       _builder_2.append("}");
       _builder_2.newLine();
-      this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+      this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
@@ -1259,42 +1223,9 @@ public class XImportSectionUpdateOnRenameTest extends AbstractXtendUITestCase {
       _builder_2.newLine();
       _builder_2.append("}");
       _builder_2.newLine();
-      this._fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
+      this.fileAsserts.assertFileContains(xtendFile, _builder_2.toString());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
-  }
-  
-  public IType findJavaType(final String typeName) throws Exception {
-    IType _xblockexpression = null;
-    {
-      this.syncUtil.totalSync(false);
-      _xblockexpression = JavaCore.create(this.testHelper.getProject()).findType(typeName);
-    }
-    return _xblockexpression;
-  }
-  
-  public void renameJavaElement(final IType javaElement, final String newName) throws Exception {
-    this.syncUtil.totalSync(false);
-    final RenameSupport renameSupport = RenameSupport.create(javaElement, newName, RenameSupport.UPDATE_REFERENCES);
-    renameSupport.perform(this.workbench.getActiveWorkbenchWindow().getShell(), this.workbench.getActiveWorkbenchWindow());
-    this.syncUtil.totalSync(false);
-    Assert.assertTrue(this.compositeRefactoringProcessorAccess.isDisposed());
-  }
-  
-  public void renameJavaElement(final IMethod javaElement, final String newName) throws Exception {
-    this.syncUtil.totalSync(false);
-    final RenameSupport renameSupport = RenameSupport.create(javaElement, newName, RenameSupport.UPDATE_REFERENCES);
-    renameSupport.perform(this.workbench.getActiveWorkbenchWindow().getShell(), this.workbench.getActiveWorkbenchWindow());
-    this.syncUtil.totalSync(false);
-    Assert.assertTrue(this.compositeRefactoringProcessorAccess.isDisposed());
-  }
-  
-  public void renameJavaElement(final IField javaElement, final String newName) throws Exception {
-    this.syncUtil.totalSync(false);
-    final RenameSupport renameSupport = RenameSupport.create(javaElement, newName, RenameSupport.UPDATE_REFERENCES);
-    renameSupport.perform(this.workbench.getActiveWorkbenchWindow().getShell(), this.workbench.getActiveWorkbenchWindow());
-    this.syncUtil.totalSync(false);
-    Assert.assertTrue(this.compositeRefactoringProcessorAccess.isDisposed());
   }
 }


### PR DESCRIPTION
- Eliminate duplicated code by introducing the
AbstractXtendRenameRefactoringTest abstract base class.
- Add missing/Update exsiting copyright headers.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>