### PR TITLE
add mavenCentral repository

### DIFF
--- a/gradle/upstream-repositories.gradle
+++ b/gradle/upstream-repositories.gradle
@@ -24,6 +24,7 @@ def jenkinsPipelineRepo = { jobName, branch ->
 }
 
 repositories {
+  mavenCentral()
   jcenter()
   if (findProperty('useJenkinsSnapshots') == 'true') {
     maven { url "http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/$MVN_REPOPATH" }


### PR DESCRIPTION
workaround for jcenter maven central sync is too slow

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>