### PR TITLE
Refactoring the JavaDocHyperlinkingTest test cases.

### DIFF
--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/hyperlinking/JavaDocHyperlinkingTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/hyperlinking/JavaDocHyperlinkingTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2018, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,25 +7,30 @@
  *******************************************************************************/
 package org.eclipse.xtend.ide.tests.hyperlinking
 
-import com.google.inject.Inject
-import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase
-import org.eclipse.xtend.ide.tests.WorkbenchTestHelper
-import org.eclipse.xtext.common.types.xtext.ui.JdtHyperlink
-import org.eclipse.xtext.resource.XtextResource
-import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkHelper
+import org.eclipse.jface.text.hyperlink.IHyperlink
+import org.eclipse.xtend.ide.tests.XtendIDEInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.eclipse.xtext.ui.testing.AbstractHyperlinkingTest
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+
+import static extension org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil.createJavaProject
 
 /**
  * @author miklossy - Initial contribution and API
  */
-class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
+@RunWith(XtextRunner)
+@InjectWith(XtendIDEInjectorProvider)
+class JavaDocHyperlinkingTest extends AbstractHyperlinkingTest {
 
-	// position marker
-	val c = '''<|>'''
-
-	@Inject extension IHyperlinkHelper
-
-	@Inject extension WorkbenchTestHelper
+	@Before def void setup() {
+		/*
+		 * Xbase-based languages require java project
+		 */
+		projectName.createJavaProject
+	}
 
 	@Test def import_statement() {
 		'''
@@ -34,7 +39,7 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 			class Foo {
 				Date date
 			}
-		'''.containsHyperlinkToJavaDate
+		'''.hasHyperlinkToJavaDate
 	}
 
 	@Test def member_type() {
@@ -47,7 +52,7 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 			class Foo {
 				«c»Date«c» date
 			}
-		'''.containsHyperlinkToJavaDate
+		'''.hasHyperlinkToJavaDate
 	}
 
 	@Test def multi_line_comment_link() {
@@ -59,7 +64,7 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 			 */
 			class Foo {
 			}
-		'''.containsHyperlinkToJavaDate
+		'''.hasHyperlinkToJavaDate
 	}
 
 	@Test def multi_line_comment_see() {
@@ -71,7 +76,7 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 			 */
 			class Foo {
 			}
-		'''.containsHyperlinkToJavaDate
+		'''.hasHyperlinkToJavaDate
 	}
 
 	@Test def javadoc_link_no_hyperlink_if_the_type_cannot_be_resolved() {
@@ -81,7 +86,7 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 			 */
 			class Foo {
 			}
-		'''.containsNoHyperlinks
+		'''.hasNoHyperlink
 	}
 
 	@Test def javadoc_see_no_hyperlink_if_the_type_cannot_be_resolved() {
@@ -91,7 +96,7 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 			 */
 			class Foo {
 			}
-		'''.containsNoHyperlinks
+		'''.hasNoHyperlink
 	}
 
 	@Test def javadoc_link01() {
@@ -104,7 +109,7 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 			class Foo {
 				Date date
 			}
-		'''.containsHyperlinkToJavaDate
+		'''.hasHyperlinkToJavaDate
 	}
 
 	@Test def javadoc_link02() {
@@ -115,7 +120,7 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 			 */
 			class Foo {
 			}
-		'''.containsHyperlinkToJavaDate
+		'''.hasHyperlinkToJavaDate
 	}
 
 	@Test def javadoc_link03() {
@@ -126,7 +131,7 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 			 */
 			class Foo {
 			}
-		'''.containsHyperlinkToJavaDate
+		'''.hasHyperlinkToJavaDate
 	}
 
 	@Test def javadoc_link04() {
@@ -139,7 +144,7 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 			class Foo {
 				Date date
 			}
-		'''.containsHyperlinkToJavaDate
+		'''.hasHyperlinkToJavaDate
 	}
 
 	@Test def javadoc_link05() {
@@ -153,7 +158,7 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 				 */
 				val a = 1
 			}
-		'''.containsHyperlinkToJavaDate
+		'''.hasHyperlinkToJavaDate
 	}
 
 	@Test def javadoc_link06() {
@@ -167,7 +172,7 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 			/**
 			 * {@link «c»Date«c»}
 			 */
-		'''.containsHyperlinkToJavaDate
+		'''.hasHyperlinkToJavaDate
 	}
 
 	@Test def javadoc_link07() {
@@ -176,7 +181,7 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 			/**
 			 * {@link «c»Date«c»}
 			 */
-		'''.containsHyperlinkToJavaDate
+		'''.hasHyperlinkToJavaDate
 	}
 
 	@Test def javadoc_see01() {
@@ -189,7 +194,7 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 			class Foo {
 				Date date
 			}
-		'''.containsHyperlinkToJavaDate
+		'''.hasHyperlinkToJavaDate
 	}
 
 	@Test def javadoc_see02() {
@@ -200,7 +205,7 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 			 */
 			class Foo {
 			}
-		'''.containsHyperlinkToJavaDate
+		'''.hasHyperlinkToJavaDate
 	}
 
 	@Test def javadoc_see03() {
@@ -211,7 +216,7 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 			 */
 			class Foo {
 			}
-		'''.containsHyperlinkToJavaDate
+		'''.hasHyperlinkToJavaDate
 	}
 
 	@Test def javadoc_see04() {
@@ -224,7 +229,7 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 			class Foo {
 				Date date
 			}
-		'''.containsHyperlinkToJavaDate
+		'''.hasHyperlinkToJavaDate
 	}
 
 	@Test def javadoc_see05() {
@@ -238,7 +243,7 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 				 */
 				val a = 1
 			}
-		'''.containsHyperlinkToJavaDate
+		'''.hasHyperlinkToJavaDate
 	}
 
 	@Test def javadoc_see06() {
@@ -252,7 +257,7 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 			/**
 			 * @see «c»Date«c»
 			 */
-		'''.containsHyperlinkToJavaDate
+		'''.hasHyperlinkToJavaDate
 	}
 
 	@Test def javadoc_see07() {
@@ -261,58 +266,23 @@ class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
 			/**
 			 * @see «c»Date«c»
 			 */
-		'''.containsHyperlinkToJavaDate
+		'''.hasHyperlinkToJavaDate
 	}
 
-	private def containsNoHyperlinks(CharSequence it) {
-		determineHyperlinks(expectedPositionInformation.head).assertNull
+	private def hasHyperlinkToJavaDate(CharSequence it) {
+		hasHyperlinkTo("java.util.Date")
 	}
 
-	private def containsHyperlinkToJavaDate(CharSequence it) {
-		val expected = expectedPositionInformation
-		val expectedOffset = expected.head
-		val expectedLength = expected.last
-		
-		val hyperlinks = determineHyperlinks(expectedOffset)
-		assertNotNull("No hyperlinks found!", hyperlinks)
-		1.assertEquals(hyperlinks.length)
-		val hyperlink = hyperlinks.head
-		
-		"Date".assertEquals(hyperlink.hyperlinkText)
-		expectedOffset.assertEquals(hyperlink.hyperlinkRegion.offset)
-		expectedLength.assertEquals(hyperlink.hyperlinkRegion.length)
-		
-		assertTrue(hyperlink instanceof JdtHyperlink)
-		val jdtHyperlink = hyperlink as JdtHyperlink
-		
-		val javaElement = jdtHyperlink.javaElement
-		"Date".assertEquals(javaElement.elementName)
+	private def hasNoHyperlink(CharSequence it) {
+		// given
+		dslFile.
+		// when
+		hyperlinkingOn(hyperlinkRegion.offset).
+		// then
+		noHyperlinkIsOffered
 	}
 
-	private def getExpectedPositionInformation(CharSequence input) {
-		val text = input.toString
-
-		val first = text.indexOf(c)
-		if(first == -1) {
-			fail('''Can't locate first position symbols '«c»' in the input text.''')
-		}
-
-		val second = text.lastIndexOf(c)
-		if(first == second) {
-			fail('''Can't locate second position symbols '«c»' in the input text.''')
-		}
-
-		val offset = first
-		val length = second - first - c.length
-
-		#[offset, length]
-	}
-
-	private def determineHyperlinks(CharSequence text, int offset) {
-		val content = text.toString.replace(c, "")
-
-		val xtendFile = "Foo".xtendFile(content)
-		val resource = xtendFile.eResource as XtextResource
-		resource.createHyperlinksByOffset(offset, true)
+	private def noHyperlinkIsOffered(IHyperlink[] hyperlinks) {
+		hyperlinks.assertNull
 	}
 }

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/hyperlinking/JavaDocHyperlinkingTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/hyperlinking/JavaDocHyperlinkingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2018, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,49 +7,34 @@
  */
 package org.eclipse.xtend.ide.tests.hyperlinking;
 
