### PR TITLE
[eclipse/xtext-eclipse#841] address removal of equinox.ds in platform 4.10

### DIFF
--- a/releng/org.eclipse.xtend.tycho.tests.parent/pom.xml
+++ b/releng/org.eclipse.xtend.tycho.tests.parent/pom.xml
@@ -61,13 +61,11 @@
 				<configuration>
 					<dependency-resolution>
 						<extraRequirements>
-							<!--
 							<requirement>
 								<type>eclipse-plugin</type>
-								<id>org.eclipse.equinox.ds</id>
+								<id>org.apache.felix.scr</id>
 								<versionRange>1.0.0</versionRange>
 							</requirement>
-							-->
 							<requirement>
 								<type>eclipse-plugin</type>
 								<id>org.eclipse.equinox.event</id>
@@ -127,6 +125,14 @@
 							<!-- matches *Tests.java as well as *Test<n>.java -->
 							<include>**/*Test?.java</include>
 						</includes>
+						<!-- TODO remove with tycho 1.3 -->
+						<bundleStartLevel>
+							<bundle>
+								<id>org.apache.felix.scr</id>
+								<level>1</level>
+								<autoStart>true</autoStart>
+							</bundle>
+						</bundleStartLevel>
 					</configuration>
 				</plugin>
 			</plugins>


### PR DESCRIPTION
[eclipse/xtext-eclipse#841] address removal of equinox.ds in platform 4.10

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>