### PR TITLE
[eclipse/xtext#1394] bootstrap against 2.17.0.M2

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -6,7 +6,7 @@ version = '2.17.0-SNAPSHOT'
 
 ext.versions = [
 	'xtext': version,
-	'xtext_bootstrap': '2.17.0.M1',
+	'xtext_bootstrap': '2.17.0.M2',
 	'xtext_gradle_plugin': '2.0.2',
 	'dependency_management_plugin' : '1.0.6.RELEASE',
 	'ant': '[1.7,2)',

--- a/org.eclipse.xtend.maven.plugin/src/test/resources/it/pom.xml
+++ b/org.eclipse.xtend.maven.plugin/src/test/resources/it/pom.xml
@@ -10,7 +10,7 @@
 		<maven.compiler.target>1.6</maven.compiler.target>
 		<xtextVersion>2.17.0-SNAPSHOT</xtextVersion>
 		<!-- The BOM version can be rather fixed for the test projects -->
-		<xtextBOMVersion>2.17.0.M1</xtextBOMVersion>
+		<xtextBOMVersion>2.17.0.M2</xtextBOMVersion>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/releng/org.eclipse.xtend.tycho.parent/pom.xml
+++ b/releng/org.eclipse.xtend.tycho.parent/pom.xml
@@ -10,7 +10,7 @@
 	<properties>
 		<tycho-version>1.3.0</tycho-version>
 		<!-- version of the "bootstrap" plugin; used to compile xtend sources in xtend -->
-		<xtend-maven-plugin-version>2.17.0.M1</xtend-maven-plugin-version>
+		<xtend-maven-plugin-version>2.17.0.M2</xtend-maven-plugin-version>
 		<project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>ISO-8859-1</project.reporting.outputEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
[eclipse/xtext#1394] bootstrap against 2.17.0.M2
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>