### PR TITLE
[eclipse/xtext#1561] removed superfluous timestamps() config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,6 @@ spec:
     buildDiscarder(logRotator(numToKeepStr:'5'))
     disableConcurrentBuilds()
     timeout(time: 240, unit: 'MINUTES')
-    timestamps()
   }
 
   stages {


### PR DESCRIPTION
[eclipse/xtext#1561] removed superfluous timestamps() config
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>