### PR TITLE
[eclipse/xtext-lib#224] Stable method order when using Delegate 

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/DelegateCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/DelegateCompilerTest.xtend
@@ -539,5 +539,44 @@ class DelegateCompilerTest extends AbstractXtendCompilerTest {
 		text.file
 	}
 	
+	@Test
+	def void methodOrder() {
+		val text = ''' 
+			import org.eclipse.xtend.lib.annotations.Delegate
+			interface A {
+				def void c()
+				def void a()
+				def void b()
+			}
+			class C implements A {
+				@Delegate A a
+			}
+		'''
+		text.file.assertNoIssues
+		text.compile [
+			assertEquals('''
+				import org.eclipse.xtend.lib.annotations.Delegate;
+				
+				@SuppressWarnings("all")
+				public class C implements A {
+				  @Delegate
+				  private A a;
+				  
+				  public void a() {
+				    this.a.a();
+				  }
+				  
+				  public void b() {
+				    this.a.b();
+				  }
+				  
+				  public void c() {
+				    this.a.c();
+				  }
+				}
+			'''.toString, it.getGeneratedCode("C"))
+		]
+	}
+	
 
 }

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/DelegateCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/DelegateCompilerTest.java
@@ -1089,4 +1089,90 @@ public class DelegateCompilerTest extends AbstractXtendCompilerTest {
       throw Exceptions.sneakyThrow(_e);
     }
   }
