### PR TITLE
[#688] Simplify IT tests

### DIFF
--- a/1-gradle-build.sh
+++ b/1-gradle-build.sh
@@ -1,0 +1,14 @@
+if [ -z "$JENKINS_URL" ]; then
+  # if not set in environment use default
+  JENKINS_URL=https://ci.eclipse.org/xtext/
+fi
+
+./gradlew \
+  clean cleanGenerateXtext build createLocalMavenRepo \
+  -PuseJenkinsSnapshots=true \
+  -PJENKINS_URL=$JENKINS_URL \
+  -PcompileXtend=true \
+  -PignoreTestFailures=true \
+  --refresh-dependencies \
+  --continue \
+  $@

--- a/2-maven-build.sh
+++ b/2-maven-build.sh
@@ -1,0 +1,25 @@
+if [ -z "$JENKINS_URL" ]; then
+  # if not set in environment use default
+  JENKINS_URL=https://ci.eclipse.org/xtext/
+fi
+if [ -z "$WORKSPACE" ]; then
+  # if not set in environment use default
+  WORKSPACE=$(pwd)
+fi
+
+mvn \
+  -f maven-pom.xml \
+  --batch-mode \
+  --update-snapshots \
+  -fae \
+  -PuseJenkinsSnapshots \
+  -DJENKINS_URL=$JENKINS_URL \
+  -DWORKSPACE=$WORKSPACE \
+  -Dmaven.test.failure.ignore=true \
+  -Dit-archetype-tests-skip=true \
+  -Dmaven.repo.local=$WORKSPACE/.m2/repository \
+  -DgradleMavenRepo=file:${WORKSPACE}/build/maven-repository/ \
+  -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+  -Dmaven.javadoc.skip=true \
+  deploy \
+  $@

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,7 @@ node {
 	dir('.m2/repository/org/eclipse/xtend') { deleteDir() }
 	
 	stage('Maven Plugin Build') {
-		sh "${mvnHome}/bin/mvn -f maven-pom.xml --batch-mode --update-snapshots -fae -PuseJenkinsSnapshots -DJENKINS_URL=$JENKINS_URL -Dmaven.test.failure.ignore=true -Dit-archetype-tests-skip=true -Dmaven.repo.local=${WORKSPACE}/.m2/repository -DgradleMavenRepo=file:${WORKSPACE}/build/maven-repository/ -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn clean deploy"
+		sh "${mvnHome}/bin/mvn -f maven-pom.xml --batch-mode --update-snapshots -fae -PuseJenkinsSnapshots -DJENKINS_URL=$JENKINS_URL -DWORKSPACE=$WORKSPACE -Dmaven.test.failure.ignore=true -Dit-archetype-tests-skip=true -Dmaven.repo.local=${WORKSPACE}/.m2/repository -DgradleMavenRepo=file:${WORKSPACE}/build/maven-repository/ -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn clean deploy"
 	}
 
 	stage('Maven Tycho Build') {

--- a/org.eclipse.xtend.maven.plugin/src/test/java/org/eclipse/xtend/maven/MavenVerifierUtil.java
+++ b/org.eclipse.xtend.maven.plugin/src/test/java/org/eclipse/xtend/maven/MavenVerifierUtil.java
@@ -32,6 +32,7 @@ public class MavenVerifierUtil {
 		verifier.setSystemProperty("gradleMavenRepo", gradleMavenRepo);
 		
 		verifier.setSystemProperty("nonTestMavenRepo", System.getProperty("maven.repo.local"));
+		verifier.setSystemProperty("WORKSPACE", System.getProperty("WORKSPACE"));
 		
 		String testMavenRepo = System.getProperty("testMavenRepo");
 		Assert.assertNotNull("testMavenRepo is null", testMavenRepo);

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/aggregation/my-module/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/aggregation/my-module/pom.xml
@@ -1,35 +1,20 @@
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.mycompany.app</groupId>
-	<artifactId>my-module</artifactId>
-	<version>1</version>
 	<parent>
 		<groupId>org.eclipse.xtend</groupId>
 		<artifactId>it-tests-parent</artifactId>
 		<version>IT-SNAPSHOT</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
+	<artifactId>my-module</artifactId>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>
-	<dependencies>
-		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-	</dependencies>
 </project>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/aggregation/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/aggregation/pom.xml
@@ -1,15 +1,16 @@
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.mycompany.app</groupId>
-	<artifactId>my-app</artifactId>
-	<version>1</version>
-	<packaging>pom</packaging>
 	<parent>
 		<groupId>org.eclipse.xtend</groupId>
 		<artifactId>it-tests-parent</artifactId>
 		<version>IT-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
+	<groupId>com.mycompany.app</groupId>
+	<artifactId>my-app</artifactId>
+	<packaging>pom</packaging>
 	<modules>
 		<module>my-module</module>
 		<!-- //https://bugs.eclipse.org/bugs/show_bug.cgi?id=409759 -->

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/aggregation/relativeoutput-module/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/aggregation/relativeoutput-module/pom.xml
@@ -1,20 +1,19 @@
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.mycompany.app</groupId>
-	<artifactId>relativeoutput-module</artifactId>
-	<version>1</version>
 	<parent>
 		<groupId>org.eclipse.xtend</groupId>
 		<artifactId>it-tests-parent</artifactId>
 		<version>IT-SNAPSHOT</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
+	<artifactId>relativeoutput-module</artifactId>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
 				<executions>
 					<execution>
 						<goals>
@@ -29,11 +28,4 @@
 			</plugin>
 		</plugins>
 	</build>
-	<dependencies>
-		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-	</dependencies>
 </project>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/encoding/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/encoding/pom.xml
@@ -1,40 +1,23 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.xtend</groupId>
-	<artifactId>simple</artifactId>
-	<version>2.2.1-SNAPSHOT</version>
 	<parent>
 		<groupId>org.eclipse.xtend</groupId>
 		<artifactId>it-tests-parent</artifactId>
 		<version>IT-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
+	<artifactId>simple</artifactId>
 	<properties>
 		<project.build.sourceEncoding>UTF-16</project.build.sourceEncoding>
 	</properties>
-
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>
-	<dependencies>
-		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-	</dependencies>
 </project>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/filesystemaccess-client/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/filesystemaccess-client/pom.xml
@@ -1,42 +1,27 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.xtend</groupId>
+	<parent>
+		<groupId>org.eclipse.xtend</groupId>
+		<artifactId>it-tests-parent</artifactId>
+		<version>IT-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 	<artifactId>filesystemaccess-client</artifactId>
-	<version>IT-SNAPSHOT</version>
-    <parent>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>it-tests-parent</artifactId>
-        <version>IT-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
-
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>
 	<dependencies>
 		<dependency>
 			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
 			<artifactId>filesystemaccess</artifactId>
-			<version>IT-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/filesystemaccess/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/filesystemaccess/pom.xml
@@ -1,49 +1,26 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.xtend</groupId>
+	<parent>
+		<groupId>org.eclipse.xtend</groupId>
+		<artifactId>it-tests-parent</artifactId>
+		<version>IT-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 	<artifactId>filesystemaccess</artifactId>
-	<version>IT-SNAPSHOT</version>
-    <parent>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>it-tests-parent</artifactId>
-        <version>IT-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
-
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-					</execution>
-				</executions>
-				<dependencies>
-					<dependency>
-						<groupId>org.eclipse.xtend</groupId>
-						<artifactId>org.eclipse.xtend.lib</artifactId>
-						<version>[2.4.9,)</version>
-					</dependency>
-				</dependencies>
 			</plugin>
 		</plugins>
 	</build>
 	<dependencies>
 		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.8.1</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/macros/client/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/macros/client/pom.xml
@@ -1,40 +1,27 @@
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.mycompany.app</groupId>
-	<artifactId>client</artifactId>
-	<version>1</version>
 	<parent>
 		<relativePath>../pom.xml</relativePath>
 		<groupId>com.mycompany.app</groupId>
 		<artifactId>macros</artifactId>
-		<version>1</version>
+		<version>IT-SNAPSHOT</version>
 	</parent>
+	<artifactId>client</artifactId>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>
 	<dependencies>
 		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-		<dependency>
 			<groupId>com.mycompany.app</groupId>
 			<artifactId>lib</artifactId>
-			<version>1</version>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/macros/lib/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/macros/lib/pom.xml
@@ -1,35 +1,20 @@
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.mycompany.app</groupId>
-	<artifactId>lib</artifactId>
-	<version>1</version>
 	<parent>
 		<relativePath>../pom.xml</relativePath>
 		<groupId>com.mycompany.app</groupId>
 		<artifactId>macros</artifactId>
-		<version>1</version>
+		<version>IT-SNAPSHOT</version>
 	</parent>
+	<artifactId>lib</artifactId>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>
-	<dependencies>
-		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-	</dependencies>
 </project>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/macros/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/macros/pom.xml
@@ -1,15 +1,16 @@
-<project>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.xtend</groupId>
+		<artifactId>it-tests-parent</artifactId>
+		<version>IT-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 	<groupId>com.mycompany.app</groupId>
 	<artifactId>macros</artifactId>
-	<version>1</version>
 	<packaging>pom</packaging>
-    <parent>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>it-tests-parent</artifactId>
-        <version>IT-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
 
 	<modules>
 		<module>lib</module>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/multisources/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/multisources/pom.xml
@@ -1,15 +1,14 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.xtend</groupId>
+	<parent>
+		<groupId>org.eclipse.xtend</groupId>
+		<artifactId>it-tests-parent</artifactId>
+		<version>IT-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 	<artifactId>multisources</artifactId>
-	<version>2.2.1-SNAPSHOT</version>
-    <parent>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>it-tests-parent</artifactId>
-        <version>IT-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
 	<build>
 		<plugins>
 			<plugin>
@@ -45,7 +44,6 @@
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
 				<executions>
 					<execution>
 						<goals>
@@ -59,14 +57,8 @@
 	</build>
 	<dependencies>
 		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.8.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/simple/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/simple/pom.xml
@@ -1,36 +1,20 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.xtend</groupId>
+	<parent>
+		<groupId>org.eclipse.xtend</groupId>
+		<artifactId>it-tests-parent</artifactId>
+		<version>IT-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 	<artifactId>simple</artifactId>
-	<version>2.2.1-SNAPSHOT</version>
-    <parent>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>it-tests-parent</artifactId>
-        <version>IT-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>
-	<dependencies>
-		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-	</dependencies>
 </project>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/suppress_warnings_annotation/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/suppress_warnings_annotation/pom.xml
@@ -1,21 +1,19 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.xtend</groupId>
+	<parent>
+		<groupId>org.eclipse.xtend</groupId>
+		<artifactId>it-tests-parent</artifactId>
+		<version>IT-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 	<artifactId>simple</artifactId>
-	<version>2.2.1-SNAPSHOT</version>
-    <parent>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>it-tests-parent</artifactId>
-        <version>IT-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
 				<configuration>
 					<generateSyntheticSuppressWarnings>false</generateSyntheticSuppressWarnings>
 				</configuration>
@@ -30,11 +28,4 @@
 			</plugin>
 		</plugins>
 	</build>
-	<dependencies>
-		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-	</dependencies>
 </project>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/symlinks/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/symlinks/pom.xml
@@ -1,15 +1,14 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.xtend</groupId>
+	<parent>
+		<groupId>org.eclipse.xtend</groupId>
+		<artifactId>it-tests-parent</artifactId>
+		<version>IT-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 	<artifactId>symlinks</artifactId>
-	<version>2.2.1-SNAPSHOT</version>
-    <parent>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>it-tests-parent</artifactId>
-        <version>IT-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
 	<build>
 		<plugins>
 			<plugin>
@@ -45,7 +44,6 @@
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
 				<executions>
 					<execution>
 						<goals>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/trace_disabled/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/trace_disabled/pom.xml
@@ -1,39 +1,23 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.xtend</groupId>
+	<parent>
+		<groupId>org.eclipse.xtend</groupId>
+		<artifactId>it-tests-parent</artifactId>
+		<version>IT-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 	<artifactId>trace_enabled</artifactId>
-	<version>2.2.1-SNAPSHOT</version>
-    <parent>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>it-tests-parent</artifactId>
-        <version>IT-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
 				<configuration>
 					<writeTraceFiles>false</writeTraceFiles>
 				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>
-	<dependencies>
-		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-	</dependencies>
 </project>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/trace_enabled/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/trace_enabled/pom.xml
@@ -1,36 +1,20 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.xtend</groupId>
+	<parent>
+		<groupId>org.eclipse.xtend</groupId>
+		<artifactId>it-tests-parent</artifactId>
+		<version>IT-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 	<artifactId>trace_enabled</artifactId>
-	<version>2.2.1-SNAPSHOT</version>
-    <parent>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>it-tests-parent</artifactId>
-        <version>IT-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>
-	<dependencies>
-		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-	</dependencies>
 </project>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/trace_withtestsrc/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/trace_withtestsrc/pom.xml
@@ -1,21 +1,19 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.xtend</groupId>
+	<parent>
+		<groupId>org.eclipse.xtend</groupId>
+		<artifactId>it-tests-parent</artifactId>
+		<version>IT-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 	<artifactId>simpletest</artifactId>
-	<version>IT-SNAPSHOT</version>
-    <parent>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>it-tests-parent</artifactId>
-        <version>IT-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
 				<executions>
 					<execution>
 						<goals>
@@ -29,14 +27,8 @@
 	</build>
 	<dependencies>
 		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.8.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/withtestsrc/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/withtestsrc/pom.xml
@@ -1,21 +1,19 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.xtend</groupId>
+	<parent>
+		<groupId>org.eclipse.xtend</groupId>
+		<artifactId>it-tests-parent</artifactId>
+		<version>IT-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 	<artifactId>simpletest</artifactId>
-	<version>IT-SNAPSHOT</version>
-    <parent>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>it-tests-parent</artifactId>
-        <version>IT-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
 				<executions>
 					<execution>
 						<goals>
@@ -29,14 +27,8 @@
 	</build>
 	<dependencies>
 		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.8.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/xtend-prefs-unused/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/xtend-prefs-unused/pom.xml
@@ -1,21 +1,19 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.xtend</groupId>
+	<parent>
+		<groupId>org.eclipse.xtend</groupId>
+		<artifactId>it-tests-parent</artifactId>
+		<version>IT-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 	<artifactId>xtend-prefs-unused</artifactId>
-	<version>2.2.1-SNAPSHOT</version>
-    <parent>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>it-tests-parent</artifactId>
-        <version>IT-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
 				<executions>
 					<execution>
 						<goals>
@@ -31,11 +29,4 @@
 			</plugin>
 		</plugins>
 	</build>
-	<dependencies>
-		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-	</dependencies>
 </project>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/xtend-prefs/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/xtend-prefs/pom.xml
@@ -1,21 +1,19 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.xtend</groupId>
+	<parent>
+		<groupId>org.eclipse.xtend</groupId>
+		<artifactId>it-tests-parent</artifactId>
+		<version>IT-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 	<artifactId>xtend-prefs</artifactId>
-	<version>2.2.1-SNAPSHOT</version>
-    <parent>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>it-tests-parent</artifactId>
-        <version>IT-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
 				<executions>
 					<execution>
 						<goals>
@@ -27,11 +25,4 @@
 			</plugin>
 		</plugins>
 	</build>
-	<dependencies>
-		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-	</dependencies>
 </project>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/xtenderrors/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/xtenderrors/pom.xml
@@ -1,37 +1,20 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.xtend</groupId>
+	<parent>
+		<groupId>org.eclipse.xtend</groupId>
+		<artifactId>it-tests-parent</artifactId>
+		<version>IT-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 	<artifactId>simple</artifactId>
-	<version>2.2.1-SNAPSHOT</version>
-    <parent>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>it-tests-parent</artifactId>
-        <version>IT-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
-		
 	</build>
-	<dependencies>
-		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-	</dependencies>
 </project>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/xtendwarnings/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/compile/xtendwarnings/pom.xml
@@ -1,36 +1,20 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.xtend</groupId>
+	<parent>
+		<groupId>org.eclipse.xtend</groupId>
+		<artifactId>it-tests-parent</artifactId>
+		<version>IT-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 	<artifactId>simple</artifactId>
-	<version>2.2.1-SNAPSHOT</version>
-    <parent>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>it-tests-parent</artifactId>
-        <version>IT-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>
-	<dependencies>
-		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-	</dependencies>
 </project>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/install_debug_info/simple_smap/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/install_debug_info/simple_smap/pom.xml
@@ -1,21 +1,19 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.xtend</groupId>
+	<parent>
+		<groupId>org.eclipse.xtend</groupId>
+		<artifactId>it-tests-parent</artifactId>
+		<version>IT-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 	<artifactId>simple</artifactId>
-	<version>2.2.1-SNAPSHOT</version>
-    <parent>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>it-tests-parent</artifactId>
-        <version>IT-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
 				<configuration>
 					<javaSourceVersion>1.5</javaSourceVersion>
 				</configuration>
@@ -30,11 +28,4 @@
 			</plugin>
 		</plugins>
 	</build>
-	<dependencies>
-		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-	</dependencies>
 </project>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/install_debug_info/smap_multisource/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/install_debug_info/smap_multisource/pom.xml
@@ -1,15 +1,14 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.xtend</groupId>
+	<parent>
+		<groupId>org.eclipse.xtend</groupId>
+		<artifactId>it-tests-parent</artifactId>
+		<version>IT-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 	<artifactId>smap_multisources</artifactId>
-	<version>2.2.1-SNAPSHOT</version>
-    <parent>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>it-tests-parent</artifactId>
-        <version>IT-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
 	<build>
 		<plugins>
 			<plugin>
@@ -45,7 +44,6 @@
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
 				<executions>
 					<execution>
 						<goals>
@@ -61,14 +59,8 @@
 	</build>
 	<dependencies>
 		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.8.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/install_debug_info/xtend_as_primary/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/install_debug_info/xtend_as_primary/pom.xml
@@ -1,21 +1,19 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.xtend</groupId>
 	<artifactId>simple</artifactId>
-	<version>2.2.1-SNAPSHOT</version>
-    <parent>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>it-tests-parent</artifactId>
-        <version>IT-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
+	<parent>
+		<groupId>org.eclipse.xtend</groupId>
+		<artifactId>it-tests-parent</artifactId>
+		<version>IT-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
 				<configuration>
 					<xtendAsPrimaryDebugSource>true</xtendAsPrimaryDebugSource>
 				</configuration>
@@ -30,11 +28,4 @@
 			</plugin>
 		</plugins>
 	</build>
-	<dependencies>
-		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-	</dependencies>
 </project>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/install_debug_info/xtend_as_primary_with_synthetic_vars/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/install_debug_info/xtend_as_primary_with_synthetic_vars/pom.xml
@@ -1,21 +1,19 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.xtend</groupId>
 	<artifactId>simple</artifactId>
-	<version>2.2.1-SNAPSHOT</version>
-    <parent>
-        <groupId>org.eclipse.xtend</groupId>
-        <artifactId>it-tests-parent</artifactId>
-        <version>IT-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
+	<parent>
+		<groupId>org.eclipse.xtend</groupId>
+		<artifactId>it-tests-parent</artifactId>
+		<version>IT-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>IT-SNAPSHOT</version>
 				<configuration>
 					<xtendAsPrimaryDebugSource>true</xtendAsPrimaryDebugSource>
 					<hideSyntheticVariables>false</hideSyntheticVariables>
@@ -31,11 +29,4 @@
 			</plugin>
 		</plugins>
 	</build>
-	<dependencies>
-		<dependency>
-			<groupId>org.eclipse.xtend</groupId>
-			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>[2.4.9,)</version>
-		</dependency>
-	</dependencies>
 </project>

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/pom.xml
@@ -5,6 +5,36 @@
 	<artifactId>it-tests-parent</artifactId>
 	<version>IT-SNAPSHOT</version>
 	<packaging>pom</packaging>
+	<properties>
+		<maven.compiler.source>1.6</maven.compiler.source>
+		<maven.compiler.target>1.6</maven.compiler.target>
+		<xtextVersion>2.17.0-SNAPSHOT</xtextVersion>
+		<!-- The BOM version can be rather fixed for the test projects -->
+		<xtextBOMVersion>2.17.0.M1</xtextBOMVersion>
+	</properties>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>21.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.xtext</groupId>
+				<artifactId>xtext-dev-bom</artifactId>
+				<version>${xtextBOMVersion}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+	<dependencies>
+		<dependency>
+			<groupId>org.eclipse.xtend</groupId>
+			<artifactId>org.eclipse.xtend.lib</artifactId>
+			<version>${xtextVersion}</version>
+		</dependency>
+	</dependencies>
 	<pluginRepositories>
 		<pluginRepository>
 			<id>central</id>
@@ -64,4 +94,23 @@
 			<url>file://${nonTestMavenRepo}</url>
 		</repository>
 	</repositories>
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.eclipse.xtend</groupId>
+					<artifactId>xtend-maven-plugin</artifactId>
+					<version>IT-SNAPSHOT</version>
+					<executions>
+						<execution>
+							<goals>
+								<goal>compile</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+	
 </project>


### PR DESCRIPTION
Moved common configuration to it-tests-parent
  - dependency management with BOM
  - dependency org.eclipse.xtend.lib
  - plugin management of xtend-maven-plugin
  - all projects have version 'IT-SNAPSHOT' now
  - removed redundant `groupId` and `version` data inherited from parent
  - pass `WORKSPACE` environment variable as system arg to surefire tests to resolve the local repo using this variable
Add shell scripts for convenient local execution

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>