### PR TITLE
[#571] Fix failing JavaDocContentAssistTest on Windows platform.

### DIFF
--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/JavaDocContentAssistTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/JavaDocContentAssistTest.xtend
@@ -1,123 +1,128 @@
 package org.eclipse.xtend.ide.tests.contentassist
 
 import org.junit.Test
+import java.util.List
 
 class JavaDocContentAssistTest extends AbstractXtendContentAssistBugTest {
 
-	@Test
-	def void testTypeInJavaDoc() {
-		newBuilder.append(
+	// cursor position marker
+	val c = '''<|>'''
+
+	@Test def testTypeInJavaDoc_1() {
 		'''
-		package foo
-		/**
-		 * @see java.util.Dat
-		 */
-		class Foo {}
-		''').assertTextAtCursorPosition(37,'java.util.Date')
-		.applyProposal(37).
-		expectContent('''
-		package foo
+			package foo
+			/**
+			 * @see java.util.Dat«c»
+			 */
+			class Foo {}
+		'''.testContentAssistant(#["java.util.Date"], '''
+			package foo
 
-		import java.util.Date
+			import java.util.Date
 
-		/**
-		 * @see Date
-		 */
-		class Foo {}
+			/**
+			 * @see Date
+			 */
+			class Foo {}
 		''')
 	}
 
-	@Test
-	def void testTypeInJavaDoc_2() {
-		newBuilder.append(
+	@Test def testTypeInJavaDoc_2() {
 		'''
-		package foo
-		/**
-		 * @see java.lang.StringBuff
-		 */
-		class Foo {}
-		''').assertTextAtCursorPosition(44, "StringBuffer")
-		.applyProposal(44).
-		expectContent('''
-		package foo
-		/**
-		 * @see StringBuffer
-		 */
-		class Foo {}
+			package foo
+			/**
+			 * @see java.lang.StringBuff«c»
+			 */
+			class Foo {}
+		'''.testContentAssistant(#["StringBuffer"], '''
+			package foo
+			/**
+			 * @see StringBuffer
+			 */
+			class Foo {}
 		''')
 	}
 
-	@Test
-	def void testTypeInJavaDoc_3() {
-		assertTrue(newBuilder.append(
+	@Test def testTypeInJavaDoc_3() {
 		'''
-		package foo
-		/**
-		 * java.lang.StringBuff
-		 */
-		class Foo {}
-		''').computeCompletionProposals(39).isEmpty())
+			package foo
+			/**
+			 * java.lang.StringBuff«c»
+			 */
+			class Foo {}
+		'''.testEmptyContentAssistant
 	}
 
-
-	@Test
-	def void testTypeInJavaDoc_4() {
-		newBuilder.append(
+	@Test def testTypeInJavaDoc_4() {
 		'''
-		package foo
-		/**
-		 * @see    java.lang.StringBuff
-		 */
-		class Foo {}
-		''').assertTextAtCursorPosition(47, "StringBuffer")
-		.applyProposal(47).
-		expectContent('''
-		package foo
-		/**
-		 * @see    StringBuffer
-		 */
-		class Foo {}
+			package foo
+			/**
+			 * @see    java.lang.StringBuff«c»
+			 */
+			class Foo {}
+		'''.testContentAssistant(#["StringBuffer"], '''
+			package foo
+			/**
+			 * @see    StringBuffer
+			 */
+			class Foo {}
 		''')
 	}
 
-	@Test
-	def void testTypeInJavaDoc_5() {
-		newBuilder.append(
+	@Test def testTypeInJavaDoc_5() {
 		'''
-		package foo
-		/**
-		 * {@link java.lang.StringBuff
-		 */
-		class Foo {}
-		''').assertTextAtCursorPosition(46, "StringBuffer")
-		.applyProposal(46).
-		expectContent('''
-		package foo
-		/**
-		 * {@link StringBuffer
-		 */
-		class Foo {}
+			package foo
+			/**
+			 * {@link java.lang.StringBuff«c»
+			 */
+			class Foo {}
+		'''.testContentAssistant(#["StringBuffer"], '''
+			package foo
+			/**
+			 * {@link StringBuffer
+			 */
+			class Foo {}
 		''')
 	}
 
-	@Test
-	def void testTypeInJavaDoc_6() {
-		newBuilder.append(
+	@Test def testTypeInJavaDoc_6() {
 		'''
-		package foo
-		/**
-		 * {@link    java.lang.StringBuff
-		 */
-		class Foo {}
-		''').assertTextAtCursorPosition(49, "StringBuffer")
-		.applyProposal(49).
-		expectContent('''
-		package foo
-		/**
-		 * {@link    StringBuffer
-		 */
-		class Foo {}
+			package foo
+			/**
+			 * {@link    java.lang.StringBuff«c»
+			 */
+			class Foo {}
+		'''.testContentAssistant(#["StringBuffer"], '''
+			package foo
+			/**
+			 * {@link    StringBuffer
+			 */
+			class Foo {}
 		''')
 	}
 
+	private def testEmptyContentAssistant(CharSequence it) {
+		testContentAssistant(#[], null, null)
+	}
+	
+	private def testContentAssistant(CharSequence it, List<String> expectedProposals, String expectedContent) {
+		testContentAssistant(expectedProposals, expectedProposals.head, expectedContent)	
+	}
+
+	private def void testContentAssistant(CharSequence text, List<String> expectedProposals,
+		String proposalToApply, String expectedContent) {
+		
+		val cursorPosition = text.toString.indexOf(c)
+		if(cursorPosition == -1) {
+			fail("Can't locate cursor position symbols '" + c + "' in the input text.")
+		}
+		
+		val content = text.toString.replace(c, "")
+		
+		val builder = newBuilder.append(content).assertTextAtCursorPosition(cursorPosition, expectedProposals)
+		
+		if(proposalToApply !== null) {
+			builder.applyProposal(cursorPosition, proposalToApply).expectContent(expectedContent)
+		}
+	}
 }

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/contentassist/JavaDocContentAssistTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/contentassist/JavaDocContentAssistTest.java
@@ -1,225 +1,230 @@
 package org.eclipse.xtend.ide.tests.contentassist;
 
+import java.util.Collections;
 import java.util.List;
-import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.xtend.ide.tests.contentassist.AbstractXtendContentAssistBugTest;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.ui.testing.ContentAssistProcessorTestBuilder;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.Functions.Function0;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.junit.Assert;
 import org.junit.Test;
 
 @SuppressWarnings("all")
 public class JavaDocContentAssistTest extends AbstractXtendContentAssistBugTest {
-  @Test
-  public void testTypeInJavaDoc() {
-    try {
-      ContentAssistProcessorTestBuilder _newBuilder = this.newBuilder();
+  private final String c = new Function0<String>() {
+    public String apply() {
       StringConcatenation _builder = new StringConcatenation();
-      _builder.append("package foo");
-      _builder.newLine();
-      _builder.append("/**");
-      _builder.newLine();
-      _builder.append(" ");
-      _builder.append("* @see java.util.Dat");
-      _builder.newLine();
-      _builder.append(" ");
-      _builder.append("*/");
-      _builder.newLine();
-      _builder.append("class Foo {}");
-      _builder.newLine();
-      ContentAssistProcessorTestBuilder _applyProposal = _newBuilder.append(_builder.toString()).assertTextAtCursorPosition(37, "java.util.Date").applyProposal(37);
-      StringConcatenation _builder_1 = new StringConcatenation();
-      _builder_1.append("package foo");
-      _builder_1.newLine();
-      _builder_1.newLine();
-      _builder_1.append("import java.util.Date");
-      _builder_1.newLine();
-      _builder_1.newLine();
-      _builder_1.append("/**");
-      _builder_1.newLine();
-      _builder_1.append(" ");
-      _builder_1.append("* @see Date");
-      _builder_1.newLine();
-      _builder_1.append(" ");
-      _builder_1.append("*/");
-      _builder_1.newLine();
-      _builder_1.append("class Foo {}");
-      _builder_1.newLine();
-      _applyProposal.expectContent(_builder_1.toString());
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
+      _builder.append("<|>");
+      return _builder.toString();
     }
+  }.apply();
+  
+  @Test
+  public void testTypeInJavaDoc_1() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package foo");
+    _builder.newLine();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* @see java.util.Dat");
+    _builder.append(this.c, " ");
+    _builder.newLineIfNotEmpty();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("class Foo {}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("package foo");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("import java.util.Date");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("/**");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("* @see Date");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("*/");
+    _builder_1.newLine();
+    _builder_1.append("class Foo {}");
+    _builder_1.newLine();
+    this.testContentAssistant(_builder, Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("java.util.Date")), _builder_1.toString());
   }
   
   @Test
   public void testTypeInJavaDoc_2() {
-    try {
-      ContentAssistProcessorTestBuilder _newBuilder = this.newBuilder();
-      StringConcatenation _builder = new StringConcatenation();
-      _builder.append("package foo");
-      _builder.newLine();
-      _builder.append("/**");
-      _builder.newLine();
-      _builder.append(" ");
-      _builder.append("* @see java.lang.StringBuff");
-      _builder.newLine();
-      _builder.append(" ");
-      _builder.append("*/");
-      _builder.newLine();
-      _builder.append("class Foo {}");
-      _builder.newLine();
-      ContentAssistProcessorTestBuilder _applyProposal = _newBuilder.append(_builder.toString()).assertTextAtCursorPosition(44, "StringBuffer").applyProposal(44);
-      StringConcatenation _builder_1 = new StringConcatenation();
-      _builder_1.append("package foo");
-      _builder_1.newLine();
-      _builder_1.append("/**");
-      _builder_1.newLine();
-      _builder_1.append(" ");
-      _builder_1.append("* @see StringBuffer");
-      _builder_1.newLine();
-      _builder_1.append(" ");
-      _builder_1.append("*/");
-      _builder_1.newLine();
-      _builder_1.append("class Foo {}");
-      _builder_1.newLine();
-      _applyProposal.expectContent(_builder_1.toString());
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
-    }
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package foo");
+    _builder.newLine();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* @see java.lang.StringBuff");
+    _builder.append(this.c, " ");
+    _builder.newLineIfNotEmpty();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("class Foo {}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("package foo");
+    _builder_1.newLine();
+    _builder_1.append("/**");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("* @see StringBuffer");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("*/");
+    _builder_1.newLine();
+    _builder_1.append("class Foo {}");
+    _builder_1.newLine();
+    this.testContentAssistant(_builder, Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("StringBuffer")), _builder_1.toString());
   }
   
   @Test
   public void testTypeInJavaDoc_3() {
-    try {
-      ContentAssistProcessorTestBuilder _newBuilder = this.newBuilder();
-      StringConcatenation _builder = new StringConcatenation();
-      _builder.append("package foo");
-      _builder.newLine();
-      _builder.append("/**");
-      _builder.newLine();
-      _builder.append(" ");
-      _builder.append("* java.lang.StringBuff");
-      _builder.newLine();
-      _builder.append(" ");
-      _builder.append("*/");
-      _builder.newLine();
-      _builder.append("class Foo {}");
-      _builder.newLine();
-      Assert.assertTrue(
-        ((List<ICompletionProposal>)Conversions.doWrapArray(_newBuilder.append(_builder.toString()).computeCompletionProposals(39))).isEmpty());
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
-    }
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package foo");
+    _builder.newLine();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* java.lang.StringBuff");
+    _builder.append(this.c, " ");
+    _builder.newLineIfNotEmpty();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("class Foo {}");
+    _builder.newLine();
+    this.testEmptyContentAssistant(_builder);
   }
   
   @Test
   public void testTypeInJavaDoc_4() {
-    try {
-      ContentAssistProcessorTestBuilder _newBuilder = this.newBuilder();
-      StringConcatenation _builder = new StringConcatenation();
-      _builder.append("package foo");
-      _builder.newLine();
-      _builder.append("/**");
-      _builder.newLine();
-      _builder.append(" ");
-      _builder.append("* @see    java.lang.StringBuff");
-      _builder.newLine();
-      _builder.append(" ");
-      _builder.append("*/");
-      _builder.newLine();
-      _builder.append("class Foo {}");
-      _builder.newLine();
-      ContentAssistProcessorTestBuilder _applyProposal = _newBuilder.append(_builder.toString()).assertTextAtCursorPosition(47, "StringBuffer").applyProposal(47);
-      StringConcatenation _builder_1 = new StringConcatenation();
-      _builder_1.append("package foo");
-      _builder_1.newLine();
-      _builder_1.append("/**");
-      _builder_1.newLine();
-      _builder_1.append(" ");
-      _builder_1.append("* @see    StringBuffer");
-      _builder_1.newLine();
-      _builder_1.append(" ");
-      _builder_1.append("*/");
-      _builder_1.newLine();
-      _builder_1.append("class Foo {}");
-      _builder_1.newLine();
-      _applyProposal.expectContent(_builder_1.toString());
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
-    }
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package foo");
+    _builder.newLine();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* @see    java.lang.StringBuff");
+    _builder.append(this.c, " ");
+    _builder.newLineIfNotEmpty();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("class Foo {}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("package foo");
+    _builder_1.newLine();
+    _builder_1.append("/**");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("* @see    StringBuffer");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("*/");
+    _builder_1.newLine();
+    _builder_1.append("class Foo {}");
+    _builder_1.newLine();
+    this.testContentAssistant(_builder, Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("StringBuffer")), _builder_1.toString());
   }
   
   @Test
   public void testTypeInJavaDoc_5() {
-    try {
-      ContentAssistProcessorTestBuilder _newBuilder = this.newBuilder();
-      StringConcatenation _builder = new StringConcatenation();
-      _builder.append("package foo");
-      _builder.newLine();
-      _builder.append("/**");
-      _builder.newLine();
-      _builder.append(" ");
-      _builder.append("* {@link java.lang.StringBuff");
-      _builder.newLine();
-      _builder.append(" ");
-      _builder.append("*/");
-      _builder.newLine();
-      _builder.append("class Foo {}");
-      _builder.newLine();
-      ContentAssistProcessorTestBuilder _applyProposal = _newBuilder.append(_builder.toString()).assertTextAtCursorPosition(46, "StringBuffer").applyProposal(46);
-      StringConcatenation _builder_1 = new StringConcatenation();
-      _builder_1.append("package foo");
-      _builder_1.newLine();
-      _builder_1.append("/**");
-      _builder_1.newLine();
-      _builder_1.append(" ");
-      _builder_1.append("* {@link StringBuffer");
-      _builder_1.newLine();
-      _builder_1.append(" ");
-      _builder_1.append("*/");
-      _builder_1.newLine();
-      _builder_1.append("class Foo {}");
-      _builder_1.newLine();
-      _applyProposal.expectContent(_builder_1.toString());
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
-    }
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package foo");
+    _builder.newLine();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* {@link java.lang.StringBuff");
+    _builder.append(this.c, " ");
+    _builder.newLineIfNotEmpty();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("class Foo {}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("package foo");
+    _builder_1.newLine();
+    _builder_1.append("/**");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("* {@link StringBuffer");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("*/");
+    _builder_1.newLine();
+    _builder_1.append("class Foo {}");
+    _builder_1.newLine();
+    this.testContentAssistant(_builder, Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("StringBuffer")), _builder_1.toString());
   }
   
   @Test
   public void testTypeInJavaDoc_6() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package foo");
+    _builder.newLine();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* {@link    java.lang.StringBuff");
+    _builder.append(this.c, " ");
+    _builder.newLineIfNotEmpty();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("class Foo {}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("package foo");
+    _builder_1.newLine();
+    _builder_1.append("/**");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("* {@link    StringBuffer");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("*/");
+    _builder_1.newLine();
+    _builder_1.append("class Foo {}");
+    _builder_1.newLine();
+    this.testContentAssistant(_builder, Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList("StringBuffer")), _builder_1.toString());
+  }
+  
+  private void testEmptyContentAssistant(final CharSequence it) {
+    this.testContentAssistant(it, Collections.<String>unmodifiableList(CollectionLiterals.<String>newArrayList()), null, null);
+  }
+  
+  private void testContentAssistant(final CharSequence it, final List<String> expectedProposals, final String expectedContent) {
+    this.testContentAssistant(it, expectedProposals, IterableExtensions.<String>head(expectedProposals), expectedContent);
+  }
+  
+  private void testContentAssistant(final CharSequence text, final List<String> expectedProposals, final String proposalToApply, final String expectedContent) {
     try {
-      ContentAssistProcessorTestBuilder _newBuilder = this.newBuilder();
-      StringConcatenation _builder = new StringConcatenation();
-      _builder.append("package foo");
-      _builder.newLine();
-      _builder.append("/**");
-      _builder.newLine();
-      _builder.append(" ");
-      _builder.append("* {@link    java.lang.StringBuff");
-      _builder.newLine();
-      _builder.append(" ");
-      _builder.append("*/");
-      _builder.newLine();
-      _builder.append("class Foo {}");
-      _builder.newLine();
-      ContentAssistProcessorTestBuilder _applyProposal = _newBuilder.append(_builder.toString()).assertTextAtCursorPosition(49, "StringBuffer").applyProposal(49);
-      StringConcatenation _builder_1 = new StringConcatenation();
-      _builder_1.append("package foo");
-      _builder_1.newLine();
-      _builder_1.append("/**");
-      _builder_1.newLine();
-      _builder_1.append(" ");
-      _builder_1.append("* {@link    StringBuffer");
-      _builder_1.newLine();
-      _builder_1.append(" ");
-      _builder_1.append("*/");
-      _builder_1.newLine();
-      _builder_1.append("class Foo {}");
-      _builder_1.newLine();
-      _applyProposal.expectContent(_builder_1.toString());
+      final int cursorPosition = text.toString().indexOf(this.c);
+      if ((cursorPosition == (-1))) {
+        Assert.fail((("Can\'t locate cursor position symbols \'" + this.c) + "\' in the input text."));
+      }
+      final String content = text.toString().replace(this.c, "");
+      final ContentAssistProcessorTestBuilder builder = this.newBuilder().append(content).assertTextAtCursorPosition(cursorPosition, ((String[])Conversions.unwrapArray(expectedProposals, String.class)));
+      if ((proposalToApply != null)) {
+        builder.applyProposal(cursorPosition, proposalToApply).expectContent(expectedContent);
+      }
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }


### PR DESCRIPTION
- Modify the JavaDocContentAssist test cases to use explicit cursor
position markers instead of absolute cursor positions, since the
absolute cursor position can lead to different actual cursor positions
on different platforms (Linux/Windows) due to the different line
delimiters.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>