### PR TITLE
[#554] Ensure static and final modifiers generated in the right order.

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/AnnotationCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/AnnotationCompilerTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -320,7 +320,7 @@ class AnnotationCompilerTest extends AbstractXtendCompilerTest {
 		'''.assertCompilesTo('''
 			@SuppressWarnings("all")
 			public class TestXtend {
-			  private final static int a = 4;
+			  private static final int a = 4;
 			  
 			  @Click({ TestXtend.a, TestXtend.a })
 			  public Object meth() {
@@ -345,7 +345,7 @@ class AnnotationCompilerTest extends AbstractXtendCompilerTest {
 		'''.assertCompilesTo('''
 			@SuppressWarnings("all")
 			public class TestXtend {
-			  private final static int a = 4;
+			  private static final int a = 4;
 			  
 			  @Click({ TestXtend.a, ((TestXtend.a & 3) << 1) })
 			  public Object meth() {

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/AnonymousClassCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/AnonymousClassCompilerTest.xtend
@@ -2331,7 +2331,7 @@ class AnonymousClassCompilerTest extends AbstractXtendCompilerTest {
 			public class Foo {
 			  public void foo() {
 			    abstract class __Foo_1 {
-			      final static int x = 1;
+			      static final int x = 1;
 			      
 			      public abstract void bar();
 			    }

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug437678Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug437678Test.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -193,7 +193,7 @@ class CompilerBug437678Test extends AbstractXtendCompilerTest {
 		''', '''
 			@SuppressWarnings("all")
 			public class C {
-			  private final static int privateField = 1;
+			  private static final int privateField = 1;
 			  
 			  private static int privateMethod() {
 			    return 2;

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.xtend
@@ -1321,7 +1321,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			public interface Foo {
 			  public abstract int foo();
 			  
-			  public final static int bar = 42;
+			  public static final int bar = 42;
 			}
 		''')
 	}
@@ -5952,7 +5952,7 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			public class Foo {
 			  private final int X = 42;
 			  
-			  private final static int Y = (-7);
+			  private static final int Y = (-7);
 			  
 			  public void foo(final int x) {
 			    boolean _matched = false;

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/declaration/ConstantExpressionsInterpreterTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/declaration/ConstantExpressionsInterpreterTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -54,11 +54,11 @@ class ConstantExpressionsInterpreterTest extends AbstractXtendTestCase {
 	@Test def void testNonConstant() {
 		val file = file('''
 			class C { 
-				public final static Class<?> REF = D.testFoo;
+				public static final Class<?> REF = D.testFoo;
 			}
 			
 			class D {
-				public final static Class<?> testFoo = Object
+				public static final Class<?> testFoo = Object
 			}
 		''')
 		// make sure the full resolution happened, so the constant values are set on the fields

--- a/org.eclipse.xtend.core.tests/testdata/test/Constants1.java
+++ b/org.eclipse.xtend.core.tests/testdata/test/Constants1.java
@@ -4,7 +4,7 @@ package test;
  * @since 2.5
  */
 public class Constants1 {
-	public final static String STRING_CONSTANT = "Some Constant";
-	public final static int INT_CONSTANT = 42;
+	public static final String STRING_CONSTANT = "Some Constant";
+	public static final int INT_CONSTANT = 42;
 	public static int NOT_A_INT_CONSTANT = 42;
 }

--- a/org.eclipse.xtend.core.tests/testdata/testdata/Constants1.java
+++ b/org.eclipse.xtend.core.tests/testdata/testdata/Constants1.java
@@ -4,7 +4,7 @@ package testdata;
  * @since 2.5
  */
 public class Constants1 {
-	public final static String STRING_CONSTANT = "Some Constant";
-	public final static int INT_CONSTANT = 42;
+	public static final String STRING_CONSTANT = "Some Constant";
+	public static final int INT_CONSTANT = 42;
 	public static int NOT_A_INT_CONSTANT = 42;
 }

--- a/org.eclipse.xtend.core.tests/testdata/types/StaticOuterClass.java
+++ b/org.eclipse.xtend.core.tests/testdata/types/StaticOuterClass.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,7 @@ package types;
 public class StaticOuterClass {
 	public static class StaticMiddleClass {
 		public static class StaticInnerClass {
-			public final static String CONSTANT = "CONSTANT";
+			public static final String CONSTANT = "CONSTANT";
 		}
 	}
 }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/AnnotationCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/AnnotationCompilerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -595,7 +595,7 @@ public class AnnotationCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("public class TestXtend {");
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("private final static int a = 4;");
+    _builder_1.append("private static final int a = 4;");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.newLine();
@@ -648,7 +648,7 @@ public class AnnotationCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("public class TestXtend {");
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("private final static int a = 4;");
+    _builder_1.append("private static final int a = 4;");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.newLine();

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/AnonymousClassCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/AnonymousClassCompilerTest.java
@@ -5513,7 +5513,7 @@ public class AnonymousClassCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("abstract class __Foo_1 {");
     _builder_1.newLine();
     _builder_1.append("      ");
-    _builder_1.append("final static int x = 1;");
+    _builder_1.append("static final int x = 1;");
     _builder_1.newLine();
     _builder_1.append("      ");
     _builder_1.newLine();

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug437678Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug437678Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -424,7 +424,7 @@ public class CompilerBug437678Test extends AbstractXtendCompilerTest {
     _builder_1.append("public class C {");
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("private final static int privateField = 1;");
+    _builder_1.append("private static final int privateField = 1;");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.newLine();

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.java
@@ -3063,7 +3063,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("public final static int bar = 42;");
+    _builder_1.append("public static final int bar = 42;");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
@@ -13144,7 +13144,7 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("  ");
     _builder_1.newLine();
     _builder_1.append("  ");
-    _builder_1.append("private final static int Y = (-7);");
+    _builder_1.append("private static final int Y = (-7);");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.newLine();

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/declaration/ConstantExpressionsInterpreterTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/declaration/ConstantExpressionsInterpreterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -93,7 +93,7 @@ public class ConstantExpressionsInterpreterTest extends AbstractXtendTestCase {
       _builder.append("class C { ");
       _builder.newLine();
       _builder.append("\t");
-      _builder.append("public final static Class<?> REF = D.testFoo;");
+      _builder.append("public static final Class<?> REF = D.testFoo;");
       _builder.newLine();
       _builder.append("}");
       _builder.newLine();
@@ -101,7 +101,7 @@ public class ConstantExpressionsInterpreterTest extends AbstractXtendTestCase {
       _builder.append("class D {");
       _builder.newLine();
       _builder.append("\t");
-      _builder.append("public final static Class<?> testFoo = Object");
+      _builder.append("public static final Class<?> testFoo = Object");
       _builder.newLine();
       _builder.append("}");
       _builder.newLine();

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendGenerator.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/XtendGenerator.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -208,10 +208,10 @@ class XtendGenerator extends JvmModelGenerator implements IGenerator2 {
 						tracedAppendable.newLine
 						generateJavaDoc(tracedAppendable, config)
 						annotations.generateAnnotations(tracedAppendable, true, config)
-						if (isFinal && isStatic)
-							tracedAppendable.append("final ")
 						if (isStatic)
 							tracedAppendable.append("static ")
+						if (isFinal && isStatic)
+							tracedAppendable.append("final ")
 						if (isTransient)
 							tracedAppendable.append("transient ")
 						if (isVolatile)

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/compiler/XtendGenerator.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/compiler/XtendGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -311,12 +311,12 @@ public class XtendGenerator extends JvmModelGenerator implements IGenerator2 {
             tracedAppendable_1.newLine();
             this.generateJavaDoc(it_1, tracedAppendable_1, config);
             this.generateAnnotations(((JvmField)it_1).getAnnotations(), tracedAppendable_1, true, config);
-            if ((((JvmField)it_1).isFinal() && ((JvmField)it_1).isStatic())) {
-              tracedAppendable_1.append("final ");
-            }
             boolean _isStatic = ((JvmField)it_1).isStatic();
             if (_isStatic) {
               tracedAppendable_1.append("static ");
+            }
+            if ((((JvmField)it_1).isFinal() && ((JvmField)it_1).isStatic())) {
+              tracedAppendable_1.append("final ");
             }
             boolean _isTransient = ((JvmField)it_1).isTransient();
             if (_isTransient) {


### PR DESCRIPTION
- Modify the XtendGenerator to generate the static and the final
modifiers in the right order (corresponding to the java language
specification) 'static final' instead of 'final static'.
- Adapt the corresponding test cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>