### PR TITLE
[#561] Fix Xtend quickfixes on missing '<<','<<<','>>','>>>' operators.

### DIFF
--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
@@ -1470,6 +1470,204 @@ class QuickfixTest extends AbstractXtendUITestCase {
 		''')
 	}
 	
+	@Test def void missingLessThanMethod() {
+		create('Foo.xtend', '''
+			class Foo {
+				
+				Object REPORT
+				
+				def a() {
+					REPORT <| 'TEST'
+				}
+				
+			}
+		''')
+		.assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC)
+		.assertResolutionLabels(
+			"Change to '+'",
+			"Create extension method 'operator_lessThan(Object, String)'")
+		.assertModelAfterQuickfix("Create extension method 'operator_lessThan(Object, String)'", '''
+			class Foo {
+				
+				Object REPORT
+				
+				def a() {
+					REPORT < 'TEST'
+				}
+				
+				def operator_lessThan(Object object, String string) {
+					«defaultBody»
+				}
+				
+			}
+		''')
+	}
+	
+	@Test def void missingGreaterThanMethod() {
+		create('Foo.xtend', '''
+			class Foo {
+				
+				Object REPORT
+				
+				def a() {
+					REPORT >| 'TEST'
+				}
+				
+			}
+		''')
+		.assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC)
+		.assertResolutionLabels(
+			"Change to '+'",
+			"Change to '->'",
+			"Change to '=>'",
+			"Create extension method 'operator_greaterThan(Object, String)'")
+		.assertModelAfterQuickfix("Create extension method 'operator_greaterThan(Object, String)'", '''
+			class Foo {
+				
+				Object REPORT
+				
+				def a() {
+					REPORT > 'TEST'
+				}
+				
+				def operator_greaterThan(Object object, String string) {
+					«defaultBody»
+				}
+				
+			}
+		''')
+	}
+	
+	@Test def void missingDoubleLessThanMethod() {
+		create('Foo.xtend', '''
+			class Foo {
+				
+				Object REPORT
+				
+				def a() {
+					REPORT <<| 'TEST'
+				}
+				
+			}
+		''')
+		.assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC)
+		.assertResolutionLabels(
+			"Create extension method 'operator_doubleLessThan(Object, String)'")
+		.assertModelAfterQuickfix('''
+			class Foo {
+				
+				Object REPORT
+				
+				def a() {
+					REPORT << 'TEST'
+				}
+				
+				def operator_doubleLessThan(Object object, String string) {
+					«defaultBody»
+				}
+				
+			}
+		''')
+	}
+	
+	@Test def void missingDoubleGreaterThanMethod() {
+		create('Foo.xtend', '''
+			class Foo {
+				
+				Object REPORT
+				
+				def a() {
+					REPORT >>| 'TEST'
+				}
+				
+			}
+		''')
+		.assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC)
+		.assertResolutionLabels(
+			"Change to '->'",
+			"Change to '=>'",
+			"Create extension method 'operator_doubleGreaterThan(Object, String)'")
+		.assertModelAfterQuickfix("Create extension method 'operator_doubleGreaterThan(Object, String)'", '''
+			class Foo {
+				
+				Object REPORT
+				
+				def a() {
+					REPORT >> 'TEST'
+				}
+				
+				def operator_doubleGreaterThan(Object object, String string) {
+					«defaultBody»
+				}
+				
+			}
+		''')
+	}
+	
+	@Test def void missingTripleLessThanMethod() {
+		create('Foo.xtend', '''
+			class Foo {
+				
+				Object REPORT
+				
+				def a() {
+					REPORT <<<| 'TEST'
+				}
+				
+			}
+		''')
+		.assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC)
+		.assertResolutionLabels(
+			"Create extension method 'operator_tripleLessThan(Object, String)'")
+		.assertModelAfterQuickfix('''
+			class Foo {
+				
+				Object REPORT
+				
+				def a() {
+					REPORT <<< 'TEST'
+				}
+				
+				def operator_tripleLessThan(Object object, String string) {
+					«defaultBody»
+				}
+				
+			}
+		''')
+	}
+	
+	@Test def void missingTripleGreaterThanMethod() {
+		create('Foo.xtend', '''
+			class Foo {
+				
+				Object REPORT
+				
+				def a() {
+					REPORT >>>| 'TEST'
+				}
+				
+			}
+		''')
+		.assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC)
+		.assertResolutionLabels(
+			"Create extension method 'operator_tripleGreaterThan(Object, String)'")
+		.assertModelAfterQuickfix('''
+			class Foo {
+				
+				Object REPORT
+				
+				def a() {
+					REPORT >>> 'TEST'
+				}
+				
+				def operator_tripleGreaterThan(Object object, String string) {
+					«defaultBody»
+				}
+				
+			}
+		''')
+	}
+	
 	@Test
 	def void inconsistentIndentation() {
 		val tripleQuotes = "'''"

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
@@ -2712,6 +2712,396 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   }
   
   @Test
+  public void missingLessThanMethod() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("Object REPORT");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def a() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("REPORT <| \'TEST\'");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC).assertResolutionLabels(
+      "Change to \'+\'", 
+      "Create extension method \'operator_lessThan(Object, String)\'");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("Object REPORT");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def a() {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("REPORT < \'TEST\'");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def operator_lessThan(Object object, String string) {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append(QuickfixTest.defaultBody, "\t\t");
+    _builder_1.newLineIfNotEmpty();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix("Create extension method \'operator_lessThan(Object, String)\'", _builder_1);
+  }
+  
+  @Test
+  public void missingGreaterThanMethod() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("Object REPORT");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def a() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("REPORT >| \'TEST\'");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC).assertResolutionLabels(
+      "Change to \'+\'", 
+      "Change to \'->\'", 
+      "Change to \'=>\'", 
+      "Create extension method \'operator_greaterThan(Object, String)\'");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("Object REPORT");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def a() {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("REPORT > \'TEST\'");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def operator_greaterThan(Object object, String string) {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append(QuickfixTest.defaultBody, "\t\t");
+    _builder_1.newLineIfNotEmpty();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix("Create extension method \'operator_greaterThan(Object, String)\'", _builder_1);
+  }
+  
+  @Test
+  public void missingDoubleLessThanMethod() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("Object REPORT");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def a() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("REPORT <<| \'TEST\'");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC).assertResolutionLabels(
+      "Create extension method \'operator_doubleLessThan(Object, String)\'");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("Object REPORT");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def a() {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("REPORT << \'TEST\'");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def operator_doubleLessThan(Object object, String string) {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append(QuickfixTest.defaultBody, "\t\t");
+    _builder_1.newLineIfNotEmpty();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void missingDoubleGreaterThanMethod() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("Object REPORT");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def a() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("REPORT >>| \'TEST\'");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC).assertResolutionLabels(
+      "Change to \'->\'", 
+      "Change to \'=>\'", 
+      "Create extension method \'operator_doubleGreaterThan(Object, String)\'");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("Object REPORT");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def a() {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("REPORT >> \'TEST\'");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def operator_doubleGreaterThan(Object object, String string) {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append(QuickfixTest.defaultBody, "\t\t");
+    _builder_1.newLineIfNotEmpty();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix("Create extension method \'operator_doubleGreaterThan(Object, String)\'", _builder_1);
+  }
+  
+  @Test
+  public void missingTripleLessThanMethod() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("Object REPORT");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def a() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("REPORT <<<| \'TEST\'");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC).assertResolutionLabels(
+      "Create extension method \'operator_tripleLessThan(Object, String)\'");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("Object REPORT");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def a() {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("REPORT <<< \'TEST\'");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def operator_tripleLessThan(Object object, String string) {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append(QuickfixTest.defaultBody, "\t\t");
+    _builder_1.newLineIfNotEmpty();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void missingTripleGreaterThanMethod() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("Object REPORT");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def a() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("REPORT >>>| \'TEST\'");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC).assertResolutionLabels(
+      "Create extension method \'operator_tripleGreaterThan(Object, String)\'");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("Object REPORT");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def a() {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("REPORT >>> \'TEST\'");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def operator_tripleGreaterThan(Object object, String string) {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append(QuickfixTest.defaultBody, "\t\t");
+    _builder_1.newLineIfNotEmpty();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
   public void inconsistentIndentation() {
     final String tripleQuotes = "\'\'\'";
     StringConcatenation _builder = new StringConcatenation();

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/CreateMemberQuickfixes.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/CreateMemberQuickfixes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -231,16 +231,22 @@ public class CreateMemberQuickfixes implements ILinkingIssueQuickfixProvider {
 	
 	/* @Nullable */
 	protected String getOperatorMethodName(XAbstractFeatureCall call) {
+		StringBuilder sb = new StringBuilder();
 		for(INode node: NodeModelUtils.findNodesForFeature(call, XbasePackage.Literals.XABSTRACT_FEATURE_CALL__FEATURE)) {
 			for(ILeafNode leafNode: node.getLeafNodes()) {
 				if(!leafNode.isHidden()) {
-					String symbol = leafNode.getText();
-					QualifiedName methodName = operatorMapping.getMethodName(QualifiedName.create(symbol));
-					if(methodName != null)
-						return methodName.getFirstSegment();
+					sb.append(leafNode.getText());
 				}
 			}
 		}
+		
+		String symbol = sb.toString();
+		if(!symbol.isEmpty()) {
+			QualifiedName methodName = operatorMapping.getMethodName(QualifiedName.create(symbol));
+			if(methodName != null)
+				return methodName.getFirstSegment();
+		}
+		
 		return null;
 	}
 	


### PR DESCRIPTION
- Ensure that all non-hidden leafs (not only the first one) are used
when composing the quickfix when hovering over a missing operator name.
- Implement corresponding QuickfixTest test cases:
	missingLessThanMethod
	missingGreaterThanMethod
	missingDoubleLessThanMethod
	missingDoubleGreaterThanMethod
	missingTripleLessThanMethod
	missingTripleGreaterThanMethod

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>