### PR TITLE
[#789] Find *.xtend test cases on the package level.

### DIFF
--- a/org.eclipse.xtend.ide/plugin.xml
+++ b/org.eclipse.xtend.ide/plugin.xml
@@ -1036,6 +1036,11 @@
      </factory>
      <factory 
         class="org.eclipse.xtend.ide.XtendExecutableExtensionFactory:org.eclipse.xtext.xbase.ui.launching.JavaElementDelegateAdapterFactory"
+        adaptableType="org.eclipse.jdt.core.IPackageFragment">
+        <adapter type="org.eclipse.xtext.xbase.ui.launching.JavaElementDelegateJunitLaunch"/>
+     </factory>
+     <factory 
+        class="org.eclipse.xtend.ide.XtendExecutableExtensionFactory:org.eclipse.xtext.xbase.ui.launching.JavaElementDelegateAdapterFactory"
         adaptableType="org.eclipse.ui.IFileEditorInput">
         <adapter type="org.eclipse.xtext.xbase.ui.launching.JavaElementDelegateMainLaunch"/>
      </factory>
@@ -1071,7 +1076,10 @@
                   <count value="1"/>
                   <iterate>
                      <and>
-                       <not><adapt type="org.eclipse.jdt.core.IJavaElement"/></not>
+                       <or>
+               	         <not><adapt type="org.eclipse.jdt.core.IJavaElement"/></not>
+               	         <adapt type="org.eclipse.jdt.core.IPackageFragment"/>
+                       </or>
                        <adapt type="org.eclipse.xtext.xbase.ui.launching.JavaElementDelegateJunitLaunch">
                          <adapt type="org.eclipse.jdt.core.IJavaElement">
                             <test property="org.eclipse.jdt.core.isInJavaProject"/>
@@ -1114,7 +1122,10 @@
                   <count value="1"/>
                	  <iterate>
                	     <and>
-               	       <not><adapt type="org.eclipse.jdt.core.IJavaElement"/></not>
+               	       <or>
+               	         <not><adapt type="org.eclipse.jdt.core.IJavaElement"/></not>
+               	         <adapt type="org.eclipse.jdt.core.IPackageFragment"/>
+                       </or>
                        <adapt type="org.eclipse.xtext.xbase.ui.launching.JavaElementDelegateJunitLaunch">
                          <adapt type="org.eclipse.jdt.core.IJavaElement">
 		                   <test property="org.eclipse.jdt.core.isInJavaProjectWithNature" value="org.eclipse.pde.PluginNature"/>

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/launching/XtendJavaElementDelegateJunitLaunch.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/launching/XtendJavaElementDelegateJunitLaunch.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2019, 2020 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,14 +7,25 @@
  *******************************************************************************/
 package org.eclipse.xtend.ide.launching;
 
+import java.util.Set;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.xtend.core.xtend.XtendFile;
 import org.eclipse.xtend.core.xtend.XtendTypeDeclaration;
+import org.eclipse.xtext.builder.EclipseOutputConfigurationProvider;
 import org.eclipse.xtext.common.types.JvmIdentifiableElement;
 import org.eclipse.xtext.common.types.util.jdt.IJavaElementFinder;
+import org.eclipse.xtext.generator.OutputConfiguration;
 import org.eclipse.xtext.parser.IParseResult;
+import org.eclipse.xtext.resource.FileExtensionProvider;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.xbase.ui.launching.JavaElementDelegateJunitLaunch;
 
@@ -28,6 +39,12 @@ public class XtendJavaElementDelegateJunitLaunch extends JavaElementDelegateJuni
 	@Inject
 	private IJavaElementFinder elementFinder;
 
+	@Inject
+	private EclipseOutputConfigurationProvider outputConfigurationProvider;
+
+	@Inject
+	private FileExtensionProvider fileExtensionProvider;
+
 	@Override
 	protected IJavaElement findJavaElement(XtextResource resource, int offset) {
 		IJavaElement javaElement = super.findJavaElement(resource, offset);
@@ -36,6 +53,78 @@ public class XtendJavaElementDelegateJunitLaunch extends JavaElementDelegateJuni
 		}
 
 		return javaElement;
+	}
+
+	@Override
+	protected IJavaElement getJavaElementForPackage(IPackageFragment packageFragment) {
+		/*
+		 * if the packageFragment contains only *.xtend files, return
+		 * the corresponding package fragment in the xtend-gen folder
+		 */
+		if (containsOnlyXtendFiles(packageFragment)) {
+			return getXtendGenPackageFragment(packageFragment);
+		}
+		return super.getJavaElementForPackage(packageFragment);
+	}
+
+	private boolean containsOnlyXtendFiles(IPackageFragment packageFragment) {
+		boolean containsJavaResources = false;
+		try {
+			containsJavaResources = packageFragment.containsJavaResources();
+		} catch (JavaModelException e) {
+			return false;
+		}
+		if (containsJavaResources) {
+			return false;
+		}
+
+		Object[] nonJavaResources = null;
+		try {
+			nonJavaResources = packageFragment.getNonJavaResources();
+		} catch (JavaModelException e) {
+			return false;
+		}
+
+		String xtendFileExtension = fileExtensionProvider.getPrimaryFileExtension();
+		for (Object nonJavaResource : nonJavaResources) {
+			if (nonJavaResource instanceof IFile) {
+				IFile nonJavaFile = (IFile) nonJavaResource;
+				if (xtendFileExtension.equals(nonJavaFile.getFileExtension())) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private IJavaElement getXtendGenPackageFragment(IPackageFragment packageFragment) {
+		String packageName = packageFragment.getElementName();
+		IJavaElement project = packageFragment.getAncestor(IJavaElement.JAVA_PROJECT);
+		if (project instanceof IJavaProject) {
+			IJavaProject javaProject = (IJavaProject) project;
+			String outputFolder = getXtendOutputFolder(packageName);
+			if (outputFolder != null) {
+				IPath xtendGenpackagePath = new Path("/" + javaProject.getElementName() + "/" +outputFolder+ "/" + packageName.replace(".", "/"));
+				IPackageFragment xtendGenPackageFragment = null;
+				try {
+					xtendGenPackageFragment = javaProject.findPackageFragment(xtendGenpackagePath);
+				} catch (JavaModelException e) {
+					return null;
+				}
+				return xtendGenPackageFragment;
+			}
+		}
+		return null;
+	}
+	
+	private String getXtendOutputFolder(String packageName) {
+		Set<OutputConfiguration> outputConfigurations = outputConfigurationProvider.getOutputConfigurations();
+		if (outputConfigurations.size() == 1) {
+			OutputConfiguration outputConfiguration = outputConfigurations.iterator().next();
+			return outputConfiguration.getOutputDirectory(packageName);
+		}
+		return null;
 	}
 
 	/**

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-oxygen.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-oxygen.target
@@ -79,7 +79,7 @@
 		<unit id="org.eclipse.xtext.xbase.junit.source" version="0.0.0"/>
 		<unit id="org.eclipse.xtext.xbase.ui" version="0.0.0"/>
 		<unit id="org.eclipse.xtext.xbase.ui.source" version="0.0.0"/>
-		<repository location="https://ci.eclipse.org/xtext/job/xtext-eclipse/job/master/lastStableBuild/artifact/build/p2-repository/"/>
+		<repository location="https://ci.eclipse.org/xtext/job/xtext-eclipse/job/miklossy_master/lastStableBuild/artifact/build/p2-repository/"/>
 	</location>
 	
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">


### PR DESCRIPTION
- Modify the plugin.xml of the Xtend IDE to ensure that the
JavaElementDelegateJunitLaunch is invoked when right clicking on a java
package.
- Modify the XtendJavaElementDelegateJunitLaunch to provide a proper
implementation of the getJavaElementForPackage(IPackageFragment) method
to deliver the corresponding java package in the xtend-gen folder.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>