### PR TITLE
Fix typo in the documentation of XtendDescriptionLabelProvider.

### DIFF
--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/labeling/XtendDescriptionLabelProvider.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/labeling/XtendDescriptionLabelProvider.java
@@ -17,7 +17,7 @@ import org.eclipse.xtext.ui.label.DefaultDescriptionLabelProvider;
 import com.google.inject.Inject;
 
 /**
- * Provides labels for a IEObjectDescriptions and IResourceDescriptions.
+ * Provides labels for IEObjectDescriptions and IResourceDescriptions.
  * 
  * See https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#label-provider
  */


### PR DESCRIPTION
Signed-off-by: Tamas Miklossy <miklossy@itemis.de>