### PR TITLE
Refactor usage of Wrapper constructors to valueOf

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/AbstractXbaseEvaluationTest.java
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/AbstractXbaseEvaluationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2010, 2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -643,7 +643,7 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	}
 
 	@Test public void testUnaryOperator_00() throws Exception {
-		assertEvaluatesTo(new Integer(-19),"-19");
+		assertEvaluatesTo(Integer.valueOf(-19),"-19");
 	}
 	
 	@Test public void testUnaryOperator_01() throws Exception {
@@ -663,7 +663,7 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	}
 	
 	@Test public void testUpToOperator() throws Exception {
-		assertEvaluatesTo(new Integer(9),"(9..13).iterator().next()");
+		assertEvaluatesTo(Integer.valueOf(9),"(9..13).iterator().next()");
 	}
 	
 	@Test public void testExclusiveRangeOperator_0() throws Exception {
@@ -733,103 +733,103 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	}
 	
 	@Test public void testAddOnIntegers() throws Exception {
-		assertEvaluatesTo(new Integer(3), "1+2");
+		assertEvaluatesTo(Integer.valueOf(3), "1+2");
 	}
 
 	@Test public void testSubtractionOnIntegers() throws Exception {
-		assertEvaluatesTo(new Integer(1), "2-1");
+		assertEvaluatesTo(Integer.valueOf(1), "2-1");
 	}
 
 	@Test public void testMultiplicationOnIntegers() throws Exception {
-		assertEvaluatesTo(new Integer(42), "6*7");
+		assertEvaluatesTo(Integer.valueOf(42), "6*7");
 	}
 
 	@Test public void testDivisionOnIntegers_01() throws Exception {
-		assertEvaluatesTo(new Integer(2), "6/3");
+		assertEvaluatesTo(Integer.valueOf(2), "6/3");
 	}
 
 	@Test public void testDivisionOnIntegers_02() throws Exception {
-		assertEvaluatesTo(new Integer(2), "7/3");
+		assertEvaluatesTo(Integer.valueOf(2), "7/3");
 	}
 
 	@Test public void testModuloOnIntegers() throws Exception {
-		assertEvaluatesTo(new Integer(1), "7%3");
+		assertEvaluatesTo(Integer.valueOf(1), "7%3");
 	}
 
 	@Test public void testPowerOnIntegers() throws Exception {
-		assertEvaluatesTo(new Double(8), "2**3");
+		assertEvaluatesTo(Double.valueOf(8), "2**3");
 	}
 
 	@Test public void testLessThanOnIntegers_01() throws Exception {
-		assertEvaluatesTo(new Boolean(true), "3<4");
+		assertEvaluatesTo(Boolean.TRUE, "3<4");
 	}
 
 	@Test public void testLessThanOnIntegers_02() throws Exception {
-		assertEvaluatesTo(new Boolean(false), "4<3");
+		assertEvaluatesTo(Boolean.FALSE, "4<3");
 	}
 
 	@Test public void testGreaterThanOnIntegers_01() throws Exception {
-		assertEvaluatesTo(new Boolean(true), "4>3");
+		assertEvaluatesTo(Boolean.TRUE, "4>3");
 	}
 
 	@Test public void testGreaterThanOnIntegers_02() throws Exception {
-		assertEvaluatesTo(new Boolean(false), "3>4");
+		assertEvaluatesTo(Boolean.FALSE, "3>4");
 	}
 
 	@Test public void testLessEqualsThanOnIntegers_01() throws Exception {
-		assertEvaluatesTo(new Boolean(true), "3<=3");
+		assertEvaluatesTo(Boolean.TRUE, "3<=3");
 	}
 
 	@Test public void testLessEqualsThanOnIntegers_02() throws Exception {
-		assertEvaluatesTo(new Boolean(true), "3<=4");
+		assertEvaluatesTo(Boolean.TRUE, "3<=4");
 	}
 
 	@Test public void testLessEqualsThanOnIntegers_03() throws Exception {
-		assertEvaluatesTo(new Boolean(false), "4<=3");
+		assertEvaluatesTo(Boolean.FALSE, "4<=3");
 	}
 
 	@Test public void testGreaterEqualsThanOnIntegers_01() throws Exception {
-		assertEvaluatesTo(new Boolean(true), "3>=3");
+		assertEvaluatesTo(Boolean.TRUE, "3>=3");
 	}
 
 	@Test public void testGreaterEqualsThanOnIntegers_02() throws Exception {
-		assertEvaluatesTo(new Boolean(true), "4>=3");
+		assertEvaluatesTo(Boolean.TRUE, "4>=3");
 	}
 
 	@Test public void testGreaterEqualsThanOnIntegers_03() throws Exception {
-		assertEvaluatesTo(new Boolean(false), "3>=4");
+		assertEvaluatesTo(Boolean.FALSE, "3>=4");
 	}
 
 	@Test public void testOrOnBooleans_01() throws Exception {
-		assertEvaluatesTo(new Boolean(true), "true||false");
+		assertEvaluatesTo(Boolean.TRUE, "true||false");
 	}
 
 	@Test public void testOrOnBooleans_02() throws Exception {
-		assertEvaluatesTo(new Boolean(true), "false||true");
+		assertEvaluatesTo(Boolean.TRUE, "false||true");
 	}
 
 	@Test public void testOrOnBooleans_03() throws Exception {
-		assertEvaluatesTo(new Boolean(true), "true||true");
+		assertEvaluatesTo(Boolean.TRUE, "true||true");
 	}
 
 	@Test public void testOrOnBooleans_04() throws Exception {
-		assertEvaluatesTo(new Boolean(false), "false||false");
+		assertEvaluatesTo(Boolean.FALSE, "false||false");
 	}
 
 	@Test public void testAndOnBooleans_01() throws Exception {
-		assertEvaluatesTo(new Boolean(true), "true&&true");
+		assertEvaluatesTo(Boolean.TRUE, "true&&true");
 	}
 
 	@Test public void testAndOnBooleans_02() throws Exception {
-		assertEvaluatesTo(new Boolean(false), "false&&true");
+		assertEvaluatesTo(Boolean.FALSE, "false&&true");
 	}
 
 	@Test public void testAndOnBooleans_03() throws Exception {
-		assertEvaluatesTo(new Boolean(false), "true&&false");
+		assertEvaluatesTo(Boolean.FALSE, "true&&false");
 	}
 
 	@Test public void testAndOnBooleans_04() throws Exception {
-		assertEvaluatesTo(new Boolean(false), "false&&false");
+		assertEvaluatesTo(Boolean.FALSE, "false&&false");
 	}
 
 	@Test public void testNull() throws Exception {
@@ -1166,25 +1166,25 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	}
 	
 	@Test public void testFeatureCall_02() throws Exception {
-		assertEvaluatesTo(new Character('a'), "'a'.toCharArray.iterator.next");
+		assertEvaluatesTo(Character.valueOf('a'), "'a'.toCharArray.iterator.next");
 	}
 	
 	@Test public void testFeatureCall_03() throws Exception {
 		assertEvaluatesTo(newArrayList(
-				new Character('a'), 
-				new Character('b'),
-				new Character('c')), "{ var java.util.List<Character> x = ('abc'.toCharArray as Iterable<Character>).toList() x }");
+				Character.valueOf('a'), 
+				Character.valueOf('b'),
+				Character.valueOf('c')), "{ var java.util.List<Character> x = ('abc'.toCharArray as Iterable<Character>).toList() x }");
 	}
 	
 	@Test public void testFeatureCall_03_2() throws Exception {
 		assertEvaluatesTo(newArrayList(
-				new Character('a'), 
-				new Character('b'),
-				new Character('c')), "{ var java.util.List<Character> x = 'abc'.toCharArray x }");
+				Character.valueOf('a'), 
+				Character.valueOf('b'),
+				Character.valueOf('c')), "{ var java.util.List<Character> x = 'abc'.toCharArray x }");
 	}
 	
 	@Test public void testFeatureCall_04() throws Exception {
-		assertEvaluatesTo(new Integer("literal".length()), "{ var x = 'literal' x.length }");
+		assertEvaluatesTo(Integer.valueOf("literal".length()), "{ var x = 'literal' x.length }");
 	}
 	
 	@Test public void testConstructorCall_00() throws Exception {
@@ -1614,7 +1614,7 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	}
 	
 	@Test public void testForLoop_01() throws Exception {
-		assertEvaluatesTo(new Character('c'), 
+		assertEvaluatesTo(Character.valueOf('c'), 
 				"{\n" +
 				"  var Character result = null\n" +
 				"  for(x: 'abc'.toCharArray) result = x\n" +
@@ -1623,7 +1623,7 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	}
 	
 	@Test public void testForLoop_02() throws Exception {
-		assertEvaluatesTo(new Character('a'), 
+		assertEvaluatesTo(Character.valueOf('a'), 
 				"{\n" +
 				"  var Character result = null\n" +
 				"  for(x: 'aba'.toCharArray) if (result == null) result = x\n" +
@@ -1682,7 +1682,7 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	}
 	
 	@Test public void testForLoop_08() throws Exception {
-		assertEvaluatesTo(new Character('c'), 
+		assertEvaluatesTo(Character.valueOf('c'), 
 				"{\n" +
 				"  var Character result = null\n" +
 				"  for(char x: 'abc'.toCharArray) result = x\n" +
@@ -1691,7 +1691,7 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	}
 	
 	@Test public void testForLoop_09() throws Exception {
-		assertEvaluatesTo(new Character('a'), 
+		assertEvaluatesTo(Character.valueOf('a'), 
 				"{\n" +
 				"  var Character result = null\n" +
 				"  for(char x: 'abc'.toCharArray) if (result == null) result = x\n" +
@@ -1700,7 +1700,7 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	}
 	
 	@Test public void testForLoop_10() throws Exception {
-		assertEvaluatesTo(new Character('c'), 
+		assertEvaluatesTo(Character.valueOf('c'), 
 				"{\n" +
 				"  var char result\n" +
 				"  for(Character x: 'abc'.toCharArray) result = x\n" +
@@ -1740,7 +1740,7 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	}
 	
 	@Test public void testForLoop_14() throws Exception {
-		assertEvaluatesTo(new Character('c'), 
+		assertEvaluatesTo(Character.valueOf('c'), 
 				"{\n" +
 				"  var Character result = null\n" +
 				"  for(char x: 'abc'.toCharArray.toList) result = x\n" +
@@ -1749,7 +1749,7 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	}
 	
 	@Test public void testForLoop_15() throws Exception {
-		assertEvaluatesTo(new Character('a'), 
+		assertEvaluatesTo(Character.valueOf('a'), 
 				"{\n" +
 				"  var Character result = null\n" +
 				"  for(x: 'abc'.toCharArray.toList) if (result == null) result = x\n" +
@@ -1758,7 +1758,7 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	}
 	
 	@Test public void testForLoop_16() throws Exception {
-		assertEvaluatesTo(new Character('a'), 
+		assertEvaluatesTo(Character.valueOf('a'), 
 				"{\n" +
 				"  var Character result = null\n" +
 				"  for(int i: 'abc'.toCharArray) if (result == null) result = i as char\n" +
@@ -1984,7 +1984,7 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	 * @since 2.6
 	 */
 	@Test public void testXBasicForLoopExpression_10() throws Exception {
-		assertEvaluatesTo(new Character('c'), 
+		assertEvaluatesTo(Character.valueOf('c'), 
 				"{\n" +
 				"  var Character result = null\n" +
 				"  val abc = 'abc'.toCharArray\n" +
@@ -1999,7 +1999,7 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	 * @since 2.6
 	 */
 	@Test public void testXBasicForLoopExpression_11() throws Exception {
-		assertEvaluatesTo(new Character('c'), 
+		assertEvaluatesTo(Character.valueOf('c'), 
 				"{\n" +
 				"  var Character result = null\n" +
 				"  val abc = 'abc'.toCharArray\n" +
@@ -2012,7 +2012,7 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	 * @since 2.6
 	 */
 	@Test public void testXBasicForLoopExpression_12() throws Exception {
-		assertEvaluatesTo(new Character('a'), 
+		assertEvaluatesTo(Character.valueOf('a'), 
 				"{\n" +
 				"  var Character result = null\n" +
 				"  val abc = 'abc'.toCharArray\n" +
@@ -2029,7 +2029,7 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	 * @since 2.6
 	 */
 	@Test public void testXBasicForLoopExpression_13() throws Exception {
-		assertEvaluatesTo(new Character('a'), 
+		assertEvaluatesTo(Character.valueOf('a'), 
 				"{\n" +
 				"  var Character result = null\n" +
 				"  val abc = 'abc'.toCharArray\n" +
@@ -2662,7 +2662,7 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	}
 	
 	@Test public void testConstructor_02() throws Exception {
-		assertEvaluatesTo(new Character('a'), "new Character('abc'.charAt(0))");
+		assertEvaluatesTo(Character.valueOf('a'), "new Character('abc'.charAt(0))");
 	}
 	
 	@Test public void testConstructor_03() throws Exception {
@@ -3167,7 +3167,7 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	}
 	
 	@Test public void testArrayConversion_03() throws Exception {
-		assertEvaluatesTo(new Integer(42), 
+		assertEvaluatesTo(Integer.valueOf(42), 
 				"{" +
 				"  var client = new testdata.ArrayClient()" +
 				"  var intArray = client.toIntArray(32, 7)" +
@@ -3178,7 +3178,7 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	}
 	
 	@Test public void testArrayConversion_04() throws Exception {
-		assertEvaluatesTo(new Integer(17), 
+		assertEvaluatesTo(Integer.valueOf(17), 
 				"{" +
 				"  var client = new testdata.ArrayClient()" +
 				"  var intArray = client.toIntArray(32, 7)" +
@@ -4263,7 +4263,7 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	// @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=412642
 	public void testMapLiteral_6() throws Exception {
 		HashMap<Object, Object> map = newHashMap();
-		map.put("Apple", new Integer(1));
+		map.put("Apple", Integer.valueOf(1));
 		assertEvaluatesTo(map, "{\n" +
 									"val pair = 'Apple' -> 1\n" +
 									"#{pair}\n" +
@@ -4274,7 +4274,7 @@ public abstract class AbstractXbaseEvaluationTest extends Assert {
 	// @see https://bugs.eclipse.org/bugs/show_bug.cgi?id=412642
 	public void testMapLiteral_7() throws Exception {
 		HashMap<Object, Object> map = newHashMap();
-		map.put("Apple", new Integer(1));
+		map.put("Apple", Integer.valueOf(1));
 		assertEvaluatesTo(map, "{\n" +
 									"#{ if (true) 'Apple' -> 1 else 'Banana' -> 2 }" +
 								"} ");

--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/formatting/preferences/AbstractProfileManager.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/formatting/preferences/AbstractProfileManager.java
@@ -213,7 +213,7 @@ public abstract class AbstractProfileManager extends org.eclipse.jdt.internal.ui
 	@Override
 	protected void notifyObservers(int message) {
 		setChanged();
-		notifyObservers(new Integer(message));
+		notifyObservers(Integer.valueOf(message));
 	}
 
 	public static boolean hasProjectSpecificSettings(IScopeContext context, KeySet[] keySets) {


### PR DESCRIPTION
The constructors of Wrapper classes have been deprecated. It is
recommended to use their static valueOf() method. For Boolean the
literals TRUE and FALSE can be used.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>