-import com.google.inject.Inject;
-import java.util.Collections;
-import java.util.List;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jface.text.hyperlink.IHyperlink;
-import org.eclipse.xtend.core.xtend.XtendFile;
-import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase;
-import org.eclipse.xtend.ide.tests.WorkbenchTestHelper;
+import org.eclipse.xtend.ide.tests.XtendIDEInjectorProvider;
 import org.eclipse.xtend2.lib.StringConcatenation;
-import org.eclipse.xtext.common.types.xtext.ui.JdtHyperlink;
-import org.eclipse.xtext.resource.XtextResource;
-import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkHelper;
-import org.eclipse.xtext.xbase.lib.CollectionLiterals;
-import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.ui.testing.AbstractHyperlinkingTest;
+import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
 import org.eclipse.xtext.xbase.lib.Exceptions;
-import org.eclipse.xtext.xbase.lib.Extension;
-import org.eclipse.xtext.xbase.lib.Functions.Function0;
-import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /**
  * @author miklossy - Initial contribution and API
  */
+@RunWith(XtextRunner.class)
+@InjectWith(XtendIDEInjectorProvider.class)
 @SuppressWarnings("all")
-public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
-  private final String c = new Function0<String>() {
-    @Override
-    public String apply() {
-      StringConcatenation _builder = new StringConcatenation();
-      _builder.append("<|>");
-      return _builder.toString();
+public class JavaDocHyperlinkingTest extends AbstractHyperlinkingTest {
+  @Before
+  public void setup() {
+    try {
+      JavaProjectSetupUtil.createJavaProject(this.getProjectName());
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
     }
-  }.apply();
-  
-  @Inject
-  @Extension
-  private IHyperlinkHelper _iHyperlinkHelper;
-  
-  @Inject
-  @Extension
-  private WorkbenchTestHelper _workbenchTestHelper;
+  }
   
   @Test
   public void import_statement() {
@@ -67,7 +52,7 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.containsHyperlinkToJavaDate(_builder);
+    this.hasHyperlinkToJavaDate(_builder);
   }
   
   @Test
@@ -94,7 +79,7 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.newLineIfNotEmpty();
     _builder.append("}");
     _builder.newLine();
-    this.containsHyperlinkToJavaDate(_builder);
+    this.hasHyperlinkToJavaDate(_builder);
   }
   
   @Test
@@ -119,7 +104,7 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.containsHyperlinkToJavaDate(_builder);
+    this.hasHyperlinkToJavaDate(_builder);
   }
   
   @Test
