### PR TITLE
[eclipse/xtext#1568] Remove Buildship classpath container

### DIFF
--- a/org.eclipse.xtend.core.tests/org.eclipse.xtend.core.tests.smoke-suites.launch
+++ b/org.eclipse.xtend.core.tests/org.eclipse.xtend.core.tests.smoke-suites.launch
@@ -11,7 +11,6 @@
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
     <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.buildship.core.classpathprovider"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.xtend.core.tests"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx1g"/>


### PR DESCRIPTION
These changes were automatically applied to the launch configurations on
a fresh workspace setup.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>