### PR TITLE
[eclipse/xtext#1311] Make test independent from system encoding

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/richstring/RichStringEvaluationTest.java
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/richstring/RichStringEvaluationTest.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.xtend.core.tests.richstring;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Stack;
 import java.util.regex.Matcher;
@@ -26,7 +27,7 @@ import org.eclipse.xtext.common.types.JvmFormalParameter;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.resource.XtextResourceSet;
 import org.eclipse.xtext.util.CancelIndicator;
-import org.eclipse.xtext.util.StringInputStream;
+import org.eclipse.xtext.util.LazyStringInputStream;
 import org.eclipse.xtext.validation.CheckMode;
 import org.eclipse.xtext.validation.Issue;
 import org.eclipse.xtext.xbase.XBooleanLiteral;
@@ -277,7 +278,7 @@ public class RichStringEvaluationTest extends AbstractRichStringEvaluationTest {
 		XtextResourceSet set = resourceSetProvider.get();
 		String fileName = getFileName(string);
 		Resource resource = set.createResource(URI.createURI(fileName + ".xtend"));
-		resource.load(new StringInputStream(string), null);
+		resource.load(new LazyStringInputStream(string, StandardCharsets.ISO_8859_1), null);
 		assertEquals(resource.getErrors().toString(), 0, resource.getErrors().size());
 		if (validate) {
 			List<Issue> issues = ((XtextResource) resource).getResourceServiceProvider().getResourceValidator()


### PR DESCRIPTION
Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>