### PR TITLE
[eclipse/xtext#1738] use java.text.MessageFormat instead of com.ibm.icu.MessageFormat

### DIFF
--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/javaconverter/ConversionProblemsDialog.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/javaconverter/ConversionProblemsDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -10,6 +10,7 @@ package org.eclipse.xtend.ide.javaconverter;
 
 import static com.google.common.collect.Sets.*;
 
+import java.text.MessageFormat;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -39,8 +40,6 @@ import org.eclipse.swt.widgets.Widget;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.xtend.core.javaconverter.JavaConverter.ConversionResult;
-
-import com.ibm.icu.text.MessageFormat;
 
 /**
  * Shows problematic files contained in a passed input map


### PR DESCRIPTION
[eclipse/xtext#1738] use java.text.MessageFormat instead of com.ibm.icu.MessageFormat
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>