### PR TITLE
[eclipse/xtext-xtend#415] use textual multi quickfix for remove unnec modifier

### DIFF
--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
@@ -4237,8 +4237,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 		.assertIssueCodes(UNNECESSARY_MODIFIER)
 		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix(
-			// TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
-			''' class Foo {}
+			'''class Foo {}
 		''')
 	}
 	
@@ -4253,8 +4252,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
 			package a
-«««			TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
-			 class Foo {}
+			class Foo {}
 		''')
 	}
 	
@@ -4271,8 +4269,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 		.assertModelAfterQuickfix('''
 			package a
 			class A {}
-«««			TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
-			 class B {}
+			class B {}
 		''')
 	}
 	
@@ -4540,7 +4537,6 @@ class QuickfixTest extends AbstractXtendUITestCase {
 		''')
 	}
 	
-	@Ignore("Javadoc will be not preserved after applying the quickfix")
 	@Test
 	def void unnecessaryModifier_17(){
 		// Xtend class with javadoc having a 'public' modifier
@@ -4556,12 +4552,10 @@ class QuickfixTest extends AbstractXtendUITestCase {
 			/**
 			 * javadoc
 			 */
-«««TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
-			 class Foo {}
+			class Foo {}
 		''')
 	}
 	
-	@Ignore("Javadoc will be not preserved after applying the quickfix")
 	@Test
 	def void unnecessaryModifier_18(){
 		// Xtend class with javadoc having a 'public' modifier
@@ -4581,12 +4575,10 @@ class QuickfixTest extends AbstractXtendUITestCase {
 			/**
 			 * javadoc
 			 */
-«««			TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
-			 class Foo {}
+			class Foo {}
 		''')
 	}
 	
-	@Ignore("Javadoc will be not preserved after applying the quickfix")
 	@Test
 	def void unnecessaryModifier_19(){
 		// Xtend class with javadoc having a 'public' modifier
@@ -4608,12 +4600,10 @@ class QuickfixTest extends AbstractXtendUITestCase {
 			/**
 			 * javadoc
 			 */
-«««			TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
-			 class B {}
+			class B {}
 		''')
 	}
 	
-	@Ignore("Javadoc will be not preserved after applying the quickfix")
 	@Test
 	def void unnecessaryModifier_20(){
 		// Xtend field with javadoc having a 'private' modifier
@@ -4891,7 +4881,6 @@ class QuickfixTest extends AbstractXtendUITestCase {
 		''')
 	}
 	
-	@Ignore("Javadoc will be not preserved after applying the quickfix")
 	@Test
 	def void unnecessaryModifier_31(){
 		// Xtend extension field without name with javadoc having a 'private' modifier
@@ -5089,7 +5078,6 @@ class QuickfixTest extends AbstractXtendUITestCase {
 		''')
 	}
 	
-	@Ignore("Javadoc will be not preserved after applying the quickfix")
 	@Test
 	def void unnecessaryModifier_37(){
 		// Xtend field in anonymous class with javadoc having 'private' modifier
@@ -5210,8 +5198,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 		.assertIssueCodes(UNNECESSARY_MODIFIER)
 		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix(
-// TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
-		''' interface Foo {}
+		'''interface Foo {}
 		''')
 	}
 	
@@ -5226,8 +5213,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 		.assertIssueCodes(UNNECESSARY_MODIFIER)
 		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
-««« TODO: improve formatting after Quickfix application
-			class Foo { new(){}
+			class Foo {
+				new(){}
 			}
 		''')
 	}
