### PR TITLE
[eclipse/xtext1475] use 2019-09 in latest target platform

### DIFF
--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-latest.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-latest.target
@@ -98,7 +98,7 @@
 		<unit id="org.eclipse.xtend" version="0.0.0"/>
 		<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
 		<unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
-		<repository location="https://download.eclipse.org/releases/2019-06"/>
+		<repository location="https://download.eclipse.org/releases/2019-09"/>
 	</location>
 
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">


### PR DESCRIPTION
[eclipse/xtext1475] use 2019-09 in latest target platform
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>