### PR TITLE
Added Test for @Inline Annotation written in Xtend using constantExpression

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/InlineInXtendTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/InlineInXtendTest.xtend
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.core.tests.compiler
+
+import org.junit.Test
+
+/**
+ * @author Stéphane Galland - Initial Contribution
+ * @author Christian Dietrich - Fixed broken test
+ */
+class InlineInXtendTest extends AbstractXtendCompilerTest {
+	
+	@Test
+	def testDataClasses_01() { 
+		assertCompilesTo('''
+			import org.eclipse.xtext.xbase.lib.Inline;
+			class Foo {
+				@Inline(value = "3", constantExpression = true)
+				def int fct() {
+					return 3
+				}
+				def int fct2() {
+					return fct() + 1
+				}
+			}
+		''', '''
+			import org.eclipse.xtext.xbase.lib.Inline;
+			
+			@SuppressWarnings("all")
+			public class Foo {
+			  @Inline(value = "3", constantExpression = true)
+			  public int fct() {
+			    return 3;
+			  }
+			  
+			  public int fct2() {
+			    int _fct = 3;
+			    return (_fct + 1);
+			  }
+			}
+		''')
+	}
+
+}

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/InlineInXtendTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/InlineInXtendTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.core.tests.compiler;
+
+import org.eclipse.xtend.core.tests.compiler.AbstractXtendCompilerTest;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.junit.Test;
+
+/**
+ * @author Stéphane Galland - Initial Contribution
+ * @author Christian Dietrich - Fixed broken test
+ */
+@SuppressWarnings("all")
+public class InlineInXtendTest extends AbstractXtendCompilerTest {
+  @Test
+  public void testDataClasses_01() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.eclipse.xtext.xbase.lib.Inline;");
+    _builder.newLine();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("@Inline(value = \"3\", constantExpression = true)");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def int fct() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("return 3");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def int fct2() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("return fct() + 1");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Inline;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("@Inline(value = \"3\", constantExpression = true)");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public int fct() {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("return 3;");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public int fct2() {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("int _fct = 3;");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("return (_fct + 1);");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
+  }
+}


### PR DESCRIPTION
Added Test for @Inline Annotation written in Xtend using constantExpression

see https://github.com/eclipse/xtext-extras/pull/324

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>