### PR TITLE
[eclipse/xtext-extras#394] fixed issues with nested inline feature calls

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug437365Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug437365Test.xtend
@@ -40,8 +40,8 @@ class CompilerBug437365Test extends AbstractXtendCompilerTest {
 			    LinkedList<String> _linkedList = new LinkedList<String>();
 			    arrayOfList[0] = _linkedList;
 			    String _string = new String();
-			    arrayOfList[0].add(_string);
-			    final String a = arrayOfList[0].get(0);
+			    (arrayOfList[0]).add(_string);
+			    final String a = (arrayOfList[0]).get(0);
 			    InputOutput.<String>println(a);
 			  }
 			}
@@ -71,8 +71,8 @@ class CompilerBug437365Test extends AbstractXtendCompilerTest {
 			    LinkedList<String> _linkedList = new LinkedList<String>();
 			    arrayOfList[0] = _linkedList;
 			    String _string = new String();
-			    arrayOfList[0].add(_string);
-			    final String a = arrayOfList[0].get(0);
+			    (arrayOfList[0]).add(_string);
+			    final String a = (arrayOfList[0]).get(0);
 			    InputOutput.<String>println(a);
 			  }
 			}

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug465649Test.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBug465649Test.xtend
@@ -184,7 +184,7 @@ class CompilerBug465649Test extends AbstractXtendCompilerTest {
 			  }
 			  
 			  public static int m() {
-			    return ((Comparable<?>)C.<Object>newArray(Integer.valueOf(1), "1")[0]).compareTo(null);
+			    return ((Comparable<?>)(C.<Object>newArray(Integer.valueOf(1), "1")[0])).compareTo(null);
 			  }
 			}
 		''')

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug437365Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug437365Test.java
@@ -74,10 +74,10 @@ public class CompilerBug437365Test extends AbstractXtendCompilerTest {
     _builder_1.append("String _string = new String();");
     _builder_1.newLine();
     _builder_1.append("    ");
-    _builder_1.append("arrayOfList[0].add(_string);");
+    _builder_1.append("(arrayOfList[0]).add(_string);");
     _builder_1.newLine();
     _builder_1.append("    ");
-    _builder_1.append("final String a = arrayOfList[0].get(0);");
+    _builder_1.append("final String a = (arrayOfList[0]).get(0);");
     _builder_1.newLine();
     _builder_1.append("    ");
     _builder_1.append("InputOutput.<String>println(a);");
@@ -144,10 +144,10 @@ public class CompilerBug437365Test extends AbstractXtendCompilerTest {
     _builder_1.append("String _string = new String();");
     _builder_1.newLine();
     _builder_1.append("    ");
-    _builder_1.append("arrayOfList[0].add(_string);");
+    _builder_1.append("(arrayOfList[0]).add(_string);");
     _builder_1.newLine();
     _builder_1.append("    ");
-    _builder_1.append("final String a = arrayOfList[0].get(0);");
+    _builder_1.append("final String a = (arrayOfList[0]).get(0);");
     _builder_1.newLine();
     _builder_1.append("    ");
     _builder_1.append("InputOutput.<String>println(a);");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug465649Test.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBug465649Test.java
@@ -421,7 +421,7 @@ public class CompilerBug465649Test extends AbstractXtendCompilerTest {
     _builder_1.append("public static int m() {");
     _builder_1.newLine();
     _builder_1.append("    ");
-    _builder_1.append("return ((Comparable<?>)C.<Object>newArray(Integer.valueOf(1), \"1\")[0]).compareTo(null);");
+    _builder_1.append("return ((Comparable<?>)(C.<Object>newArray(Integer.valueOf(1), \"1\")[0])).compareTo(null);");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("}");


### PR DESCRIPTION
[eclipse/xtext-extras#394] fixed issues with nested inline feature calls
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>