### PR TITLE
[eclipse/xtext#1279] use orbit simrel alias directly

### DIFF
--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-latest.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-latest.target
@@ -131,7 +131,7 @@
 		<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 		<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-oxygen.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-oxygen.target
@@ -119,7 +119,7 @@
 		<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 		<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-photon.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-photon.target
@@ -119,7 +119,7 @@
 		<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 		<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201809.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201809.target
@@ -119,7 +119,7 @@
 		<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 		<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201812.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201812.target
@@ -119,7 +119,7 @@
 		<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 		<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201903.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201903.target
@@ -119,7 +119,7 @@
 		<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 		<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201906.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201906.target
@@ -119,7 +119,7 @@
 		<unit id="org.objectweb.asm" version="7.1.0.v20190412-2143"/>
 		<unit id="org.objectweb.asm.tree" version="7.1.0.v20190412-2143"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
 	</location>
 </locations>
 </target>


### PR DESCRIPTION
[eclipse/xtext#1279] use orbit simrel alias directly
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>