### PR TITLE
[#919] Add quickfixes that adds JUnit 4 or 5 libs to the classpath

### DIFF
--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/AddJunitLibToClasspathQuickfixTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/AddJunitLibToClasspathQuickfixTest.xtend
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.ide.tests.quickfix
+
+import javax.inject.Inject
+import org.eclipse.xtend.ide.buildpath.Junit4LibClasspathAdder
+import org.eclipse.xtend.ide.buildpath.Junit5LibClasspathAdder
+import org.eclipse.xtend.ide.tests.XtendIDEInjectorProvider
+import org.eclipse.xtend.ide.tests.buildpath.AbstractJunitLibClasspathAdderTestCase
+import org.eclipse.xtext.diagnostics.Diagnostic
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * @author vivien.jovet - Initial contribution and API
+ */
+@InjectWith(XtendIDEInjectorProvider)
+@RunWith(XtextRunner)
+class AddJunitLibToClasspathQuickfixTest extends AbstractJunitLibClasspathAdderTestCase {
+
+    @Inject extension QuickfixTestBuilder builder
+    
+    @Before
+    override void setUpProject() throws Exception {
+        closeAllEditors(false)
+        super.setUpProject
+    }
+
+    @Test
+    def void addJUnit4LibToPluginProjectClasspath() {
+        val content = '''
+            import org.junit|.Test
+            
+            class FooTest {
+                @Test
+                def test() {}
+            }
+        '''
+        create('FooTest.xtend', content)
+            .assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC)
+            .assertResolutionLabels('Add JUnit 4 lib to classpath')
+            .assertModelAfterQuickfix(content.replace('|', ''))
+        assertRequireBundles(#[Junit4LibClasspathAdder.BUNDLE_ID])
+    }
+
+    @Test
+    def void addJUnit4LibToProjectClasspath() {
+        removePluginNature
+        val content = '''
+            import org.junit|.Test
+            
+            class FooTest {
+                @Test
+                def test() {}
+            }
+        '''
+        create('FooTest.xtend', content)
+            .assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC)
+            .assertResolutionLabels('Add JUnit 4 lib to classpath')
+            .assertModelAfterQuickfix(content.replace('|', ''))
+        assertClasspath(
+            'classpath should contain a JUnit 4 container entry', 
+            Junit4LibClasspathAdder.JUNIT4_LIBRARY_PATH
+        )
+    }
+
+    @Test
+    def void addJUnit5LibToPluginProjectClasspath() {
+        val content = '''
+            import org.junit.jupiter.api|.Test
+            
+            class FooTest2 {
+                @Test
+                def test() {}
+            }
+        '''
+        create('FooTest2.xtend', content)
+            .assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC)
+            .assertResolutionLabels('Add JUnit 5 lib to classpath')
+            .assertModelAfterQuickfix(content.replace('|', ''))
+       assertRequireBundles(Junit5LibClasspathAdder.BUNDLE_IDS)
+    }
+    
+    
+    @Test
+    def void addJUnit5LibToProjectClasspath() {
+        removePluginNature
+        val content = '''
+            import org.junit.jupiter.api|.Test
+            
+            class FooTest {
+                @Test
+                def test() {}
+            }
+        '''
+        create('FooTest.xtend', content)
+            .assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC)
+            .assertResolutionLabels('Add JUnit 5 lib to classpath')
+            .assertModelAfterQuickfix(content.replace('|', ''))
+        assertClasspath(
+            'classpath should contain a JUnit 5 container entry', 
+            Junit5LibClasspathAdder.JUNIT5_LIBRARY_PATH
+        )
+    }
+
+}

