### PR TITLE
[eclipse/xtext-core#1137] Filter static methods in Delegate active annotation

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/DelegateCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/DelegateCompilerTest.xtend
@@ -497,6 +497,18 @@ class DelegateCompilerTest extends AbstractXtendCompilerTest {
 	}
 	
 	@Test
+	def void testStaticMethodsInInterfaces() {
+		val text = ''' 
+			import org.eclipse.xtend.lib.annotations.Delegate
+			import testdata.InterfaceWithStaticMethod
+			class Bar implements InterfaceWithStaticMethod {
+				@Delegate InterfaceWithStaticMethod delegate
+			}
+		'''
+		text.file.assertNoIssues
+	}
+	
+	@Test
 	def void genericsWithLowerBound() {
 		val text = ''' 
 			import org.eclipse.xtend.lib.annotations.Delegate

--- a/org.eclipse.xtend.core.tests/testdata/testdata/InterfaceWithStaticMethod.java
+++ b/org.eclipse.xtend.core.tests/testdata/testdata/InterfaceWithStaticMethod.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package testdata;
+
+/**
+ * @author Christian Dietrich - Initial contribution and API
+ */
+public interface InterfaceWithStaticMethod {
+	
+	public int doit();
+	public static int iamtheanswer() {
+		return 42;
+	}
+
+}

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/DelegateCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/DelegateCompilerTest.java
@@ -1012,6 +1012,28 @@ public class DelegateCompilerTest extends AbstractXtendCompilerTest {
   }
   
   @Test
+  public void testStaticMethodsInInterfaces() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("import org.eclipse.xtend.lib.annotations.Delegate");
+      _builder.newLine();
+      _builder.append("import testdata.InterfaceWithStaticMethod");
+      _builder.newLine();
+      _builder.append("class Bar implements InterfaceWithStaticMethod {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("@Delegate InterfaceWithStaticMethod delegate");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      final String text = _builder.toString();
+      this._validationTestHelper.assertNoIssues(this.file(text));
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
   public void genericsWithLowerBound() {
     try {
       StringConcatenation _builder = new StringConcatenation();


### PR DESCRIPTION
[eclipse/xtext-core#1137] Filter static methods in Delegate active annotation

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>