### PR TITLE
[issue#699] Add xtend wizard menu items to Project Explorer New menu

### DIFF
--- a/org.eclipse.xtend.ide/plugin.xml
+++ b/org.eclipse.xtend.ide/plugin.xml
@@ -1619,4 +1619,31 @@
          </adapter>
       </factory>
    </extension>
+   <extension
+         point="org.eclipse.ui.navigator.navigatorContent">
+         <commonWizard
+               type="new"
+               wizardId="org.eclipse.xtend.ide.wizards.NewXtendClassWizard"
+               menuGroupId="org.eclipse.jdt.ui.java">
+            <enablement></enablement>
+         </commonWizard>
+         <commonWizard
+               type="new"
+               wizardId="org.eclipse.xtend.ide.wizards.NewXtendInterfaceWizard"
+               menuGroupId="org.eclipse.jdt.ui.java">
+            <enablement></enablement>
+         </commonWizard>
+         <commonWizard
+               type="new"
+               wizardId="org.eclipse.xtend.ide.wizards.NewXtendEnumWizard"
+               menuGroupId="org.eclipse.jdt.ui.java">
+            <enablement></enablement>
+         </commonWizard>
+         <commonWizard
+               type="new"
+               wizardId="org.eclipse.xtend.ide.wizards.NewXtendAnnotationWizard"
+               menuGroupId="org.eclipse.jdt.ui.java">
+            <enablement></enablement>
+         </commonWizard>
+   </extension>
 </plugin>


### PR DESCRIPTION
The Xtend wizards are now showing in the Project Explorer New menu.

![image](https://user-images.githubusercontent.com/6960133/54403029-8ef1cd80-4709-11e9-8d04-fdfc2a3094d8.png)