### PR TITLE
[issue#744] Xtend Quickfix "Rename class" if the class name does not match the file name

### DIFF
--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
@@ -15,6 +15,7 @@ import org.junit.Test
 
 import static org.eclipse.xtend.core.validation.IssueCodes.*
 import static org.eclipse.xtext.xbase.validation.IssueCodes.*
+import static extension org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.fileToString
 
 class QuickfixTest extends AbstractXtendUITestCase {
 	
@@ -353,11 +354,51 @@ class QuickfixTest extends AbstractXtendUITestCase {
 			class Foo|1 {
 			}
 		'''
-		create('Foo.xtend', model).assertIssueCodes(WRONG_FILE).assertResolutionLabels("Rename file to 'Foo1.xtend'").
-			assertModelAfterQuickfix(model.replace('|', ''))
+		create('Foo.xtend', model).assertIssueCodes(WRONG_FILE).assertResolutionLabelsSubset("Rename file to 'Foo1.xtend'").
+			assertModelAfterQuickfix("Rename file to 'Foo1.xtend'", model.replace('|', ''))
 		assertNotNull(getFile("Foo1.xtend"))
 		assertTrue(getFile("Foo1.xtend").exists)
 		assertFalse(getFile("Foo.xtend").exists)
+	}
+	
+	@Test
+	def void fixWrongFile_renameClass() {
+		val className = 'Foo'
+		val fileName = className + '.xtend'
+		val wrongClassName = 'Bar'
+		
+		val otherClassFile = createFile('Other.xtend', '''
+			class Other {
+				val «wrongClassName» test = new «wrongClassName»
+			}
+		''')
+		
+		create(fileName, '''
+			class «wrongClassName»| {
+				static val «wrongClassName» INSTANCE = new «wrongClassName»
+			
+				def static «wrongClassName» getInstance() {
+					INSTANCE
+				}
+			}
+		''')
+		.assertIssueCodes(WRONG_FILE)
+		.assertResolutionLabelsSubset("Rename class to '" + className + "'")
+		.assertModelAfterQuickfix('''
+			class «className» {
+				static val «className» INSTANCE = new «className»
+			
+				def static «className» getInstance() {
+					INSTANCE
+				}
+			}
+		''')
+		
+		assertEquals('''
+			class Other {
+				val «className» test = new «className»
+			}
+		'''.toString, otherClassFile.fileToString)
 	}
 	
 	@Test
@@ -365,7 +406,6 @@ class QuickfixTest extends AbstractXtendUITestCase {
 		create('Foo1.xtend', '''class Foo|2{} class Foo3{}''')
 		create('Foo.xtend', '''class Foo|1 {}''')
 			.assertIssueCodes(WRONG_FILE)
-			.assertResolutionLabels("")
 	}
 		
 	@Test 

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.java
@@ -1,6 +1,7 @@
 package org.eclipse.xtend.ide.tests.quickfix;
 
 import com.google.inject.Inject;
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase;
 import org.eclipse.xtend.ide.tests.WorkbenchTestHelper;
@@ -9,6 +10,7 @@ import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.diagnostics.Diagnostic;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.refactoring.ui.SyncUtil;
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.util.JavaVersion;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Extension;
@@ -604,10 +606,97 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     _builder.append("}");
     _builder.newLine();
     final String model = _builder.toString();
-    this.builder.create("Foo.xtend", model).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.WRONG_FILE).assertResolutionLabels("Rename file to \'Foo1.xtend\'").assertModelAfterQuickfix(model.replace("|", ""));
+    this.builder.create("Foo.xtend", model).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.WRONG_FILE).assertResolutionLabelsSubset("Rename file to \'Foo1.xtend\'").assertModelAfterQuickfix("Rename file to \'Foo1.xtend\'", model.replace("|", ""));
     Assert.assertNotNull(this._workbenchTestHelper.getFile("Foo1.xtend"));
     Assert.assertTrue(this._workbenchTestHelper.getFile("Foo1.xtend").exists());
     Assert.assertFalse(this._workbenchTestHelper.getFile("Foo.xtend").exists());
+  }
+  
+  @Test
+  public void fixWrongFile_renameClass() {
+    try {
+      final String className = "Foo";
+      final String fileName = (className + ".xtend");
+      final String wrongClassName = "Bar";
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("class Other {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("val ");
+      _builder.append(wrongClassName, "\t");
+      _builder.append(" test = new ");
+      _builder.append(wrongClassName, "\t");
+      _builder.newLineIfNotEmpty();
+      _builder.append("}");
+      _builder.newLine();
+      final IFile otherClassFile = this._workbenchTestHelper.createFile("Other.xtend", _builder.toString());
+      StringConcatenation _builder_1 = new StringConcatenation();
+      _builder_1.append("class ");
+      _builder_1.append(wrongClassName);
+      _builder_1.append("| {");
+      _builder_1.newLineIfNotEmpty();
+      _builder_1.append("\t");
+      _builder_1.append("static val ");
+      _builder_1.append(wrongClassName, "\t");
+      _builder_1.append(" INSTANCE = new ");
+      _builder_1.append(wrongClassName, "\t");
+      _builder_1.newLineIfNotEmpty();
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("def static ");
+      _builder_1.append(wrongClassName, "\t");
+      _builder_1.append(" getInstance() {");
+      _builder_1.newLineIfNotEmpty();
+      _builder_1.append("\t\t");
+      _builder_1.append("INSTANCE");
+      _builder_1.newLine();
+      _builder_1.append("\t");
+      _builder_1.append("}");
+      _builder_1.newLine();
+      _builder_1.append("}");
+      _builder_1.newLine();
+      QuickfixTestBuilder _assertResolutionLabelsSubset = this.builder.create(fileName, _builder_1.toString()).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.WRONG_FILE).assertResolutionLabelsSubset((("Rename class to \'" + className) + "\'"));
+      StringConcatenation _builder_2 = new StringConcatenation();
+      _builder_2.append("class ");
+      _builder_2.append(className);
+      _builder_2.append(" {");
+      _builder_2.newLineIfNotEmpty();
+      _builder_2.append("\t");
+      _builder_2.append("static val ");
+      _builder_2.append(className, "\t");
+      _builder_2.append(" INSTANCE = new ");
+      _builder_2.append(className, "\t");
+      _builder_2.newLineIfNotEmpty();
+      _builder_2.newLine();
+      _builder_2.append("\t");
+      _builder_2.append("def static ");
+      _builder_2.append(className, "\t");
+      _builder_2.append(" getInstance() {");
+      _builder_2.newLineIfNotEmpty();
+      _builder_2.append("\t\t");
+      _builder_2.append("INSTANCE");
+      _builder_2.newLine();
+      _builder_2.append("\t");
+      _builder_2.append("}");
+      _builder_2.newLine();
+      _builder_2.append("}");
+      _builder_2.newLine();
+      _assertResolutionLabelsSubset.assertModelAfterQuickfix(_builder_2);
+      StringConcatenation _builder_3 = new StringConcatenation();
+      _builder_3.append("class Other {");
+      _builder_3.newLine();
+      _builder_3.append("\t");
+      _builder_3.append("val ");
+      _builder_3.append(className, "\t");
+      _builder_3.append(" test = new ");
+      _builder_3.append(className, "\t");
+      _builder_3.newLineIfNotEmpty();
+      _builder_3.append("}");
+      _builder_3.newLine();
+      Assert.assertEquals(_builder_3.toString(), IResourcesSetupUtil.fileToString(otherClassFile));
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
   }
   
   @Test
@@ -617,7 +706,7 @@ public class QuickfixTest extends AbstractXtendUITestCase {
     this.builder.create("Foo1.xtend", _builder.toString());
     StringConcatenation _builder_1 = new StringConcatenation();
     _builder_1.append("class Foo|1 {}");
-    this.builder.create("Foo.xtend", _builder_1.toString()).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.WRONG_FILE).assertResolutionLabels("");
+    this.builder.create("Foo.xtend", _builder_1.toString()).assertIssueCodes(org.eclipse.xtend.core.validation.IssueCodes.WRONG_FILE);
   }
   
   @Test

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/XtendQuickfixProvider.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/quickfix/XtendQuickfixProvider.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -31,6 +32,12 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.TextSelection;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.PerformChangeOperation;
+import org.eclipse.ltk.core.refactoring.RefactoringCore;
+import org.eclipse.ltk.core.refactoring.participants.ProcessorBasedRefactoring;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.xtend.core.jvmmodel.IXtendJvmAssociations;
 import org.eclipse.xtend.core.services.XtendGrammarAccess;
 import org.eclipse.xtend.core.typing.XtendExpressionHelper;
@@ -74,7 +81,11 @@ import org.eclipse.xtext.ui.editor.model.edit.IssueModificationContext;
 import org.eclipse.xtext.ui.editor.quickfix.Fix;
 import org.eclipse.xtext.ui.editor.quickfix.IssueResolution;
 import org.eclipse.xtext.ui.editor.quickfix.IssueResolutionAcceptor;
+import org.eclipse.xtext.ui.refactoring.IRenameRefactoringProvider;
 import org.eclipse.xtext.ui.refactoring.impl.ProjectUtil;
+import org.eclipse.xtext.ui.refactoring.impl.RenameElementProcessor;
+import org.eclipse.xtext.ui.refactoring.ui.IRenameContextFactory;
+import org.eclipse.xtext.ui.refactoring.ui.IRenameElementContext;
 import org.eclipse.xtext.util.ITextRegion;
 import org.eclipse.xtext.util.StopWatch;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
@@ -103,6 +114,7 @@ import com.google.inject.Singleton;
  * @author Jan Koehnlein - Quickfixes for inconsistent indentation
  * @author Sebastian Zarnekow - Quickfixes for misspelled types and constructors
  * @author Holger Schill - Quickfixes for missing methods / fields / localVars
+ * @author Vivien Jovet - Quickfix for rename class
  */
 @Singleton
 public class XtendQuickfixProvider extends XbaseQuickfixProvider {
@@ -138,6 +150,10 @@ public class XtendQuickfixProvider extends XbaseQuickfixProvider {
 	@Inject private OrganizeImportsHandler organizeImportsHandler;
 	
 	@Inject private XtendExpressionHelper expressionHelper;
+
+	@Inject private IRenameRefactoringProvider renameRefactoringProvider;
+	
+	@Inject private IRenameContextFactory renameContextFactory;
 	
 	private static final Set<String> LINKING_ISSUE_CODES = newHashSet(
 			Diagnostic.LINKING_DIAGNOSTIC,
@@ -183,6 +199,36 @@ public class XtendQuickfixProvider extends XbaseQuickfixProvider {
 		javaTypeQuickfixes.addQuickfixes(issue, issueResolutionAcceptor, xtextDocument, resource, referenceOwner, unresolvedReference);
 		createTypeQuickfixes.addQuickfixes(issue, issueResolutionAcceptor, xtextDocument, resource, referenceOwner, unresolvedReference);
 		createMemberQuickfixes.addQuickfixes(issue, issueResolutionAcceptor, xtextDocument, resource, referenceOwner, unresolvedReference);
+	}
+	
+	@Fix(IssueCodes.WRONG_FILE)
+	public void fixWrongFileRenameClass(final Issue issue, final IssueResolutionAcceptor acceptor) {
+		URI uri = issue.getUriToProblem();
+		String className = uri.trimFileExtension().lastSegment();
+		String label = String.format("Rename class to '%s'", className);
+		acceptor.accept(issue, label, label, null, (element, context) -> {
+			context.getXtextDocument().modify(resource -> {
+				IRenameElementContext renameContext = renameContextFactory.createRenameElementContext(element, null,
+						new TextSelection(context.getXtextDocument(), issue.getOffset(), issue.getLength()), resource);
+				final ProcessorBasedRefactoring refactoring = renameRefactoringProvider.getRenameRefactoring(renameContext);
+				((RenameElementProcessor) refactoring.getProcessor()).setNewName(className);
+				PlatformUI.getWorkbench().getActiveWorkbenchWindow().run(true, true, monitor -> {
+					try {
+						if (!refactoring.checkFinalConditions(monitor).isOK())
+							return;
+						Change change = refactoring.createChange(monitor);
+						change.initializeValidationData(monitor);
+						PerformChangeOperation performChangeOperation = new PerformChangeOperation(change);
+						performChangeOperation.setUndoManager(RefactoringCore.getUndoManager(), refactoring.getName());
+						performChangeOperation.setSchedulingRule(ResourcesPlugin.getWorkspace().getRoot());
+						performChangeOperation.run(monitor);
+					} catch (CoreException e) {
+						logger.error(e);
+					}
+				});
+				return null;
+			});
+		});
 	}
 
 	@Fix(IssueCodes.INCONSISTENT_INDENTATION)


### PR DESCRIPTION
Add a _rename the class_ quick fix for WRONG_FILE issue. #744 

Preview:
![rename_class](https://user-images.githubusercontent.com/6960133/54173106-8906ad00-44bb-11e9-8738-d2bf7a21f262.gif)


I added a test for it in `QuickfixTest.xtend` and had to modify two failing tests due to the additional quick fix. `QuickfixTest.missingAnnotationImport` is still failing but I'm not sure if it's because of my changes.

Signed-off-by: Vivien Jovet <vivien.jovet@gmail.com>