### PR TITLE
XtendValidator: Remove com.google.common.collect.Sets.* unused import.

### DIFF
--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendValidator.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendValidator.java
@@ -11,7 +11,6 @@ import static com.google.common.collect.Iterables.*;
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Lists.*;
 import static com.google.common.collect.Lists.transform;
-import static com.google.common.collect.Sets.*;
 import static org.eclipse.xtend.core.validation.IssueCodes.*;
 import static org.eclipse.xtend.core.xtend.XtendPackage.Literals.*;
 import static org.eclipse.xtext.util.JavaVersion.*;


### PR DESCRIPTION
Signed-off-by: Tamas Miklossy <miklossy@itemis.de>