### PR TITLE
[eclipse/xtext#1685] use 4.16 ibuilds in latest target

### DIFF
--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-latest.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-latest.target
@@ -87,7 +87,7 @@
 		<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.api.tools.ee.feature.feature.group" version="0.0.0"/>
-		<repository location="https://download.eclipse.org/eclipse/updates/4.15-I-builds"/>
+		<repository location="https://download.eclipse.org/eclipse/updates/4.16-I-builds"/>
 	</location>
 
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">


### PR DESCRIPTION
[eclipse/xtext#1685] use 4.16 ibuilds in latest target
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>