### PR TITLE
Make protected the functions of ActiveAnnotationContextProvider.

### DIFF
--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/ActiveAnnotationContext.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/ActiveAnnotationContext.xtend
@@ -99,6 +99,7 @@ class ActiveAnnotationContexts extends AdapterImpl {
 
 /**
  * @author Sven Efftinge
+ * @author Stephane Galland
  */
 class ActiveAnnotationContextProvider {
 	static val logger = Logger.getLogger(ActiveAnnotationContextProvider)
@@ -161,7 +162,7 @@ class ActiveAnnotationContextProvider {
 	/**
 	 * recursively looks for macro annotations on XtendAnnotationTargets 
 	 */
-	def private void searchAnnotatedElements(EObject element, IAcceptor<Pair<JvmAnnotationType, XAnnotation>> acceptor) {
+	def protected void searchAnnotatedElements(EObject element, IAcceptor<Pair<JvmAnnotationType, XAnnotation>> acceptor) {
 		switch element {
 			XtendFile : {
 				element.xtendTypes.forEach [
@@ -210,7 +211,7 @@ class ActiveAnnotationContextProvider {
 		}
 	}
 	
-	def private void registerMacroAnnotations(XtendAnnotationTarget candidate, IAcceptor<Pair<JvmAnnotationType, XAnnotation>> acceptor) {
+	def protected void registerMacroAnnotations(XtendAnnotationTarget candidate, IAcceptor<Pair<JvmAnnotationType, XAnnotation>> acceptor) {
 		for (annotation : candidate.annotations.filter[ processed ]) {
 			val activeAnnotationDeclaration = annotation.tryFindAnnotationType
 			if (activeAnnotationDeclaration !== null) {

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ActiveAnnotationContextProvider.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ActiveAnnotationContextProvider.java
@@ -50,6 +50,7 @@ import org.eclipse.xtext.xbase.lib.Pair;
 
 /**
  * @author Sven Efftinge
+ * @author Stephane Galland
  */
 @SuppressWarnings("all")
 public class ActiveAnnotationContextProvider {
@@ -159,7 +160,7 @@ public class ActiveAnnotationContextProvider {
   /**
    * recursively looks for macro annotations on XtendAnnotationTargets
    */
-  private void searchAnnotatedElements(final EObject element, final IAcceptor<Pair<JvmAnnotationType, XAnnotation>> acceptor) {
+  protected void searchAnnotatedElements(final EObject element, final IAcceptor<Pair<JvmAnnotationType, XAnnotation>> acceptor) {
     boolean _matched = false;
     if (element instanceof XtendFile) {
       _matched=true;
@@ -236,7 +237,7 @@ public class ActiveAnnotationContextProvider {
     }
   }
   
-  private void registerMacroAnnotations(final XtendAnnotationTarget candidate, final IAcceptor<Pair<JvmAnnotationType, XAnnotation>> acceptor) {
+  protected void registerMacroAnnotations(final XtendAnnotationTarget candidate, final IAcceptor<Pair<JvmAnnotationType, XAnnotation>> acceptor) {
     final Function1<XAnnotation, Boolean> _function = (XAnnotation it) -> {
       return Boolean.valueOf(this._xAnnotationExtensions.isProcessed(it));
     };


### PR DESCRIPTION
This Pr enables to create subclasses of `ActiveAnnotationContextProvider`.

Signed-off-by: Stéphane Galland <galland@arakhne.org>