### PR TITLE
[eclipse/xtext-eclipse#900] Consume Xpand from release train repo

### DIFF
--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-latest.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-latest.target
@@ -94,7 +94,10 @@
 
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 		<unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
-		<repository location="http://download.eclipse.org/releases/photon"/>
+		<unit id="org.eclipse.xpand" version="0.0.0"/>
+		<unit id="org.eclipse.xtend" version="0.0.0"/>
+		<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
+		<repository location="http://download.eclipse.org/releases/2018-12"/>
 	</location>
 
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
@@ -122,13 +125,6 @@
 	<location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="de.itemis.xtext.antlr.sdk.feature.group" version="0.0.0"/>
 		<repository location="http://download.itemis.com/updates/releases/2.1.1/"/>
-	</location>
-	
-	<location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<unit id="org.eclipse.xpand" version="0.0.0"/>
-		<unit id="org.eclipse.xtend" version="0.0.0"/>
-		<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
-		<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/xpand/R201406030414"/>
 	</location>
 	
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-photon.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-photon.target
@@ -94,6 +94,9 @@
 
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 		<unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
+		<unit id="org.eclipse.xpand" version="0.0.0"/>
+		<unit id="org.eclipse.xtend" version="0.0.0"/>
+		<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
 		<repository location="http://download.eclipse.org/releases/photon"/>
 	</location>
 
@@ -122,13 +125,6 @@
 	<location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="de.itemis.xtext.antlr.sdk.feature.group" version="0.0.0"/>
 		<repository location="http://download.itemis.com/updates/releases/2.1.1/"/>
-	</location>
-	
-	<location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<unit id="org.eclipse.xpand" version="0.0.0"/>
-		<unit id="org.eclipse.xtend" version="0.0.0"/>
-		<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
-		<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/xpand/R201406030414"/>
 	</location>
 	
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201809.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201809.target
@@ -94,7 +94,10 @@
 
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 		<unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
-		<repository location="http://download.eclipse.org/releases/photon"/>
+		<unit id="org.eclipse.xpand" version="0.0.0"/>
+		<unit id="org.eclipse.xtend" version="0.0.0"/>
+		<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
+		<repository location="http://download.eclipse.org/releases/2018-09"/>
 	</location>
 
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
@@ -122,13 +125,6 @@
 	<location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="de.itemis.xtext.antlr.sdk.feature.group" version="0.0.0"/>
 		<repository location="http://download.itemis.com/updates/releases/2.1.1/"/>
-	</location>
-	
-	<location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<unit id="org.eclipse.xpand" version="0.0.0"/>
-		<unit id="org.eclipse.xtend" version="0.0.0"/>
-		<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
-		<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/xpand/R201406030414"/>
 	</location>
 	
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
Also fixed release train repo URL for 2018-09 & 2018-12

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>