@@ -5245,8 +5232,8 @@ class QuickfixTest extends AbstractXtendUITestCase {
 		.assertIssueCodes(UNNECESSARY_MODIFIER)
 		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
-««« TODO: improve formatting after Quickfix application
-			class Foo { interface Bar {
+			class Foo {
+				interface Bar {
 					def m() {}
 				}
 			}
@@ -5282,8 +5269,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 		.assertIssueCodes(UNNECESSARY_MODIFIER)
 		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
-««« TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
-			 annotation Foo {
+			annotation Foo {
 			}
 		''')
 	}
@@ -5298,8 +5284,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 		.assertIssueCodes(UNNECESSARY_MODIFIER)
 		.assertResolutionLabels("Remove the unnecessary modifier.")
 		.assertModelAfterQuickfix('''
-««« TODO: check why the whitespace after the 'public' modifier will not be removed by the quickfix
-			 enum Foo {
+			enum Foo {
 			}
 		''')
 	}
@@ -5331,7 +5316,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 					val e = «tripleQuotes»
 						«ifLiteral»
 							a
-						
+			
 							b
 						«endifLiteral»
 					«tripleQuotes»

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
@@ -7687,7 +7687,6 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append(" ");
     _builder_1.append("class Foo {}");
     _builder_1.newLine();
     _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
@@ -7704,7 +7703,6 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("package a");
     _builder_1.newLine();
-    _builder_1.append(" ");
     _builder_1.append("class Foo {}");
     _builder_1.newLine();
     _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
@@ -7725,7 +7723,6 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder_1.newLine();
     _builder_1.append("class A {}");
     _builder_1.newLine();
-    _builder_1.append(" ");
     _builder_1.append("class B {}");
     _builder_1.newLine();
     _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
@@ -8115,7 +8112,6 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
   }
   
-  @Ignore("Javadoc will be not preserved after applying the quickfix")
   @Test
   public void unnecessaryModifier_17() {
     StringConcatenation _builder = new StringConcatenation();
@@ -8139,13 +8135,11 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder_1.append(" ");
     _builder_1.append("*/");
     _builder_1.newLine();
-    _builder_1.append(" ");
     _builder_1.append("class Foo {}");
     _builder_1.newLine();
     _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
   }
   
-  @Ignore("Javadoc will be not preserved after applying the quickfix")
   @Test
   public void unnecessaryModifier_18() {
     StringConcatenation _builder = new StringConcatenation();
@@ -8175,13 +8169,11 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder_1.append(" ");
     _builder_1.append("*/");
     _builder_1.newLine();
-    _builder_1.append(" ");
     _builder_1.append("class Foo {}");
     _builder_1.newLine();
     _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
   }
   
-  @Ignore("Javadoc will be not preserved after applying the quickfix")
   @Test
   public void unnecessaryModifier_19() {
     StringConcatenation _builder = new StringConcatenation();
@@ -8215,13 +8207,11 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder_1.append(" ");
     _builder_1.append("*/");
     _builder_1.newLine();
-    _builder_1.append(" ");
     _builder_1.append("class B {}");
     _builder_1.newLine();
     _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
   }
   
-  @Ignore("Javadoc will be not preserved after applying the quickfix")
   @Test
   public void unnecessaryModifier_20() {
     StringConcatenation _builder = new StringConcatenation();
@@ -8718,7 +8708,6 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
   }
   
-  @Ignore("Javadoc will be not preserved after applying the quickfix")
   @Test
   public void unnecessaryModifier_31() {
     StringConcatenation _builder = new StringConcatenation();
@@ -9113,7 +9102,6 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
   }
   
-  @Ignore("Javadoc will be not preserved after applying the quickfix")
   @Test
   public void unnecessaryModifier_37() {
     StringConcatenation _builder = new StringConcatenation();
@@ -9355,7 +9343,6 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append(" ");
     _builder_1.append("interface Foo {}");
     _builder_1.newLine();
     _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
@@ -9373,7 +9360,10 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("class Foo { new(){}");
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("new(){}");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
@@ -9398,7 +9388,10 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("class Foo { interface Bar {");
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("interface Bar {");
     _builder_1.newLine();
     _builder_1.append("\t\t");
     _builder_1.append("def m() {}");
@@ -9448,7 +9441,6 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append(" ");
     _builder_1.append("annotation Foo {");
     _builder_1.newLine();
     _builder_1.append("}");
@@ -9465,7 +9457,6 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.newLine();
     QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNNECESSARY_MODIFIER).assertResolutionLabels("Remove the unnecessary modifier.");
     StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append(" ");
     _builder_1.append("enum Foo {");
     _builder_1.newLine();
     _builder_1.append("}");
@@ -9526,7 +9517,6 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder_1.append("\t\t\t\t");
     _builder_1.append("a");
     _builder_1.newLine();
-    _builder_1.append("\t\t\t");
     _builder_1.newLine();
     _builder_1.append("\t\t\t\t");
     _builder_1.append("b");


### PR DESCRIPTION
[eclipse/xtext#2306] use textual multi quickfix for remove unnec modifier

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>