### PR TITLE
[eclipse/xtext-core#1418] removed redundant superinterface from generated ca parsers

### DIFF
--- a/org.eclipse.xtend.ide.common/src-gen/org/eclipse/xtend/ide/common/contentassist/antlr/PartialXtendContentAssistParser.java
+++ b/org.eclipse.xtend.ide.common/src-gen/org/eclipse/xtend/ide/common/contentassist/antlr/PartialXtendContentAssistParser.java
@@ -13,10 +13,9 @@ import java.util.Collections;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.AbstractInternalContentAssistParser;
-import org.eclipse.xtext.ide.editor.partialEditing.IPartialEditingContentAssistParser;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
 
-public class PartialXtendContentAssistParser extends XtendParser implements IPartialEditingContentAssistParser {
+public class PartialXtendContentAssistParser extends XtendParser {
 
 	private AbstractRule rule;
 


### PR DESCRIPTION
[eclipse/xtext-core#1418] removed redundant superinterface from generated ca parsers

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>