### PR TITLE
Fixed two issues with Xtend File Hyperlinks in Consoles

### DIFF
--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/hyperlinking/ConsoleHyperlinking.xtend
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/hyperlinking/ConsoleHyperlinking.xtend
@@ -26,7 +26,7 @@ class ConsoleHyperlinking implements IPatternMatchListenerDelegate {
             val length = event.getLength();
             val link = new XtendFileHyperlink(console.document.get(offset, length), workbench, console);
             console.addHyperlink(link, offset, length);   
-        } catch (BadLocationException e) {
+        } catch (BadLocationException | NumberFormatException e) {
         }
     }
 
@@ -62,7 +62,7 @@ class XtendFileHyperlink implements IHyperlink {
 	
 	override linkActivated() {
 		try {
-			switch l : launch.sourceLocator {
+			switch l : launch?.sourceLocator {
 				AbstractSourceLookupDirector : {
 					val result = l.getSourceElement(fileName)
 					switch result {	IFile : {

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/hyperlinking/ConsoleHyperlinking.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/hyperlinking/ConsoleHyperlinking.java
@@ -25,7 +25,7 @@ public class ConsoleHyperlinking implements IPatternMatchListenerDelegate {
       final XtendFileHyperlink link = new XtendFileHyperlink(_get, this.workbench, this.console);
       this.console.addHyperlink(link, offset, length);
     } catch (final Throwable _t) {
-      if (_t instanceof BadLocationException) {
+      if (_t instanceof BadLocationException || _t instanceof NumberFormatException) {
       } else {
         throw Exceptions.sneakyThrow(_t);
       }

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/hyperlinking/XtendFileHyperlink.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/hyperlinking/XtendFileHyperlink.java
@@ -41,7 +41,11 @@ public class XtendFileHyperlink implements IHyperlink {
   public void linkActivated() {
     try {
       try {
-        ISourceLocator _sourceLocator = this.getLaunch().getSourceLocator();
+        ILaunch _launch = this.getLaunch();
+        ISourceLocator _sourceLocator = null;
+        if (_launch!=null) {
+          _sourceLocator=_launch.getSourceLocator();
+        }
         final ISourceLocator l = _sourceLocator;
         boolean _matched = false;
         if (l instanceof AbstractSourceLookupDirector) {


### PR DESCRIPTION
- [538503] catch NumberFormatExceptions that can be caused by changed console content
- Fixed problem with non launch based stacktraces

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>