@@ -143,7 +128,7 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.containsHyperlinkToJavaDate(_builder);
+    this.hasHyperlinkToJavaDate(_builder);
   }
   
   @Test
@@ -165,7 +150,7 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.containsNoHyperlinks(_builder);
+    this.hasNoHyperlink(_builder);
   }
   
   @Test
@@ -186,7 +171,7 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.containsNoHyperlinks(_builder);
+    this.hasNoHyperlink(_builder);
   }
   
   @Test
@@ -214,7 +199,7 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.containsHyperlinkToJavaDate(_builder);
+    this.hasHyperlinkToJavaDate(_builder);
   }
   
   @Test
@@ -239,7 +224,7 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.containsHyperlinkToJavaDate(_builder);
+    this.hasHyperlinkToJavaDate(_builder);
   }
   
   @Test
@@ -264,7 +249,7 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.containsHyperlinkToJavaDate(_builder);
+    this.hasHyperlinkToJavaDate(_builder);
   }
   
   @Test
@@ -292,7 +277,7 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.containsHyperlinkToJavaDate(_builder);
+    this.hasHyperlinkToJavaDate(_builder);
   }
   
   @Test
@@ -323,7 +308,7 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.containsHyperlinkToJavaDate(_builder);
+    this.hasHyperlinkToJavaDate(_builder);
   }
   
   @Test
@@ -352,7 +337,7 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.append(" ");
     _builder.append("*/");
     _builder.newLine();
-    this.containsHyperlinkToJavaDate(_builder);
+    this.hasHyperlinkToJavaDate(_builder);
   }
   
   @Test
@@ -372,7 +357,7 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.append(" ");
     _builder.append("*/");
     _builder.newLine();
-    this.containsHyperlinkToJavaDate(_builder);
+    this.hasHyperlinkToJavaDate(_builder);
   }
   
   @Test
@@ -399,7 +384,7 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.containsHyperlinkToJavaDate(_builder);
+    this.hasHyperlinkToJavaDate(_builder);
   }
   
   @Test
@@ -423,7 +408,7 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.containsHyperlinkToJavaDate(_builder);
+    this.hasHyperlinkToJavaDate(_builder);
   }
   
   @Test
@@ -447,7 +432,7 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.containsHyperlinkToJavaDate(_builder);
+    this.hasHyperlinkToJavaDate(_builder);
   }
   
   @Test
@@ -474,7 +459,7 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.containsHyperlinkToJavaDate(_builder);
+    this.hasHyperlinkToJavaDate(_builder);
   }
   
   @Test
@@ -504,7 +489,7 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.newLine();
     _builder.append("}");
     _builder.newLine();
-    this.containsHyperlinkToJavaDate(_builder);
+    this.hasHyperlinkToJavaDate(_builder);
   }
   
   @Test
@@ -532,7 +517,7 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.append(" ");
     _builder.append("*/");
     _builder.newLine();