+  
+  @Test
+  public void methodOrder() {
+    try {
+      StringConcatenation _builder = new StringConcatenation();
+      _builder.append("import org.eclipse.xtend.lib.annotations.Delegate");
+      _builder.newLine();
+      _builder.append("interface A {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("def void c()");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("def void a()");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("def void b()");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      _builder.append("class C implements A {");
+      _builder.newLine();
+      _builder.append("\t");
+      _builder.append("@Delegate A a");
+      _builder.newLine();
+      _builder.append("}");
+      _builder.newLine();
+      final String text = _builder.toString();
+      this._validationTestHelper.assertNoIssues(this.file(text));
+      final IAcceptor<CompilationTestHelper.Result> _function = (CompilationTestHelper.Result it) -> {
+        StringConcatenation _builder_1 = new StringConcatenation();
+        _builder_1.append("import org.eclipse.xtend.lib.annotations.Delegate;");
+        _builder_1.newLine();
+        _builder_1.newLine();
+        _builder_1.append("@SuppressWarnings(\"all\")");
+        _builder_1.newLine();
+        _builder_1.append("public class C implements A {");
+        _builder_1.newLine();
+        _builder_1.append("  ");
+        _builder_1.append("@Delegate");
+        _builder_1.newLine();
+        _builder_1.append("  ");
+        _builder_1.append("private A a;");
+        _builder_1.newLine();
+        _builder_1.append("  ");
+        _builder_1.newLine();
+        _builder_1.append("  ");
+        _builder_1.append("public void a() {");
+        _builder_1.newLine();
+        _builder_1.append("    ");
+        _builder_1.append("this.a.a();");
+        _builder_1.newLine();
+        _builder_1.append("  ");
+        _builder_1.append("}");
+        _builder_1.newLine();
+        _builder_1.append("  ");
+        _builder_1.newLine();
+        _builder_1.append("  ");
+        _builder_1.append("public void b() {");
+        _builder_1.newLine();
+        _builder_1.append("    ");
+        _builder_1.append("this.a.b();");
+        _builder_1.newLine();
+        _builder_1.append("  ");
+        _builder_1.append("}");
+        _builder_1.newLine();
+        _builder_1.append("  ");
+        _builder_1.newLine();
+        _builder_1.append("  ");
+        _builder_1.append("public void c() {");
+        _builder_1.newLine();
+        _builder_1.append("    ");
+        _builder_1.append("this.a.c();");
+        _builder_1.newLine();
+        _builder_1.append("  ");
+        _builder_1.append("}");
+        _builder_1.newLine();
+        _builder_1.append("}");
+        _builder_1.newLine();
+        Assert.assertEquals(_builder_1.toString(), it.getGeneratedCode("C"));
+      };
+      this.compilationTestHelper.compile(text, _function);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
 }

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/CodeGenerationContextImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/CodeGenerationContextImpl.java
@@ -80,18 +80,6 @@ public class CodeGenerationContextImpl implements CodeGenerationContext {
     this.getFileSystemSupport().delete(path);
   }
   
-  public void mkdir(final Path path) {
-    this.getFileSystemSupport().mkdir(path);
-  }
-  
-  public void setContents(final Path path, final CharSequence contents) {
-    this.getFileSystemSupport().setContents(path, contents);
-  }
-  
-  public void setContentsAsStream(final Path path, final InputStream source) {
-    this.getFileSystemSupport().setContentsAsStream(path, source);
-  }
-  
   public boolean exists(final Path path) {
     return this.getFileSystemSupport().exists(path);
   }
@@ -122,6 +110,18 @@ public class CodeGenerationContextImpl implements CodeGenerationContext {
   
   public boolean isFolder(final Path path) {
     return this.getFileSystemSupport().isFolder(path);
+  }
+  
+  public void mkdir(final Path path) {
+    this.getFileSystemSupport().mkdir(path);
+  }
+  
+  public void setContents(final Path path, final CharSequence contents) {
+    this.getFileSystemSupport().setContents(path, contents);
+  }
+  
+  public void setContentsAsStream(final Path path, final InputStream source) {
+    this.getFileSystemSupport().setContentsAsStream(path, source);
   }
   
   public URI toURI(final Path path) {

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/TransformationContextImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/TransformationContextImpl.java
@@ -197,16 +197,16 @@ public class TransformationContextImpl implements TransformationContext {
     return this.getTypeReferenceProvider().newSelfTypeReference(typeDeclaration);
   }
   
+  public TypeReference newTypeReference(final Class<?> clazz, final TypeReference... typeArguments) {
+    return this.getTypeReferenceProvider().newTypeReference(clazz, typeArguments);
+  }
+  
   public TypeReference newTypeReference(final String typeName, final TypeReference... typeArguments) {
     return this.getTypeReferenceProvider().newTypeReference(typeName, typeArguments);
   }
   
   public TypeReference newTypeReference(final Type typeDeclaration, final TypeReference... typeArguments) {
     return this.getTypeReferenceProvider().newTypeReference(typeDeclaration, typeArguments);
-  }
-  
-  public TypeReference newTypeReference(final Class<?> clazz, final TypeReference... typeArguments) {
-    return this.getTypeReferenceProvider().newTypeReference(clazz, typeArguments);
   }
   
   public TypeReference newWildcardTypeReference() {
@@ -221,36 +221,36 @@ public class TransformationContextImpl implements TransformationContext {
     return this.getTypeReferenceProvider().newWildcardTypeReferenceWithLowerBound(lowerBound);
   }
   
-  public AnnotationReference newAnnotationReference(final String annotationTypeName) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeName);
+  public AnnotationReference newAnnotationReference(final AnnotationReference annotationReference) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationReference);
   }
   
-  public AnnotationReference newAnnotationReference(final Type annotationTypeDelcaration) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeDelcaration);
+  public AnnotationReference newAnnotationReference(final AnnotationReference annotationReference, final Procedure1<AnnotationReferenceBuildContext> initializer) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationReference, initializer);
   }
   
   public AnnotationReference newAnnotationReference(final Class<?> annotationClass) {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationClass);
   }
   
-  public AnnotationReference newAnnotationReference(final AnnotationReference annotationReference) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationReference);
+  public AnnotationReference newAnnotationReference(final Class<?> annotationClass, final Procedure1<AnnotationReferenceBuildContext> initializer) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationClass, initializer);
+  }
+  
+  public AnnotationReference newAnnotationReference(final String annotationTypeName) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeName);
   }
   
   public AnnotationReference newAnnotationReference(final String annotationTypeName, final Procedure1<AnnotationReferenceBuildContext> initializer) {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeName, initializer);
   }
   
