### PR TITLE
[eclipse/xtext#1550] set default compliance level to 8.0

### DIFF
--- a/org.eclipse.xtend.core/model/RichStrings.genmodel
+++ b/org.eclipse.xtend.core/model/RichStrings.genmodel
@@ -3,7 +3,7 @@
     xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" copyrightText="Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.&#xA;All rights reserved. This program and the accompanying materials&#xA;are made available under the terms of the Eclipse Public License v1.0&#xA;which accompanies this distribution, and is available at&#xA;http://www.eclipse.org/legal/epl-v10.html"
     modelDirectory="/org.eclipse.xtend.core/emf-gen" modelPluginID="org.eclipse.xtend.core"
     modelName="RichStrings" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
-    importerID="org.eclipse.emf.importer.ecore" complianceLevel="5.0" copyrightFields="false"
+    importerID="org.eclipse.emf.importer.ecore" complianceLevel="8.0" copyrightFields="false"
     runtimeVersion="2.9" usedGenPackages="platform:/resource/org.eclipse.xtext.common.types/model/JavaVMTypes.genmodel#//types platform:/resource/org.eclipse.xtext.xbase/model/Xbase.genmodel#//xAnnotations platform:/resource/org.eclipse.xtext.xbase/model/Xbase.genmodel#//xbase Xtend.genmodel#//xtend platform:/resource/org.eclipse.xtext.xbase/model/Xbase.genmodel#//xtype">
   <foreignModel>RichStrings.ecore</foreignModel>
   <genPackages prefix="ProcessedRichString" basePackage="org.eclipse.xtend.core" disposableProviderFactory="true"

--- a/org.eclipse.xtend.core/model/Xtend.genmodel
+++ b/org.eclipse.xtend.core/model/Xtend.genmodel
@@ -3,7 +3,7 @@
     xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" copyrightText="Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.&#xA;All rights reserved. This program and the accompanying materials&#xA;are made available under the terms of the Eclipse Public License v1.0&#xA;which accompanies this distribution, and is available at&#xA;http://www.eclipse.org/legal/epl-v10.html"
     modelDirectory="/org.eclipse.xtend.core/emf-gen" modelPluginID="org.eclipse.xtend.core"
     modelName="Xtend" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
-    importerID="org.eclipse.emf.importer.ecore" complianceLevel="5.0" copyrightFields="false"
+    importerID="org.eclipse.emf.importer.ecore" complianceLevel="8.0" copyrightFields="false"
     runtimeVersion="2.9" usedGenPackages="platform:/resource/org.eclipse.xtext.common.types/model/JavaVMTypes.genmodel#//types platform:/resource/org.eclipse.xtext.xbase/model/Xbase.genmodel#//xAnnotations platform:/resource/org.eclipse.xtext.xbase/model/Xbase.genmodel#//xbase platform:/resource/org.eclipse.xtext.xbase/model/Xbase.genmodel#//xtype">
   <foreignModel>Xtend.ecore</foreignModel>
   <genPackages prefix="Xtend" basePackage="org.eclipse.xtend.core" disposableProviderFactory="true"


### PR DESCRIPTION
[eclipse/xtext#1550] set default compliance level to 8.0
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>