### PR TITLE
Solution Issue #719

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/ValidationIssue719Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/validation/ValidationIssue719Test.xtend
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.core.tests.validation
+
+import com.google.inject.Inject
+import org.eclipse.xtend.core.tests.AbstractXtendTestCase
+import org.eclipse.xtend.core.xtend.XtendFile
+import org.eclipse.xtext.testing.util.ParseHelper
+import org.eclipse.xtext.testing.validation.ValidationTestHelper
+import org.junit.Test
+
+import static org.eclipse.xtend.core.validation.IssueCodes.*
+import static org.eclipse.xtend.core.xtend.XtendPackage.Literals.*
+
+/**
+ * @author Eva Poell - Initial contribution
+ */
+class ValidationIssue719Test extends AbstractXtendTestCase {
+	@Inject extension ValidationTestHelper
+	@Inject extension ParseHelper<XtendFile>
+
+	@Test
+	def void namedAndDeclaredAbstract() {
+		'''
+			abstract class AbstractC {
+			}
+		'''.parse.assertNoIssues
+	}
+
+	@Test
+	def void namedAndNotDeclaredAbstract() {
+		'''
+			class AbstractC {
+			}
+		'''.warn()
+	}
+
+	@Test
+	def void namedAndNotDeclaredAbstractPackage() {
+		'''
+			package class AbstractC {
+			}
+		'''.warn()
+	}
+
+	@Test
+	def void namedAndNotDeclaredAbstractFinal() {
+		'''
+			final class AbstractC {
+			}
+		'''.warn()
+	}
+	
+	@Test
+	def void namedAndNotDeclaredAbstractAnnotation() {
+		'''
+			@Depreciated
+			class AbstractX{
+			}
+		'''.warn()
+	}
+	
+	@Test
+	def void namedAndNotDeclaredAbstractJavaDoc() {
+		'''
+			/**
+			 * This is a doc for this abstract class.
+			 * It even has two lines.
+			 */
+			class AbstractX{
+			}
+		'''.warn()
+	}
+	
+	def private warn(CharSequence input) {
+		input.parse.assertWarning(XTEND_CLASS, MODIFIER_DOES_NOT_MATCH_TYPENAME, "not declared abstract")
+	}
+}

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/ValidationIssue719Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/validation/ValidationIssue719Test.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.core.tests.validation;
+
+import com.google.inject.Inject;
+import org.eclipse.xtend.core.tests.AbstractXtendTestCase;
+import org.eclipse.xtend.core.validation.IssueCodes;
+import org.eclipse.xtend.core.xtend.XtendFile;
+import org.eclipse.xtend.core.xtend.XtendPackage;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.testing.util.ParseHelper;
+import org.eclipse.xtext.testing.validation.ValidationTestHelper;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.junit.Test;
+
+/**
+ * @author Eva Poell - Initial contribution
+ */
+@SuppressWarnings("all")
+public class ValidationIssue719Test extends AbstractXtendTestCase {
+  @Inject
+  @Extension
+  private ValidationTestHelper _validationTestHelper;
+  
+  @Inject
+  @Extension
+  private ParseHelper<XtendFile> _parseHelper;
+  
+  @Test
+  public void namedAndDeclaredAbstract() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("abstract class AbstractC {");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      this._validationTestHelper.assertNoIssues(this._parseHelper.parse(_builder));
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void namedAndNotDeclaredAbstract() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class AbstractC {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.warn(_builder);
+  }
+  
+  @Test
+  public void namedAndNotDeclaredAbstractPackage() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package class AbstractC {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.warn(_builder);
+  }
+  
+  @Test
+  public void namedAndNotDeclaredAbstractFinal() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("final class AbstractC {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.warn(_builder);
+  }
+  
+  @Test
+  public void namedAndNotDeclaredAbstractAnnotation() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("@Depreciated");
+    _builder.newLine();
+    _builder.append("class AbstractX{");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.warn(_builder);
+  }
+  
+  @Test
+  public void namedAndNotDeclaredAbstractJavaDoc() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* This is a doc for this abstract class.");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* It even has two lines.");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("class AbstractX{");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    this.warn(_builder);
+  }
+  
+  private void warn(final CharSequence input) {
+    try {
+      this._validationTestHelper.assertWarning(this._parseHelper.parse(input), XtendPackage.Literals.XTEND_CLASS, IssueCodes.MODIFIER_DOES_NOT_MATCH_TYPENAME, "not declared abstract");
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+}

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/IssueCodes.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/IssueCodes.java
@@ -88,6 +88,7 @@ public final class IssueCodes {
 	
 	public static final String INVALID_MODIFIER = ISSUE_CODE_PREFIX +  "invalid_modifier";
 	public static final String MISSING_STATIC_MODIFIER = ISSUE_CODE_PREFIX +  "missing_static_modifier";
+	public static final String MODIFIER_DOES_NOT_MATCH_TYPENAME = ISSUE_CODE_PREFIX + "missing_abstract_modifier";
 	
 	public static final String WILDCARD_IN_SUPERTYPE = ISSUE_CODE_PREFIX +  "wildcard_in_supertype";
 

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendConfigurableIssueCodes.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendConfigurableIssueCodes.java
@@ -37,6 +37,7 @@ public class XtendConfigurableIssueCodes extends XbaseConfigurableIssueCodes {
 		iAcceptor.accept(create(IssueCodes.ORPHAN_ELEMENT, SeverityConverter.SEVERITY_IGNORE));
 		iAcceptor.accept(create(IssueCodes.WRONG_FILE, SeverityConverter.SEVERITY_WARNING));
 		iAcceptor.accept(create(IssueCodes.UNNECESSARY_MODIFIER, SeverityConverter.SEVERITY_WARNING));
+		iAcceptor.accept(create(IssueCodes.MODIFIER_DOES_NOT_MATCH_TYPENAME, SeverityConverter.SEVERITY_WARNING));
 		// overwrite xbase default
 		iAcceptor.accept(create(org.eclipse.xtext.validation.IssueCodes.COPY_JAVA_PROBLEMS, SeverityConverter.SEVERITY_ERROR));
 	}

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendValidator.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/validation/XtendValidator.java
@@ -2168,7 +2168,18 @@ public class XtendValidator extends XbaseWithAnnotationsValidator {
 		}
 		return api;
 	}
-	
+
+	@Check
+	protected void checkModifierMatchesTypename(XtendClass xtendClass) {
+		String name = xtendClass.getName();
+		if (name != null) {
+			if (name.startsWith("Abstract") && !xtendClass.isAbstract()) {
+				addIssue("The class" + name + "is not declared abstract.", xtendClass, XTEND_TYPE_DECLARATION__NAME, -1,
+						MODIFIER_DOES_NOT_MATCH_TYPENAME);
+			}
+		}
+	}
+
 	@Check
 	protected void checkImplicitReturn(final XtendFunction method) {
 		if (isIgnored(IMPLICIT_RETURN)) 

--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/ValidationIssue719QuickFixTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/ValidationIssue719QuickFixTest.xtend
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.ide.tests.quickfix
+
+import org.eclipse.xtend.ide.tests.XtendIDEInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractQuickfixTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import static org.eclipse.xtend.core.validation.IssueCodes.MODIFIER_DOES_NOT_MATCH_TYPENAME
+
+import static extension org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil.createJavaProject
+
+/**
+ * @author Eva Poell - Initial contribution
+ */
+@RunWith(XtextRunner)
+@InjectWith(XtendIDEInjectorProvider)
+class ValidationIssue719QuickFixTest extends AbstractQuickfixTest {
+
+	@Before
+	def void setup() {
+		// Xbase-based languages require java project
+		projectName.createJavaProject
+	}
+
+	@Test
+	def void add_abstract_simple() {
+		'''
+			class AbstractSample {
+			}
+		'''.applyFix('''
+			abstract class AbstractSample {
+			}
+		''')
+	}
+
+	@Test
+	def void add_abstract_final_simple() {
+		'''
+			final class AbstractSample {
+			}
+		'''.applyFix('''
+			abstract class AbstractSample {
+			}
+		''')
+	}
+
+	@Test
+	def void add_abstract_package() {
+		'''
+			package class AbstractSample {
+			}
+		'''.applyFix('''
+			package abstract class AbstractSample {
+			}
+		''')
+	}
+
+	@Test
+	def void add_abstract_package_final() {
+		'''
+			package final class AbstractSample {
+			}
+		'''.applyFix('''
+			package abstract class AbstractSample {
+			}
+		''')
+	}
+
+	@Test
+	def void add_abstract_static() {
+		'''
+			static class AbstractSample {
+			}
+		'''.applyFix('''
+			abstract static class AbstractSample {
+			}
+		''')
+	}
+
+	@Test
+	def void add_abstract_nested_classes_outer() {
+		'''
+			class AbstractX{
+				abstract static class AbstractY{
+				}
+			}
+		'''.applyFix('''
+			abstract class AbstractX{
+				abstract static class AbstractY{
+				}
+			}
+		''')
+	}
+
+	@Test
+	def void add_abstract_nested_classes_inner() {
+		'''
+			abstract class AbstractX{
+				class AbstractY{
+				}
+			}
+		'''.applyFix('''
+			abstract class AbstractX{
+				abstract class AbstractY{
+				}
+			}
+		''')
+	}
+
+	@Test
+	def void add_abstract_nested_classes_outer_static() {
+		'''
+			static class AbstractX{
+				class SampleInner{
+				}
+			}
+		'''.applyFix('''
+			abstract static class AbstractX{
+				class SampleInner{
+				}
+			}
+		''')
+	}
+
+	@Test
+	def void add_abstract_annotation() {
+		'''
+			@Depreciated
+			class AbstractX{
+			}
+		'''.applyFix('''
+			@Depreciated
+			abstract class AbstractX{
+			}
+		''')
+	}
+
+	@Test
+	def void add_abstract_javadoc() {
+		'''
+			/**
+			 * This is a doc for this abstract class.
+			 * It even has two lines.
+			 */
+			class AbstractX{
+			}
+		'''.applyFix('''
+			/**
+			 * This is a doc for this abstract class.
+			 * It even has two lines.
+			 */
+			abstract class AbstractX{
+			}
+		''')
+	}
+
+	def private applyFix(CharSequence input, CharSequence result) {
+		val issueCode = MODIFIER_DOES_NOT_MATCH_TYPENAME
+		val fixlabel = "Add missing abstract modifier."
+		val fixdescription = "Add the abstract modifier to match naming conventions for the type name. Delete final modifier if necessary."
+
+		input.testQuickfixesOn(issueCode, new Quickfix(fixlabel, fixdescription, result.toString))
+	}
+}

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/ValidationIssue719QuickFixTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/ValidationIssue719QuickFixTest.java
@@ -1,0 +1,258 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.ide.tests.quickfix;
+
+import org.eclipse.xtend.core.validation.IssueCodes;
+import org.eclipse.xtend.ide.tests.XtendIDEInjectorProvider;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractQuickfixTest;
+import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Eva Poell - Initial contribution
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(XtendIDEInjectorProvider.class)
+@SuppressWarnings("all")
+public class ValidationIssue719QuickFixTest extends AbstractQuickfixTest {
+  @Before
+  public void setup() {
+    try {
+      JavaProjectSetupUtil.createJavaProject(this.getProjectName());
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void add_abstract_simple() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class AbstractSample {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("abstract class AbstractSample {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.applyFix(_builder, _builder_1);
+  }
+  
+  @Test
+  public void add_abstract_final_simple() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("final class AbstractSample {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("abstract class AbstractSample {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.applyFix(_builder, _builder_1);
+  }
+  
+  @Test
+  public void add_abstract_package() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package class AbstractSample {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("package abstract class AbstractSample {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.applyFix(_builder, _builder_1);
+  }
+  
+  @Test
+  public void add_abstract_package_final() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package final class AbstractSample {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("package abstract class AbstractSample {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.applyFix(_builder, _builder_1);
+  }
+  
+  @Test
+  public void add_abstract_static() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("static class AbstractSample {");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("abstract static class AbstractSample {");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.applyFix(_builder, _builder_1);
+  }
+  
+  @Test
+  public void add_abstract_nested_classes_outer() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class AbstractX{");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("abstract static class AbstractY{");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("abstract class AbstractX{");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("abstract static class AbstractY{");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.applyFix(_builder, _builder_1);
+  }
+  
+  @Test
+  public void add_abstract_nested_classes_inner() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("abstract class AbstractX{");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("class AbstractY{");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("abstract class AbstractX{");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("abstract class AbstractY{");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.applyFix(_builder, _builder_1);
+  }
+  
+  @Test
+  public void add_abstract_nested_classes_outer_static() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("static class AbstractX{");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("class SampleInner{");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("abstract static class AbstractX{");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("class SampleInner{");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.applyFix(_builder, _builder_1);
+  }
+  
+  @Test
+  public void add_abstract_annotation() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("@Depreciated");
+    _builder.newLine();
+    _builder.append("class AbstractX{");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("@Depreciated");
+    _builder_1.newLine();
+    _builder_1.append("abstract class AbstractX{");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.applyFix(_builder, _builder_1);
+  }
+  
+  @Test
+  public void add_abstract_javadoc() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("/**");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* This is a doc for this abstract class.");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("* It even has two lines.");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("*/");
+    _builder.newLine();
+    _builder.append("class AbstractX{");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("/**");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("* This is a doc for this abstract class.");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("* It even has two lines.");
+    _builder_1.newLine();
+    _builder_1.append(" ");
+    _builder_1.append("*/");
+    _builder_1.newLine();
+    _builder_1.append("abstract class AbstractX{");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.applyFix(_builder, _builder_1);
+  }
+  
+  private void applyFix(final CharSequence input, final CharSequence result) {
+    final String issueCode = IssueCodes.MODIFIER_DOES_NOT_MATCH_TYPENAME;
+    final String fixlabel = "Add missing abstract modifier.";
+    final String fixdescription = "Add the abstract modifier to match naming conventions for the type name. Delete final modifier if necessary.";
+    String _string = result.toString();
+    AbstractQuickfixTest.Quickfix _quickfix = new AbstractQuickfixTest.Quickfix(fixlabel, fixdescription, _string);
+    this.testQuickfixesOn(input, issueCode, _quickfix);
+  }
+}

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/validator/preferences/XtendValidatorConfigurationBlock.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/validator/preferences/XtendValidatorConfigurationBlock.java
@@ -71,7 +71,8 @@ public class XtendValidatorConfigurationBlock extends XbaseValidationConfigurati
 		super.fillCodingStyleSection(builder);
 		builder.addComboBox(API_TYPE_INFERENCE, "Type inference for API methods/fields:")
 				.addComboBox(IMPLICIT_RETURN, "Implicit return:")
-				.addComboBox(WRONG_FILE, "File name doesn't match type name:");
+				.addComboBox(WRONG_FILE, "File name doesn't match type name:")
+				.addComboBox(MODIFIER_DOES_NOT_MATCH_TYPENAME, "Modifier does not match type name:");
 	}
 
 	@Override


### PR DESCRIPTION
[Solution to Issue to #719 ](https://github.com/eclipse/xtext-xtend/issues/719)
If a type is named Abstractfoo but not declared abstract, an issue is raised.
The severity is configurable, default is warning. Also a quick fix is available to add the missing abstract modifier. If a the type is also declared final (but named Abstractfoo), the final modifier is removed, as it can be assumed that the abstract modifier is more important to the user (the type's name takes more time and thought to type in than the final keyword).