### PR TITLE
[eclipse/xtext#1526] Replace Jenkinsfile with content of CBI.Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,12 +1,67 @@
 pipeline {
-  agent any
-
+  agent {
+    kubernetes {
+      label 'xtext-xtend-' + env.BRANCH_NAME + '-' + env.BUILD_NUMBER
+      defaultContainer 'xtext-buildenv'
+      yaml '''
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - name: jnlp
+    image: 'eclipsecbi/jenkins-jnlp-agent'
+    args: ['\$(JENKINS_SECRET)', '\$(JENKINS_NAME)']
+    resources:
+      limits:
+        memory: "0.4Gi"
+        cpu: "0.2"
+      requests:
+        memory: "0.4Gi"
+        cpu: "0.2"
+    volumeMounts:
+    - mountPath: /home/jenkins/.ssh
+      name: volume-known-hosts
+  - name: xtext-buildenv
+    image: docker.io/smoht/xtext-buildenv:0.7
+    tty: true
+    resources:
+      limits:
+        memory: "3.6Gi"
+        cpu: "1.0"
+      requests:
+        memory: "3.6Gi"
+        cpu: "1.0"
+    volumeMounts:
+    - name: settings-xml
+      mountPath: /home/jenkins/.m2/settings.xml
+      subPath: settings.xml
+      readOnly: true
+    - name: m2-repo
+      mountPath: /home/jenkins/.m2/repository
+    - name: volume-known-hosts
+      mountPath: /home/jenkins/.ssh
+  volumes:
+  - name: volume-known-hosts
+    configMap:
+      name: known-hosts
+  - name: settings-xml
+    configMap: 
+      name: m2-dir
+      items:
+      - key: settings.xml
+        path: settings.xml
+  - name: m2-repo
+    emptyDir: {}
+    '''
+    }
+  }
+  
   environment {
     DOWNSTREAM_JOBS = 'xtext-umbrella'
   }
 
   parameters {
-    choice(name: 'target_platform', choices: 'oxygen\nlatest\nr201906\nr201903\nr201812\nr201809\nphoton', description: 'Which Target Platform should be used?')
+    choice(name: 'target_platform', choices: ['oxygen', 'photon', 'r201812', 'r201809', 'r201903', 'r201906', 'latest'], description: 'Which Target Platform should be used?')
     booleanParam(
       name: 'TRIGGER_DOWNSTREAM_BUILD', 
       defaultValue: (env.BRANCH_NAME.startsWith('milestone')||env.BRANCH_NAME.startsWith('release')), 
@@ -21,56 +76,43 @@ pipeline {
     timestamps()
   }
 
-  tools { 
-    maven 'M3'
-  }
-  
   stages {
-    stage('Prepare') {
+    stage('Checkout') {
       steps {
-        sh '''
-          if [ -d ".git" ]; then
-            git reset --hard
-          fi
-        '''
         checkout scm
         
         script {
-          if ("latest" == params.target_platform) {
+          if (params.target_platform == 'latest') {
             currentBuild.displayName = "#${BUILD_NUMBER}(4.13)"
-          } else if ("r201906" == params.target_platform) {
+          } else if (params.target_platform == 'r201906') {
             currentBuild.displayName = "#${BUILD_NUMBER}(4.12)"
-          } else if ("r201903" == params.target_platform) {
+          } else if (params.target_platform == 'r201903') {
             currentBuild.displayName = "#${BUILD_NUMBER}(4.11)"
-          } else if ("r201812" == params.target_platform) {
+          } else if (params.target_platform == 'r201812') {
             currentBuild.displayName = "#${BUILD_NUMBER}(4.10)"
-          } else if ("r201809" == params.target_platform) {
+          } else if (params.target_platform == 'r201809') {
             currentBuild.displayName = "#${BUILD_NUMBER}(4.9)"
-          } else if ("photon" == params.target_platform) {
+          } else if (params.target_platform == 'photon') {
             currentBuild.displayName = "#${BUILD_NUMBER}(4.8)"
           } else {
             currentBuild.displayName = "#${BUILD_NUMBER}(4.7)"
           }
         }
-        dir('build') { deleteDir() }
-        dir('.m2/repository/org/eclipse/xtext') { deleteDir() }
-        dir('.m2/repository/org/eclipse/xtend') { deleteDir() }
-
         sh '''
-          sed_inplace() {
-            if [[ "$OSTYPE" == "darwin"* ]]; then
-              sed -i '' "$@"
-            else
-              sed -i "$@"
-            fi
-          }
-          
-          targetfiles="$(find releng -type f -iname '*.target')"
-          for targetfile in $targetfiles
-          do
-            echo "Redirecting target platforms in $targetfile to $JENKINS_URL"
-            sed_inplace "s?<repository location=\\".*/job/\\([^/]*\\)/job/\\([^/]*\\)/?<repository location=\\"$JENKINS_URL/job/\\1/job/\\2/?" $targetfile
-          done
+            sed_inplace() {
+                if [[ "$OSTYPE" == "darwin"* ]]; then
+                    sed -i '' "$@"
+                else
+                    sed -i "$@" 
+                fi    
+            }
+            
+            targetfiles="$(find releng -type f -iname '*.target')"
+            for targetfile in $targetfiles
+            do
+                echo "Redirecting target platforms in $targetfile to $JENKINS_URL"
+                sed_inplace "s?<repository location=\\".*/job/\\([^/]*\\)/job/\\([^/]*\\)/?<repository location=\\"$JENKINS_URL/job/\\1/job/\\2/?" $targetfile
+            done
         '''
       }
     }
@@ -85,17 +127,20 @@ pipeline {
       stages { // TODO use of parallel { here kills Tycho process with OOM
         stage('Maven Plugin Build') {
           steps {
-            sh "./2-maven-plugin-build.sh --local-repository=$WORKSPACE/.m2/repository"
+            sh """
+              ./2-maven-plugin-build.sh -s /home/jenkins/.m2/settings.xml --local-repository=/home/jenkins/.m2/repository
+            """
           } // END steps
         } // END stage
         stage('Maven Tycho Build') {
           steps {
-            wrap([$class:'Xvnc', useXauthority: true]) {
-              sh "./3-maven-tycho-build.sh --tp=${params.target_platform} --local-repository=$WORKSPACE/.m2/repository"
-            }
+            sh """
+              /home/vnc/.vnc/xstartup.sh
+              ./3-maven-tycho-build.sh -s /home/jenkins/.m2/settings.xml --tp=${params.target_platform} --local-repository=/home/jenkins/.m2/repository
+            """
           }// END steps
         } // END stage
-      } // END stages
+      } // END parallel
     } // END stage
   } // END stages
 
@@ -120,28 +165,37 @@ pipeline {
     failure {
       archiveArtifacts artifacts: 'org.eclipse.xtend.ide.swtbot.tests/screenshots/**, build/**, **/target/work/data/.metadata/.log, **/hs_err_pid*.log'
     }
-    changed {
+    cleanup {
       script {
-        def envName = ''
-        if (env.JENKINS_URL.contains('ci.eclipse.org/xtext')) {
-          envName = ' (JIPP)'
-        } else if (env.JENKINS_URL.contains('typefox.io')) {
-          envName = ' (TF)'
-        }
-        
         def curResult = currentBuild.currentResult
-        def color = '#00FF00'
-        if (curResult == 'SUCCESS') {
-           if (currentBuild.previousBuild != null && currentBuild.previousBuild.result != 'SUCCESS') {
-             curResult = 'FIXED'
-           }
-        } else if (curResult == 'UNSTABLE') {
-          color = '#FFFF00'
-        } else { // FAILURE, ABORTED, NOT_BUILD
-          color = '#FF0000'
+        def lastResult = 'NEW'
+        if (currentBuild.previousBuild != null) {
+          lastResult = currentBuild.previousBuild.result
         }
-        
-        slackSend message: "${curResult}: <${env.BUILD_URL}|${env.JOB_NAME}#${env.BUILD_NUMBER}${envName}>", botUser: true, channel: 'xtext-builds', color: "${color}"
+
+        if (curResult != 'SUCCESS' || lastResult != 'SUCCESS') {
+          def color = ''
+          switch (curResult) {
+            case 'SUCCESS':
+              color = '#00FF00'
+              break
+            case 'UNSTABLE':
+              color = '#FFFF00'
+              break
+            case 'FAILURE':
+              color = '#FF0000'
+              break
+            default: // e.g. ABORTED
+              color = '#666666'
+          }
+
+          slackSend (
+            message: "${lastResult} => ${curResult}: <${env.BUILD_URL}|${env.JOB_NAME}#${env.BUILD_NUMBER}>",
+            botUser: true,
+            channel: 'xtext-builds',
+            color: "${color}"
+          )
+        }
       }
     }
   }


### PR DESCRIPTION
This commit purposefully introduces a duplicate Jenkinsfile,
which is meant to be kept long enough for all
branches to receive it.

After this and when the Jenkins jobs point to the new Jenkinsfile,
CBI.Jenkinsfile can be removed without losing build histories in Jenkins

Signed-off-by: Nico Prediger <mail@nicoprediger.de>