-    this.containsHyperlinkToJavaDate(_builder);
+    this.hasHyperlinkToJavaDate(_builder);
   }
   
   @Test
@@ -551,71 +536,18 @@ public class JavaDocHyperlinkingTest extends AbstractXtendUITestCase {
     _builder.append(" ");
     _builder.append("*/");
     _builder.newLine();
-    this.containsHyperlinkToJavaDate(_builder);
+    this.hasHyperlinkToJavaDate(_builder);
   }
   
-  private void containsNoHyperlinks(final CharSequence it) {
-    Assert.assertNull(this.determineHyperlinks(it, (IterableExtensions.<Integer>head(this.getExpectedPositionInformation(it))).intValue()));
+  private void hasHyperlinkToJavaDate(final CharSequence it) {
+    this.hasHyperlinkTo(it, "java.util.Date");
   }
   
-  private void containsHyperlinkToJavaDate(final CharSequence it) {
-    final List<Integer> expected = this.getExpectedPositionInformation(it);
-    final Integer expectedOffset = IterableExtensions.<Integer>head(expected);
-    final Integer expectedLength = IterableExtensions.<Integer>last(expected);
-    final IHyperlink[] hyperlinks = this.determineHyperlinks(it, (expectedOffset).intValue());
-    Assert.assertNotNull("No hyperlinks found!", hyperlinks);
-    Assert.assertEquals(1, hyperlinks.length);
-    final IHyperlink hyperlink = IterableExtensions.<IHyperlink>head(((Iterable<IHyperlink>)Conversions.doWrapArray(hyperlinks)));
-    Assert.assertEquals("Date", hyperlink.getHyperlinkText());
-    Assert.assertEquals((expectedOffset).intValue(), hyperlink.getHyperlinkRegion().getOffset());
-    Assert.assertEquals((expectedLength).intValue(), hyperlink.getHyperlinkRegion().getLength());
-    Assert.assertTrue((hyperlink instanceof JdtHyperlink));
-    final JdtHyperlink jdtHyperlink = ((JdtHyperlink) hyperlink);
-    final IJavaElement javaElement = jdtHyperlink.getJavaElement();
-    Assert.assertEquals("Date", javaElement.getElementName());
+  private void hasNoHyperlink(final CharSequence it) {
+    this.noHyperlinkIsOffered(this.hyperlinkingOn(this.dslFile(it), this.hyperlinkRegion(it).getOffset()));
   }
   
-  private List<Integer> getExpectedPositionInformation(final CharSequence input) {
-    List<Integer> _xblockexpression = null;
-    {
-      final String text = input.toString();
-      final int first = text.indexOf(this.c);
-      if ((first == (-1))) {
-        StringConcatenation _builder = new StringConcatenation();
-        _builder.append("Can\'t locate first position symbols \'");
-        _builder.append(this.c);
-        _builder.append("\' in the input text.");
-        Assert.fail(_builder.toString());
-      }
-      final int second = text.lastIndexOf(this.c);
-      if ((first == second)) {
-        StringConcatenation _builder_1 = new StringConcatenation();
-        _builder_1.append("Can\'t locate second position symbols \'");
-        _builder_1.append(this.c);
-        _builder_1.append("\' in the input text.");
-        Assert.fail(_builder_1.toString());
-      }
-      final int offset = first;
-      int _length = this.c.length();
-      final int length = ((second - first) - _length);
-      _xblockexpression = Collections.<Integer>unmodifiableList(CollectionLiterals.<Integer>newArrayList(Integer.valueOf(offset), Integer.valueOf(length)));
-    }
-    return _xblockexpression;
-  }
-  
-  private IHyperlink[] determineHyperlinks(final CharSequence text, final int offset) {
-    try {
-      IHyperlink[] _xblockexpression = null;
-      {
-        final String content = text.toString().replace(this.c, "");
-        final XtendFile xtendFile = this._workbenchTestHelper.xtendFile("Foo", content);
-        Resource _eResource = xtendFile.eResource();
-        final XtextResource resource = ((XtextResource) _eResource);
-        _xblockexpression = this._iHyperlinkHelper.createHyperlinksByOffset(resource, offset, true);
-      }
-      return _xblockexpression;
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
-    }
+  private void noHyperlinkIsOffered(final IHyperlink[] hyperlinks) {
+    Assert.assertNull(hyperlinks);
   }
 }


### PR DESCRIPTION
- Modify the JavaDocHyperlinkingTest class to use the
org.eclipse.xtext.ui.testing.AbstractHyperlinkingTest API class instead
of the AbstractXtendUITestCase non API class.
- With this refactoring, the Xtend JavaDocHyperlinkingTest class becomes
consistent to the Domainmodel HyperlinkingTest test class.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>