--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/QuickfixTest.xtend
@@ -5432,4 +5432,5 @@ class QuickfixTest extends AbstractXtendUITestCase {
 			}
 		''')
 	}
+	
 }

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/buildpath/AbstractJunitLibClasspathAdderTestCase.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/buildpath/AbstractJunitLibClasspathAdderTestCase.xtend
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.ide.tests.buildpath
+
+import com.google.inject.Inject
+import org.eclipse.core.runtime.IPath
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.core.runtime.Path
+import org.eclipse.jdt.core.IClasspathEntry
+import org.eclipse.jdt.core.JavaCore
+import org.eclipse.xtend.ide.buildpath.XtendClasspathContainer
+import org.eclipse.xtend.ide.buildpath.XtendLibClasspathAdder
+import org.eclipse.xtend.ide.tests.AbstractXtendTestCase
+import org.eclipse.xtend.ide.tests.WorkbenchTestHelper
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil
+import org.eclipse.xtext.ui.testing.util.TargetPlatformUtil
+import org.eclipse.xtext.util.MergeableManifest2
+import org.junit.AfterClass
+import org.junit.Before
+import org.junit.BeforeClass
+
+import static org.junit.Assert.assertTrue
+
+/**
+ * @author vivienjovet - Initial contribution and API
+ */
+abstract class AbstractJunitLibClasspathAdderTestCase {
+    
+    @Inject protected extension WorkbenchTestHelper workbenchHelper
+
+    @Inject extension XtendLibClasspathAdder xtendLibAdder
+    
+    
+    @BeforeClass
+    def static void setUp() throws Exception {
+        TargetPlatformUtil.setTargetPlatform(AbstractXtendTestCase)
+    }
+
+    @Before
+    def void setUpProject() throws Exception {
+        IResourcesSetupUtil.cleanWorkspace
+        WorkbenchTestHelper.createPluginProject(WorkbenchTestHelper.TESTPROJECT_NAME,
+            XtendClasspathContainer.BUNDLE_IDS_TO_INCLUDE)
+    }
+
+    @AfterClass
+    def static void tearDownProject() throws Exception {
+        IResourcesSetupUtil.cleanWorkspace();
+    }
+    
+    def protected removePluginNature() {
+        val project = project
+        val description = project.description
+        description.natureIds = description.natureIds.filter[it != 'org.eclipse.pde.PluginNature']
+        project.setDescription(description, new NullProgressMonitor)
+        JavaCore.create(project).addLibsToClasspath(new NullProgressMonitor)
+    }
+    
+    def protected assertClasspath(String message, IPath entryPath) {
+        assertTrue(
+            message, 
+            JavaCore.create(project).rawClasspath.exists[path == entryPath && entryKind == IClasspathEntry.CPE_CONTAINER]
+        )
+    }
+
+    def protected assertRequireBundles(String[] expectedBundleIds) {
+        val manifest = new MergeableManifest2(project.getFile(new Path('META-INF/MANIFEST.MF')).contents)
+        val requireBunbles = manifest.mainAttributes.get(MergeableManifest2.REQUIRE_BUNDLE)
+        for (bundleId : expectedBundleIds)
+            assertTrue('''require bundle entry «bundleId» is present''', requireBunbles.contains(bundleId))
+    }
+    
+}

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/buildpath/JunitLibClasspathAdderTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/buildpath/JunitLibClasspathAdderTest.xtend
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.ide.tests.buildpath
+
+import javax.inject.Inject
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.jdt.core.JavaCore
+import org.eclipse.xtend.ide.buildpath.Junit4LibClasspathAdder
+import org.eclipse.xtend.ide.buildpath.Junit5LibClasspathAdder
+import org.eclipse.xtend.ide.tests.XtendIDEInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * @author vivien.jovet - Initial contribution and API
+ */
+@InjectWith(XtendIDEInjectorProvider)
+@RunWith(XtextRunner)
+class JunitLibClasspathAdderTest extends AbstractJunitLibClasspathAdderTestCase {
+
+    @Inject Junit4LibClasspathAdder junit4LibAdder
+
+    @Inject Junit5LibClasspathAdder junit5LibAdder
+
+    @Test
+    def void addJUnit4LibToPluginProjectClasspath() {
+        junit4LibAdder.addLibsToClasspath(JavaCore.create(project), new NullProgressMonitor)
+        JavaCore.create(project).rawClasspath.forEach[println(path)]
+        assertRequireBundles(#[Junit4LibClasspathAdder.BUNDLE_ID])
+    }
+
+    @Test
+    def void addJUnit4LibToProjectClasspath() {
+        removePluginNature
+        junit4LibAdder.addLibsToClasspath(JavaCore.create(project), new NullProgressMonitor)
+        assertClasspath(
+            'classpath should contain a JUnit 4 container entry',
+            Junit4LibClasspathAdder.JUNIT4_LIBRARY_PATH
+        )
+    }
+
+    @Test
+    def void addJUnit5LibToPluginProjectClasspath() {
+        junit5LibAdder.addLibsToClasspath(JavaCore.create(project), new NullProgressMonitor)
+        assertRequireBundles(Junit5LibClasspathAdder.BUNDLE_IDS)
+    }
+
+    @Test
+    def void addJUnit5LibToProjectClasspath() {
+        removePluginNature
+        junit5LibAdder.addLibsToClasspath(JavaCore.create(project), new NullProgressMonitor)
+        assertClasspath(
+            'classpath should contain a JUnit 5 container entry',
+            Junit5LibClasspathAdder.JUNIT5_LIBRARY_PATH
+        )
+    }
+
+}

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/buildpath/AbstractJunitLibClasspathAdderTestCase.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/buildpath/AbstractJunitLibClasspathAdderTestCase.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.ide.tests.buildpath;
+
+import com.google.common.base.Objects;
+import com.google.inject.Inject;
+import java.io.InputStream;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.xtend.ide.buildpath.XtendClasspathContainer;
+import org.eclipse.xtend.ide.buildpath.XtendLibClasspathAdder;
+import org.eclipse.xtend.ide.tests.AbstractXtendTestCase;
+import org.eclipse.xtend.ide.tests.WorkbenchTestHelper;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
+import org.eclipse.xtext.ui.testing.util.TargetPlatformUtil;
+import org.eclipse.xtext.util.MergeableManifest2;
+import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+/**
+ * @author vivienjovet - Initial contribution and API
+ */
+@SuppressWarnings("all")
+public abstract class AbstractJunitLibClasspathAdderTestCase {
+  @Inject
+  @Extension
+  protected WorkbenchTestHelper workbenchHelper;
+  
+  @Inject
+  @Extension
+  private XtendLibClasspathAdder xtendLibAdder;
+  
+  @BeforeClass
+  public static void setUp() throws Exception {
+    TargetPlatformUtil.setTargetPlatform(AbstractXtendTestCase.class);
+  }
+  
+  @Before
+  public void setUpProject() throws Exception {
+    IResourcesSetupUtil.cleanWorkspace();
+    WorkbenchTestHelper.createPluginProject(WorkbenchTestHelper.TESTPROJECT_NAME, 
+      XtendClasspathContainer.BUNDLE_IDS_TO_INCLUDE);
+  }
+  
+  @AfterClass
+  public static void tearDownProject() throws Exception {
+    IResourcesSetupUtil.cleanWorkspace();
+  }
+  
+  protected void removePluginNature() {
+    try {
+      final IProject project = this.workbenchHelper.getProject();
+      final IProjectDescription description = project.getDescription();
+      final Function1<String, Boolean> _function = (String it) -> {
+        return Boolean.valueOf((!Objects.equal(it, "org.eclipse.pde.PluginNature")));
+      };
+      description.setNatureIds(((String[])Conversions.unwrapArray(IterableExtensions.<String>filter(((Iterable<String>)Conversions.doWrapArray(description.getNatureIds())), _function), String.class)));
+      NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
+      project.setDescription(description, _nullProgressMonitor);
+      IJavaProject _create = JavaCore.create(project);
+      NullProgressMonitor _nullProgressMonitor_1 = new NullProgressMonitor();
+      this.xtendLibAdder.addLibsToClasspath(_create, _nullProgressMonitor_1);
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  protected void assertClasspath(final String message, final IPath entryPath) {
+    try {
+      final Function1<IClasspathEntry, Boolean> _function = (IClasspathEntry it) -> {
+        return Boolean.valueOf((Objects.equal(it.getPath(), entryPath) && (it.getEntryKind() == IClasspathEntry.CPE_CONTAINER)));
+      };
+      Assert.assertTrue(message, 
+        IterableExtensions.<IClasspathEntry>exists(((Iterable<IClasspathEntry>)Conversions.doWrapArray(JavaCore.create(this.workbenchHelper.getProject()).getRawClasspath())), _function));
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  protected void assertRequireBundles(final String[] expectedBundleIds) {
+    try {
+      IProject _project = this.workbenchHelper.getProject();
+      Path _path = new Path("META-INF/MANIFEST.MF");
+      InputStream _contents = _project.getFile(_path).getContents();
+      final MergeableManifest2 manifest = new MergeableManifest2(_contents);
+      final String requireBunbles = manifest.getMainAttributes().get(MergeableManifest2.REQUIRE_BUNDLE);
+      for (final String bundleId : expectedBundleIds) {
+        StringConcatenation _builder = new StringConcatenation();
+        _builder.append("require bundle entry ");
+        _builder.append(bundleId);
+        _builder.append(" is present");
+        Assert.assertTrue(_builder.toString(), requireBunbles.contains(bundleId));
+      }
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+}

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/buildpath/JunitLibClasspathAdderTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/buildpath/JunitLibClasspathAdderTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.ide.tests.buildpath;
+
+import java.util.List;
+import java.util.function.Consumer;
+import javax.inject.Inject;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.xtend.ide.buildpath.Junit4LibClasspathAdder;
+import org.eclipse.xtend.ide.buildpath.Junit5LibClasspathAdder;
+import org.eclipse.xtend.ide.tests.XtendIDEInjectorProvider;
+import org.eclipse.xtend.ide.tests.buildpath.AbstractJunitLibClasspathAdderTestCase;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.InputOutput;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author vivien.jovet - Initial contribution and API
+ */
+@InjectWith(XtendIDEInjectorProvider.class)
+@RunWith(XtextRunner.class)
+@SuppressWarnings("all")
+public class JunitLibClasspathAdderTest extends AbstractJunitLibClasspathAdderTestCase {
+  @Inject
+  private Junit4LibClasspathAdder junit4LibAdder;
+  
+  @Inject
+  private Junit5LibClasspathAdder junit5LibAdder;
+  
+  @Test
+  public void addJUnit4LibToPluginProjectClasspath() {
+    try {
+      IJavaProject _create = JavaCore.create(this.workbenchHelper.getProject());
+      NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
+      this.junit4LibAdder.addLibsToClasspath(_create, _nullProgressMonitor);
+      final Consumer<IClasspathEntry> _function = (IClasspathEntry it) -> {
+        InputOutput.<IPath>println(it.getPath());
+      };
+      ((List<IClasspathEntry>)Conversions.doWrapArray(JavaCore.create(this.workbenchHelper.getProject()).getRawClasspath())).forEach(_function);
+      this.assertRequireBundles(new String[] { Junit4LibClasspathAdder.BUNDLE_ID });
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Test
+  public void addJUnit4LibToProjectClasspath() {
+    this.removePluginNature();
+    IJavaProject _create = JavaCore.create(this.workbenchHelper.getProject());
+    NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
+    this.junit4LibAdder.addLibsToClasspath(_create, _nullProgressMonitor);
+    this.assertClasspath(
+      "classpath should contain a JUnit 4 container entry", 
+      Junit4LibClasspathAdder.JUNIT4_LIBRARY_PATH);
+  }
+  
+  @Test
+  public void addJUnit5LibToPluginProjectClasspath() {
+    IJavaProject _create = JavaCore.create(this.workbenchHelper.getProject());
+    NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
+    this.junit5LibAdder.addLibsToClasspath(_create, _nullProgressMonitor);
+    this.assertRequireBundles(Junit5LibClasspathAdder.BUNDLE_IDS);
+  }
+  
+  @Test
+  public void addJUnit5LibToProjectClasspath() {
+    this.removePluginNature();
+    IJavaProject _create = JavaCore.create(this.workbenchHelper.getProject());
+    NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
+    this.junit5LibAdder.addLibsToClasspath(_create, _nullProgressMonitor);
+    this.assertClasspath(
+      "classpath should contain a JUnit 5 container entry", 
+      Junit5LibClasspathAdder.JUNIT5_LIBRARY_PATH);
+  }
+}

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/AddJunitLibToClasspathQuickfixTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/AddJunitLibToClasspathQuickfixTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.xtend.ide.tests.quickfix;
+
+import javax.inject.Inject;
+import org.eclipse.xtend.ide.buildpath.Junit4LibClasspathAdder;
+import org.eclipse.xtend.ide.buildpath.Junit5LibClasspathAdder;
+import org.eclipse.xtend.ide.tests.XtendIDEInjectorProvider;
+import org.eclipse.xtend.ide.tests.buildpath.AbstractJunitLibClasspathAdderTestCase;
+import org.eclipse.xtend.ide.tests.quickfix.QuickfixTestBuilder;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.diagnostics.Diagnostic;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author vivien.jovet - Initial contribution and API
+ */
+@InjectWith(XtendIDEInjectorProvider.class)
+@RunWith(XtextRunner.class)
+@SuppressWarnings("all")
+public class AddJunitLibToClasspathQuickfixTest extends AbstractJunitLibClasspathAdderTestCase {
+  @Inject
+  @Extension
+  private QuickfixTestBuilder builder;
+  
+  @Before
+  @Override
+  public void setUpProject() throws Exception {
+    this.workbenchHelper.closeAllEditors(false);
+    super.setUpProject();
+  }
+  
+  @Test
+  public void addJUnit4LibToPluginProjectClasspath() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.junit|.Test");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class FooTest {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("@Test");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("def test() {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    final String content = _builder.toString();
+    this.builder.create("FooTest.xtend", content).assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC).assertResolutionLabels("Add JUnit 4 lib to classpath").assertModelAfterQuickfix(content.replace("|", ""));
+    this.assertRequireBundles(new String[] { Junit4LibClasspathAdder.BUNDLE_ID });
+  }
+  
+  @Test
+  public void addJUnit4LibToProjectClasspath() {
+    this.removePluginNature();
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.junit|.Test");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class FooTest {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("@Test");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("def test() {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    final String content = _builder.toString();
+    this.builder.create("FooTest.xtend", content).assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC).assertResolutionLabels("Add JUnit 4 lib to classpath").assertModelAfterQuickfix(content.replace("|", ""));
+    this.assertClasspath(
+      "classpath should contain a JUnit 4 container entry", 
+      Junit4LibClasspathAdder.JUNIT4_LIBRARY_PATH);
+  }
+  
+  @Test
+  public void addJUnit5LibToPluginProjectClasspath() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.junit.jupiter.api|.Test");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class FooTest2 {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("@Test");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("def test() {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    final String content = _builder.toString();
+    this.builder.create("FooTest2.xtend", content).assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC).assertResolutionLabels("Add JUnit 5 lib to classpath").assertModelAfterQuickfix(content.replace("|", ""));
+    this.assertRequireBundles(Junit5LibClasspathAdder.BUNDLE_IDS);
+  }
+  
+  @Test
+  public void addJUnit5LibToProjectClasspath() {
+    this.removePluginNature();
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.junit.jupiter.api|.Test");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("class FooTest {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("@Test");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("def test() {}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    final String content = _builder.toString();
+    this.builder.create("FooTest.xtend", content).assertIssueCodes(Diagnostic.LINKING_DIAGNOSTIC).assertResolutionLabels("Add JUnit 5 lib to classpath").assertModelAfterQuickfix(content.replace("|", ""));
+    this.assertClasspath(
+      "classpath should contain a JUnit 5 container entry", 
+      Junit5LibClasspathAdder.JUNIT5_LIBRARY_PATH);
+  }
+}

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/buildpath/AbstractLibClasspathAdder.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/buildpath/AbstractLibClasspathAdder.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.ide.buildpath;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.log4j.Logger;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.xtext.util.MergeableManifest2;
+
+/**
+ * @author Jan Koehnlein - Initial contribution and API
+ * @author vivien.jovet
+ */
+public abstract class AbstractLibClasspathAdder {
+	
+	private static final Logger LOG = Logger.getLogger(XtendLibClasspathAdder.class);
+
+	private static final String PLUGIN_NATURE = "org.eclipse.pde.PluginNature";
+	
+	public void addLibsToClasspath(IJavaProject javaProject, IProgressMonitor monitor) {
+		try {
+			SubMonitor progress = SubMonitor.convert(monitor, 2);
+			IProject project = javaProject.getProject();
+			if (!project.hasNature(PLUGIN_NATURE) || !addToPluginManifest(project, progress.newChild(1)))
+				addToClasspath(javaProject, progress.newChild(1));
+		} catch (Exception exc) {
+			LOG.error("Error adding Xtend libs to classpath", exc);
+		}
+	}
+
+	protected abstract IClasspathEntry createContainerClasspathEntry();
+
+	protected abstract String[] getBundleIds();
+
+	protected boolean addToClasspath(IJavaProject javaProject, IProgressMonitor monitor) throws JavaModelException {
+		IClasspathEntry containerEntry = createContainerClasspathEntry();
+		IClasspathEntry[] rawClasspath = javaProject.getRawClasspath();
+		IClasspathEntry[] newRawClasspath = new IClasspathEntry[rawClasspath.length + 1];
+		for (int i = 0; i < rawClasspath.length; ++i) {
+			IClasspathEntry entry = rawClasspath[i];
+			if (entry.getEntryKind() == IClasspathEntry.CPE_CONTAINER && entry.getPath().equals(containerEntry.getPath())) {
+				return false;
+			}
+			newRawClasspath[i + 1] = entry;
+		}
+		newRawClasspath[0] = containerEntry;
+		javaProject.setRawClasspath(newRawClasspath, monitor);
+		return true;
+	}
+
+	protected boolean addToPluginManifest(IProject project, IProgressMonitor monitor) throws IOException, CoreException {
+		IResource manifestFile = project.findMember("META-INF/MANIFEST.MF");
+		if (manifestFile != null && manifestFile.isAccessible() && !manifestFile.getResourceAttributes().isReadOnly()
+				&& manifestFile instanceof IFile) {
+			OutputStream output = null;
+			InputStream input = null;
+			try {
+				MergeableManifest2 manifest = createMergableManifest(manifestFile);
+				manifest.addRequiredBundles(getBundleIds());
+				ByteArrayOutputStream out = new ByteArrayOutputStream();
+				output = new BufferedOutputStream(out);
+				manifest.write(output);
+				ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+				input = new BufferedInputStream(in);
+				((IFile) manifestFile).setContents(input, true, true, monitor);
+				return true;
+			} finally {
+				if (output != null)
+					output.close();
+				if (input != null)
+					input.close();
+			}
+		}
+		return false;
+	}
+
+	private MergeableManifest2 createMergableManifest(IResource manifestFile) throws IOException, CoreException {
+		InputStream originalManifest = ((IFile) manifestFile).getContents();
+		try {
+			return new MergeableManifest2(originalManifest);
+		} finally {
+			originalManifest.close();
+		}
+	}
+
+}

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/buildpath/Junit4LibClasspathAdder.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/buildpath/Junit4LibClasspathAdder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,21 +7,27 @@
  *******************************************************************************/
 package org.eclipse.xtend.ide.buildpath;
 
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.JavaCore;
 
 /**
- * @author Jan Koehnlein - Initial contribution and API
+ * @author vivienjovet - Initial contribution and API
  */
-public class XtendLibClasspathAdder extends AbstractLibClasspathAdder {
+public class Junit4LibClasspathAdder extends AbstractLibClasspathAdder {
+
+	public static final IPath JUNIT4_LIBRARY_PATH = new Path("org.eclipse.jdt.junit.JUNIT_CONTAINER/4");
+	public static final String BUNDLE_ID = "org.junit";
 
 	@Override
 	protected IClasspathEntry createContainerClasspathEntry() {
-		return JavaCore.newContainerEntry(XtendContainerInitializer.XTEND_LIBRARY_PATH);
+		return JavaCore.newContainerEntry(JUNIT4_LIBRARY_PATH);
 	}
 
 	@Override
 	protected String[] getBundleIds() {
-		return XtendClasspathContainer.BUNDLE_IDS_TO_INCLUDE;
+		return new String[] { BUNDLE_ID };
 	}
+
 }

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/buildpath/Junit5LibClasspathAdder.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/buildpath/Junit5LibClasspathAdder.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.xtend.ide.buildpath;
+
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.JavaCore;
+
+/**
+ * @author vivienjovet - Initial contribution and API
+ */
+public class Junit5LibClasspathAdder extends AbstractLibClasspathAdder {
+
+	public static final IPath JUNIT5_LIBRARY_PATH = new Path("org.eclipse.jdt.junit.JUNIT_CONTAINER/5");
+	public static final String[] BUNDLE_IDS = new String[] { 
+			"org.junit", "org.junit.jupiter.api", "org.junit.jupiter.engine",
+			"org.junit.jupiter.migrationsupport", "org.junit.jupiter.params", 
+			"org.junit.platform.commons", "org.junit.platform.engine",
+			"org.junit.platform.launcher", "org.junit.platform.runner", 
+			"org.junit.platform.suite.api", "org.junit.vintage.engine",
+			"org.hamcrest.core", "org.opentest4j", "org.apiguardian"
+	};
+
+	@Override
+	protected IClasspathEntry createContainerClasspathEntry() {
+		return JavaCore.newContainerEntry(JUNIT5_LIBRARY_PATH);
+	}
+
+	@Override
+	protected String[] getBundleIds() {
+		return BUNDLE_IDS;
+	}
+
+}


### PR DESCRIPTION
[#919] Add quickfixes that adds JUnit 4 or 5 libs to the classpath.

Similar to the quickfix that adds Xtend libs, it will first check if the
project is a plugin project and add the required bundles to the `MANIFEST.MF`, if not it
will add a container entry to the `.classpath`. The quickfixes appear for errors on
import declaration that starts by "org.junit" or
"org.junit.jupiter".

Examples:
![junit4_quickfix](https://user-images.githubusercontent.com/6960133/69411897-d32d7700-0d48-11ea-8cf1-ed15143b8828.gif)
![junit5_quickfix](https://user-images.githubusercontent.com/6960133/69411910-d7f22b00-0d48-11ea-9420-0650d2914ac4.gif)



What I haven't done yet is show the quickfix only if JUnit4/5 can "really" be added to the classpath. Currently it still proposes the quickfix even if after applying it the error will persist.

Signed-off-by: Vivien Jovet <vivien.jovet@gmail.com>