### PR TITLE
avoid 'Directory is empty. Can't process' warning

### DIFF
--- a/releng/org.eclipse.xtend.tycho.parent/pom.xml
+++ b/releng/org.eclipse.xtend.tycho.parent/pom.xml
@@ -270,6 +270,7 @@
 					</execution>
 				</executions>
 				<configuration>
+					<showEmptyDirWarning>false</showEmptyDirWarning>
 					<outputDirectory>${basedir}/xtend-gen</outputDirectory>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
avoid 'Directory is empty. Can't process' warning
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>