### PR TITLE
[399591] Ensure the visibility of overridden method are properly applied

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug399591Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug399591Test.xtend
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.core.tests.compiler
+
+import org.junit.Test
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+class CompilerBug399591Test extends AbstractXtendCompilerTest {
+
+	@Test def visibility_override_protected() {
+		'''
+			class C extends junit.framework.TestCase {
+				override setUp () {}
+			}
+		'''.assertCompilesTo('''
+			import junit.framework.TestCase;
+			
+			@SuppressWarnings("all")
+			public class C extends TestCase {
+			  protected void setUp() {
+			  }
+			}
+		''')
+	}
+
+	@Test def visibility_override_protected_protected() {
+		'''
+			class C extends junit.framework.TestCase {
+				protected override setUp () {}
+			}
+		'''.assertCompilesTo('''
+			import junit.framework.TestCase;
+			
+			@SuppressWarnings("all")
+			public class C extends TestCase {
+			  protected void setUp() {
+			  }
+			}
+		''')
+	}
+
+	@Test def visibility_override_protected_public() {
+		'''
+			class C extends junit.framework.TestCase {
+				public override setUp () {}
+			}
+		'''.assertCompilesTo('''
+			import junit.framework.TestCase;
+			
+			@SuppressWarnings("all")
+			public class C extends TestCase {
+			  public void setUp() {
+			  }
+			}
+		''')
+	}
+
+	@Test def visibility_override_public() {
+		'''
+			class C extends junit.framework.TestCase {
+				override getName () {}
+			}
+		'''.assertCompilesTo('''
+			import junit.framework.TestCase;
+			
+			@SuppressWarnings("all")
+			public class C extends TestCase {
+			  public String getName() {
+			    return null;
+			  }
+			}
+		''')
+	}
+
+	@Test def visibility_override_public_public() {
+		'''
+			class C extends junit.framework.TestCase {
+				public override getName () {}
+			}
+		'''.assertCompilesTo('''
+			import junit.framework.TestCase;
+			
+			@SuppressWarnings("all")
+			public class C extends TestCase {
+			  public String getName() {
+			    return null;
+			  }
+			}
+		''')
+	}
+}

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug399591Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug399591Test.java
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.core.tests.compiler;
+
+import org.eclipse.xtend.core.tests.compiler.AbstractXtendCompilerTest;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.junit.Test;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public class CompilerBug399591Test extends AbstractXtendCompilerTest {
+  @Test
+  public void visibility_override_protected() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class C extends junit.framework.TestCase {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("override setUp () {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import junit.framework.TestCase;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class C extends TestCase {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("protected void setUp() {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
+  }
+  
+  @Test
+  public void visibility_override_protected_protected() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class C extends junit.framework.TestCase {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("protected override setUp () {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import junit.framework.TestCase;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class C extends TestCase {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("protected void setUp() {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
+  }
+  
+  @Test
+  public void visibility_override_protected_public() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class C extends junit.framework.TestCase {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("public override setUp () {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import junit.framework.TestCase;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class C extends TestCase {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public void setUp() {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
+  }
+  
+  @Test
+  public void visibility_override_public() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class C extends junit.framework.TestCase {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("override getName () {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import junit.framework.TestCase;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class C extends TestCase {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public String getName() {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("return null;");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
+  }
+  
+  @Test
+  public void visibility_override_public_public() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class C extends junit.framework.TestCase {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("public override getName () {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import junit.framework.TestCase;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class C extends TestCase {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public String getName() {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("return null;");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
+  }
+}

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/jvmmodel/XtendJvmModelInferrer.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/jvmmodel/XtendJvmModelInferrer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2018 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -86,6 +86,7 @@ import org.eclipse.xtext.xbase.jvmmodel.JvmTypesBuilder;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.eclipse.xtext.xbase.resource.BatchLinkableResource;
+import org.eclipse.xtext.xbase.typesystem.override.OverrideHelper;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
@@ -149,6 +150,9 @@ public class XtendJvmModelInferrer extends AbstractModelInferrer {
 	
 	@Inject
 	private OperationCanceledManager operationCanceledManager;
+	
+	@Inject
+	private OverrideHelper overrideHelper;
 	
 	private GeneratorConfig generatorConfig;
 	
@@ -598,6 +602,13 @@ public class XtendJvmModelInferrer extends AbstractModelInferrer {
 			sourceName = "_" + sourceName;
 		}
 		operation.setSimpleName(sourceName);
+		if(source.isOverride() && source.getDeclaredVisibility() == null) {
+			JvmOperation jvmOperation = associations.getDirectlyInferredOperation(source);
+			JvmOperation overriddenJvmOperation = overrideHelper.findOverriddenOperation(jvmOperation);
+			if(overriddenJvmOperation != null) {
+				visibility = overriddenJvmOperation.getVisibility();
+			}
+		}
 		operation.setVisibility(visibility);
 		operation.setStatic(source.isStatic());
 		if (!operation.isAbstract() && !operation.isStatic() && container.isInterface())


### PR DESCRIPTION
- Modify the XtendJvmModelInferrer to consider the visibility of the
overridden method when no explicit visibility modifier is defined.
- Implement corresponding Xtend Compiler test cases.

https://bugs.eclipse.org/bugs/show_bug.cgi?id=399591

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>