### PR TITLE
[issue#736] Xtend Quickfix should also remove the unused imports and all writing accesses to the field

### DIFF
--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
@@ -4182,14 +4182,23 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	@Test
 	def void fixUnusedPrivateField() {
 		create('Foo.xtend', '''
+			import java.util.List
+			import java.util.Date
+			
 			class Foo {
-				val a| = 42
+				List<Date> |a
+				new () {
+					a = newArrayList
+				}
 			}
 		''')
 		.assertIssueCodes(UNUSED_PRIVATE_MEMBER)
 		.assertResolutionLabels("Remove member.")
 		.assertModelAfterQuickfix('''
 			class Foo {
+			
+				new () {
+				}
 			}
 		''')
 	}

--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
@@ -4182,6 +4182,22 @@ class QuickfixTest extends AbstractXtendUITestCase {
 	@Test
 	def void fixUnusedPrivateField() {
 		create('Foo.xtend', '''
+			class Foo {
+				val a| = 42
+			}
+		''')
+		.assertIssueCodes(UNUSED_PRIVATE_MEMBER)
+		.assertResolutionLabels("Remove member.")
+		.assertModelAfterQuickfix('''
+			class Foo {
+				
+			}
+		''')
+	}
+	
+	@Test
+	def void fixUnusedPrivateFieldWithAssignmentsAndImports() {
+		create('Foo.xtend', '''
 			import java.util.List
 			import java.util.Date
 			
@@ -4196,8 +4212,41 @@ class QuickfixTest extends AbstractXtendUITestCase {
 		.assertResolutionLabels("Remove member.")
 		.assertModelAfterQuickfix('''
 			class Foo {
-			
+				
 				new () {
+					
+				}
+			}
+		''')
+	}
+	
+	@Test
+	def void fixUnusedPrivateFieldWithSideEffectAssignmentAndImports() {
+		create('Foo.xtend', '''
+			import java.util.List
+			import java.util.Date
+			
+			class Foo {
+				List<Date> a
+				boolean |b
+				new () {
+					a = newArrayList
+					b = a.add(new Date)
+				}
+			}
+		''')
+		.assertIssueCodes(UNUSED_PRIVATE_MEMBER)
+		.assertResolutionLabels("Remove member.")
+		.assertModelAfterQuickfix('''
+			import java.util.Date
+			import java.util.List
+			
+			class Foo {
+				List<Date> a
+				
+				new () {
+					a = newArrayList
+					a.add(new Date)
 				}
 			}
 		''')
@@ -4214,6 +4263,7 @@ class QuickfixTest extends AbstractXtendUITestCase {
 		.assertResolutionLabels("Remove member.")
 		.assertModelAfterQuickfix('''
 			class Foo {
+				
 			}
 		''')
 	}

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
@@ -7614,6 +7614,27 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   @Test
   public void fixUnusedPrivateField() {
     StringConcatenation _builder = new StringConcatenation();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("val a| = 42");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNUSED_PRIVATE_MEMBER).assertResolutionLabels("Remove member.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void fixUnusedPrivateFieldWithAssignmentsAndImports() {
+    StringConcatenation _builder = new StringConcatenation();
     _builder.append("import java.util.List");
     _builder.newLine();
     _builder.append("import java.util.Date");
@@ -7639,9 +7660,73 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
     _builder_1.newLine();
+    _builder_1.append("\t");
     _builder_1.newLine();
     _builder_1.append("\t");
     _builder_1.append("new () {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _assertResolutionLabels.assertModelAfterQuickfix(_builder_1);
+  }
+  
+  @Test
+  public void fixUnusedPrivateFieldWithSideEffectAssignmentAndImports() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import java.util.List");
+    _builder.newLine();
+    _builder.append("import java.util.Date");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("List<Date> a");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("boolean |b");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("new () {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("a = newArrayList");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("b = a.add(new Date)");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNUSED_PRIVATE_MEMBER).assertResolutionLabels("Remove member.");
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import java.util.Date");
+    _builder_1.newLine();
+    _builder_1.append("import java.util.List");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("List<Date> a");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("new () {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("a = newArrayList");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("a.add(new Date)");
     _builder_1.newLine();
     _builder_1.append("\t");
     _builder_1.append("}");
@@ -7664,6 +7749,8 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNUSED_PRIVATE_MEMBER).assertResolutionLabels("Remove member.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
@@ -7614,16 +7614,37 @@ public class QuickfixTest extends AbstractXtendUITestCase {
   @Test
   public void fixUnusedPrivateField() {
     StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import java.util.List");
+    _builder.newLine();
+    _builder.append("import java.util.Date");
+    _builder.newLine();
+    _builder.newLine();
     _builder.append("class Foo {");
     _builder.newLine();
     _builder.append("\t");
-    _builder.append("val a| = 42");
+    _builder.append("List<Date> |a");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("new () {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("a = newArrayList");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
     QuickfixTestBuilder _assertResolutionLabels = this.builder.create("Foo.xtend", _builder.toString()).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.UNUSED_PRIVATE_MEMBER).assertResolutionLabels("Remove member.");
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo {");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("new () {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/XtendQuickfixProvider.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/XtendQuickfixProvider.java
@@ -748,21 +748,21 @@ public class XtendQuickfixProvider extends XbaseQuickfixProvider {
 		acceptor.accept(issue, label, description, image, new ISemanticModification() {
 			@Override
 			public void apply(EObject element, IModificationContext context) throws Exception {
-				if (element instanceof XtendField) {
-					final JvmField field = associations.getJvmField((XtendField)element);
-					final IXtextDocument document = context.getXtextDocument();
-					document.modify(new IUnitOfWork.Void<XtextResource>() {
-						@Override
-						public void process(XtextResource resource) throws Exception {
-							EcoreUtil.remove(element);
+				final IXtextDocument document = context.getXtextDocument();
+				document.modify(new IUnitOfWork.Void<XtextResource>() {
+					@Override
+					public void process(XtextResource resource) throws Exception {
+						if (element instanceof XtendField) {
+							final JvmField field = associations.getJvmField((XtendField)element);
 							EcoreUtil.removeAll(EcoreUtil2.eAllContentsAsList(resource).stream()
 									.filter(XAssignment.class::isInstance).map(XAssignment.class::cast)
 									.filter(assignment -> field == assignment.getFeature())
 									.collect(Collectors.toList()));
 						}
-					});
-					organizeImportsHandler.doOrganizeImports(document);
-				}
+						EcoreUtil.remove(element);
+					}
+				});
+				organizeImportsHandler.doOrganizeImports(document);
 			}
 		});
 	}


### PR DESCRIPTION
Xtend Quickfix should also remove the unused imports and all writing accesses to the field #736

Signed-off-by: Lorenzo Addazi <addazi.lorenzo@gmail.com>