### PR TITLE
Parallelize stages 'Maven Plugin Build' & 'Maven Tycho Build'

### DIFF
--- a/CBI.Jenkinsfile
+++ b/CBI.Jenkinsfile
@@ -121,7 +121,7 @@ spec:
     }
 
     stage('Maven Build & Test') {
-      stages { // TODO use of parallel { here kills Tycho process with OOM
+      parallel {
         stage('Maven Plugin Build') {
           steps {
             sh """


### PR DESCRIPTION
This change enables parallelization of the two Maven stages. It looks as this saves a few minutes in the build and looks stable.

without parallel execution (master)
![screenshot 128](https://user-images.githubusercontent.com/265597/60500914-6cd18a80-9cbb-11e9-9495-b4eefd42f18e.png)

with parallel execution
![screenshot 129](https://user-images.githubusercontent.com/265597/60500975-84107800-9cbb-11e9-8930-89db40af0530.png)

