### PR TITLE
[eclipse/xtext#1310] Set encoding for Test tasks

### DIFF
--- a/gradle/java-compiler-settings.gradle
+++ b/gradle/java-compiler-settings.gradle
@@ -8,6 +8,10 @@ tasks.withType(JavaCompile) {
 	options.encoding = 'ISO-8859-1'
 }
 
+tasks.withType(Test) {
+	systemProperty 'file.encoding', 'ISO-8859-1'
+}
+
 tasks.withType(Javadoc) {
 	options.encoding = 'ISO-8859-1'
 	options.tags = [ 'noreference', 'noextend', 'noimplement', 'noinstantiate', 'nooverride', 'model', 'generated', 'ordered' ] 


### PR DESCRIPTION
Test failures can happen on machines that do not define a LANG environment property

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>