### PR TITLE
[#656] Improve unnecessary modifier warning message on extension fields.

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/ModifierValidationTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/ModifierValidationTest.xtend
@@ -175,8 +175,9 @@ class ModifierValidationTest extends AbstractXtendTestCase {
 		field('''final volatile int foo = 42''').assertError(XTEND_FIELD, INVALID_MODIFIER)
 		field('''volatile transient int foo''').assertNoErrors
 		field('''private transient volatile int foo''').assertNoErrors
-		field('''private int foo''').assertWarning(XTEND_FIELD, UNNECESSARY_MODIFIER)
-		field('''private val foo=42''').assertWarning(XTEND_FIELD, UNNECESSARY_MODIFIER)
+		field('''private int foo''').assertWarning(XTEND_FIELD, UNNECESSARY_MODIFIER, "The private modifier is unnecessary on field foo")
+		field('''private val foo=42''').assertWarning(XTEND_FIELD, UNNECESSARY_MODIFIER, "The private modifier is unnecessary on field foo")
+		field('''private extension Object''').assertWarning(XTEND_FIELD, UNNECESSARY_MODIFIER, "The private modifier is unnecessary on extension field Object")
 	}
 	
 	@Test def void testFieldInInterfaceAllowedModifiers() {

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/ModifierValidationTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/ModifierValidationTest.java
@@ -472,10 +472,13 @@ public class ModifierValidationTest extends AbstractXtendTestCase {
       this._validationTestHelper.assertNoErrors(this.field(_builder_11.toString()));
       StringConcatenation _builder_12 = new StringConcatenation();
       _builder_12.append("private int foo");
-      this._validationTestHelper.assertWarning(this.field(_builder_12.toString()), XtendPackage.Literals.XTEND_FIELD, IssueCodes.UNNECESSARY_MODIFIER);
+      this._validationTestHelper.assertWarning(this.field(_builder_12.toString()), XtendPackage.Literals.XTEND_FIELD, IssueCodes.UNNECESSARY_MODIFIER, "The private modifier is unnecessary on field foo");
       StringConcatenation _builder_13 = new StringConcatenation();
       _builder_13.append("private val foo=42");
-      this._validationTestHelper.assertWarning(this.field(_builder_13.toString()), XtendPackage.Literals.XTEND_FIELD, IssueCodes.UNNECESSARY_MODIFIER);
+      this._validationTestHelper.assertWarning(this.field(_builder_13.toString()), XtendPackage.Literals.XTEND_FIELD, IssueCodes.UNNECESSARY_MODIFIER, "The private modifier is unnecessary on field foo");
+      StringConcatenation _builder_14 = new StringConcatenation();
+      _builder_14.append("private extension Object");
+      this._validationTestHelper.assertWarning(this.field(_builder_14.toString()), XtendPackage.Literals.XTEND_FIELD, IssueCodes.UNNECESSARY_MODIFIER, "The private modifier is unnecessary on extension field Object");
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendValidator.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendValidator.java
@@ -2068,10 +2068,29 @@ public class XtendValidator extends XbaseWithAnnotationsValidator {
 			if (field.isFinal() && field.isVolatile()) {
 				error("The field " + field.getName() + " can be either final or volatile, not both.", XTEND_FIELD__NAME, -1, INVALID_MODIFIER);
 			}
-			fieldModifierValidator.checkModifiers(field, "field " + field.getName());
+			fieldModifierValidator.checkModifiers(field, getMemberName(field));
 		}
 		else if(declaringType instanceof XtendInterface || declaringType instanceof XtendAnnotationType)
 			fieldInInterfaceModifierValidator.checkModifiers(field,  "field " + field.getName());
+	}
+	
+	protected String getMemberName(XtendField field) {
+		String memberName = "field " + field.getName();
+		
+		/*
+		 * Determine the member name of an extension field where the field name is not explicitly set.
+		 */
+		if(field.isExtension() && field.getName() == null) {
+			JvmField jvmField = associations.getJvmField(field);
+			if(jvmField != null) {
+				LightweightTypeReference type = getActualType(jvmField);
+				if(type != null) {
+					memberName = "extension field " + type.getHumanReadableName();
+				}
+			}
+		}
+		
+		return memberName;
 	}
 	
 	@Check


### PR DESCRIPTION
- Modifiy the Xtend ModifierValidator to provide a more meaningful
warning message in case of extension fields where the field name is not
set.
- Implement corresponding ModifierValidationTest test cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>