+  public AnnotationReference newAnnotationReference(final Type annotationTypeDelcaration) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeDelcaration);
+  }
+  
   public AnnotationReference newAnnotationReference(final Type annotationTypeDelcaration, final Procedure1<AnnotationReferenceBuildContext> initializer) {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeDelcaration, initializer);
-  }
-  
-  public AnnotationReference newAnnotationReference(final Class<?> annotationClass, final Procedure1<AnnotationReferenceBuildContext> initializer) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationClass, initializer);
-  }
-  
-  public AnnotationReference newAnnotationReference(final AnnotationReference annotationReference, final Procedure1<AnnotationReferenceBuildContext> initializer) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationReference, initializer);
   }
   
   public boolean exists(final Path path) {

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ValidationContextImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/ValidationContextImpl.java
@@ -190,16 +190,16 @@ public class ValidationContextImpl implements ValidationContext {
     return this.getTypeReferenceProvider().newSelfTypeReference(typeDeclaration);
   }
   
+  public TypeReference newTypeReference(final Class<?> clazz, final TypeReference... typeArguments) {
+    return this.getTypeReferenceProvider().newTypeReference(clazz, typeArguments);
+  }
+  
   public TypeReference newTypeReference(final String typeName, final TypeReference... typeArguments) {
     return this.getTypeReferenceProvider().newTypeReference(typeName, typeArguments);
   }
   
   public TypeReference newTypeReference(final Type typeDeclaration, final TypeReference... typeArguments) {
     return this.getTypeReferenceProvider().newTypeReference(typeDeclaration, typeArguments);
-  }
-  
-  public TypeReference newTypeReference(final Class<?> clazz, final TypeReference... typeArguments) {
-    return this.getTypeReferenceProvider().newTypeReference(clazz, typeArguments);
   }
   
   public TypeReference newWildcardTypeReference() {
@@ -214,36 +214,36 @@ public class ValidationContextImpl implements ValidationContext {
     return this.getTypeReferenceProvider().newWildcardTypeReferenceWithLowerBound(lowerBound);
   }
   
-  public AnnotationReference newAnnotationReference(final String annotationTypeName) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeName);
+  public AnnotationReference newAnnotationReference(final AnnotationReference annotationReference) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationReference);
   }
   
-  public AnnotationReference newAnnotationReference(final Type annotationTypeDelcaration) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeDelcaration);
+  public AnnotationReference newAnnotationReference(final AnnotationReference annotationReference, final Procedure1<AnnotationReferenceBuildContext> initializer) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationReference, initializer);
   }
   
   public AnnotationReference newAnnotationReference(final Class<?> annotationClass) {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationClass);
   }
   
-  public AnnotationReference newAnnotationReference(final AnnotationReference annotationReference) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationReference);
+  public AnnotationReference newAnnotationReference(final Class<?> annotationClass, final Procedure1<AnnotationReferenceBuildContext> initializer) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationClass, initializer);
+  }
+  
+  public AnnotationReference newAnnotationReference(final String annotationTypeName) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeName);
   }
   
   public AnnotationReference newAnnotationReference(final String annotationTypeName, final Procedure1<AnnotationReferenceBuildContext> initializer) {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeName, initializer);
   }
   
+  public AnnotationReference newAnnotationReference(final Type annotationTypeDelcaration) {
+    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeDelcaration);
+  }
+  
   public AnnotationReference newAnnotationReference(final Type annotationTypeDelcaration, final Procedure1<AnnotationReferenceBuildContext> initializer) {
     return this.getAnnotationReferenceProvider().newAnnotationReference(annotationTypeDelcaration, initializer);
-  }
-  
-  public AnnotationReference newAnnotationReference(final Class<?> annotationClass, final Procedure1<AnnotationReferenceBuildContext> initializer) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationClass, initializer);
-  }
-  
-  public AnnotationReference newAnnotationReference(final AnnotationReference annotationReference, final Procedure1<AnnotationReferenceBuildContext> initializer) {
-    return this.getAnnotationReferenceProvider().newAnnotationReference(annotationReference, initializer);
   }
   
   public boolean exists(final Path path) {


### PR DESCRIPTION
[eclipse/xtext-lib#224] Stable method order when using Delegate annotation