### PR TITLE
[#164] Add further test case reproducing the issue (currently ignored).

### DIFF
--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/refactoring/XtendRenameRefactoringTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/refactoring/XtendRenameRefactoringTest.xtend
@@ -11,9 +11,41 @@ import org.junit.Test
 import org.junit.Ignore
 
 class XtendRenameRefactoringTest extends AbstractXtendRenameRefactoringTest {
-	
+
 	@Ignore("https://github.com/eclipse/xtext-xtend/issues/164")
-	@Test def testRenameXtendMember() {
+	@Test def testRenameXtendMember001() {
+		val xtendModel = '''
+			class A {
+			
+				val i1 = new I(){}
+			
+				def a() { b(i1) }
+				
+				def b(I i2) {}
+			}
+			
+			interface I {}
+		'''
+		val editor = openEditorSafely("A.xtend", xtendModel)
+		
+		editor.renameXtendElement(xtendModel.indexOf("i1"), "i3")
+		
+		editor.assertDocumentContains('''
+			class A {
+			
+				val i3 = new I(){}
+			
+				def a() { b(i3) }
+				
+				def b(I i2) {}
+			}
+			
+			interface I {}
+		''')
+	}
+
+	@Ignore("https://github.com/eclipse/xtext-xtend/issues/164")
+	@Test def testRenameXtendMember002() {
 		testHelper.createFile("testb/B.java", '''
 			package testb;
 			
@@ -58,9 +90,9 @@ class XtendRenameRefactoringTest extends AbstractXtendRenameRefactoringTest {
 			}
 		'''
 		val editor = openEditorSafely("A.xtend", xtendModel)
-			
+		
 		editor.renameXtendElement(xtendModel.indexOf("ARROWHEAD__E"), "arrowhead__e1")
-			
+		
 		editor.assertDocumentContains("arrowhead__e1")
 	}
 }

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/refactoring/XtendRenameRefactoringTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/refactoring/XtendRenameRefactoringTest.java
@@ -18,7 +18,62 @@ import org.junit.Test;
 public class XtendRenameRefactoringTest extends AbstractXtendRenameRefactoringTest {
   @Ignore("https://github.com/eclipse/xtext-xtend/issues/164")
   @Test
-  public void testRenameXtendMember() {
+  public void testRenameXtendMember001() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("class A {");
+      _builder.newLine();
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("val i1 = new I(){}");
+      _builder.newLine();
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("def a() { b(i1) }");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("def b(I i2) {}");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      _builder.newLine();
+      _builder.append("interface I {}");
+      _builder.newLine();
+      final String xtendModel = _builder.toString();
+      final XtextEditor editor = this.openEditorSafely("A.xtend", xtendModel);
+      this.renameXtendElement(editor, xtendModel.indexOf("i1"), "i3");
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("class A {");
+      _builder_1.newLine();
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("val i3 = new I(){}");
+      _builder_1.newLine();
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("def a() { b(i3) }");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("def b(I i2) {}");
+      _builder_1.newLine();
+      _builder_1.append("}");
+      _builder_1.newLine();
+      _builder_1.newLine();
+      _builder_1.append("interface I {}");
+      _builder_1.newLine();
+      this.assertDocumentContains(editor, _builder_1.toString());
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Ignore("https://github.com/eclipse/xtext-xtend/issues/164")
+  @Test
+  public void testRenameXtendMember002() {
     try {
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("package testb;");


### PR DESCRIPTION
- Add testRenameXtendMember001 test case that is smaller and easier to
understand/debug than the testRenameXtendMember002 test case.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>