### PR TITLE
Change defaultGoal to install

### DIFF
--- a/releng/org.eclipse.xtend.p2-repository/pom.xml
+++ b/releng/org.eclipse.xtend.p2-repository/pom.xml
@@ -19,8 +19,8 @@
 				<artifactId>tycho-p2-repository-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-                    <repositoryName>Xtend Repository</repositoryName>
-                </configuration>
+					<repositoryName>Xtend Repository</repositoryName>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/tycho-pom.xml
+++ b/tycho-pom.xml
@@ -33,7 +33,7 @@
 	</modules>
 	
 	<build>
-		<defaultGoal>verify</defaultGoal>
+		<defaultGoal>install</defaultGoal>
 	</build>
 
 </project>


### PR DESCRIPTION
install is required to trigger the maven-antrun-plugin in
org.eclipse.xtend.p2-repository, which copies the resulting p2
repository to the target build folder. Without, the p2 repository is not
archived.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>