### PR TITLE
[eclipse/xtext-eclipse#1155] Avoid unconditonal cast to IXtextDocument

### DIFF
--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/contentassist/javadoc/XtendJavaDocContentAssistProcessor.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/contentassist/javadoc/XtendJavaDocContentAssistProcessor.java
@@ -11,9 +11,9 @@ import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.xtext.common.types.xtext.ui.ITypesProposalProvider;
 import org.eclipse.xtext.scoping.IScopeProvider;
-import org.eclipse.xtext.ui.editor.XtextSourceViewer;
 import org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 
 import com.google.inject.Inject;
 
@@ -33,11 +33,17 @@ public class XtendJavaDocContentAssistProcessor extends AbstractJavaDocContentAs
 
 	@Inject
 	private XtendJavaDocProposalFactory proposalFactory;
+	
+	/**
+	 * @since 2.19
+	 */
+	@Inject
+	private XtextDocumentUtil xtextDocumentUtil;
 
 	@Override
 	public ICompletionProposal[] computeCompletionProposals(ITextViewer viewer, int offset) {
-		if(viewer instanceof XtextSourceViewer){
-			IXtextDocument document = (IXtextDocument) viewer.getDocument();
+		IXtextDocument document = xtextDocumentUtil.getXtextDocument(viewer);
+		if (document != null) {
 			return document.priorityReadOnly(createCompletionProposalComputer(viewer, offset));
 		}
 		return new ICompletionProposal[0];

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/editor/OverrideIndicatorRulerAction.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/editor/OverrideIndicatorRulerAction.java
@@ -26,7 +26,6 @@ import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.editor.XtextMarkerRulerAction;
 import org.eclipse.xtext.ui.editor.actions.IActionContributor;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
-import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil;
 import org.eclipse.xtext.util.concurrent.IUnitOfWork;
 import org.eclipse.xtext.xbase.typesystem.override.OverrideHelper;
 
@@ -141,7 +140,7 @@ public class OverrideIndicatorRulerAction extends ResourceAction implements IAct
 	}
 
 	protected IXtextDocument getDocument() {
-		IXtextDocument xtextDocument = XtextDocumentUtil.get(editor);
+		IXtextDocument xtextDocument = editor.getDocument();
 		return xtextDocument;
 	}
 


### PR DESCRIPTION
[eclipse/xtext-eclipse#1155] Avoid unconditonal cast to IXtextDocument