### PR TITLE
[eclipse/xtext#1283] update to MWE 2.10

### DIFF
--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-latest.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-latest.target
@@ -109,7 +109,7 @@
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 		<unit id="org.eclipse.emf.mwe2.lib" version="0.0.0"/>
 		<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
-		<repository location="http://download.eclipse.org/modeling/emft/mwe/updates/milestones/S201901281525/"/>
+		<repository location="http://download.eclipse.org/modeling/emft/mwe/updates/releases/2.10.0/"/>
 	</location>
 	
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">


### PR DESCRIPTION
[eclipse/xtext#1283] update to MWE 2.10
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>

to not merge before MWE 2.10 is out