### PR TITLE
[eclipse/xtext#1738] removed no longer needed icu dependency

### DIFF
--- a/org.eclipse.xtend.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.ide/META-INF/MANIFEST.MF
@@ -29,8 +29,7 @@ Require-Bundle: org.eclipse.xtend.core,
  org.eclipse.xtend.lib;resolution:=optional,
  org.eclipse.xtext.xbase.lib;bundle-version="2.22.0",
  org.eclipse.jdt.core.manipulation;bundle-version="1.9.100";resolution:=optional
-Import-Package: com.ibm.icu.text,
- org.apache.log4j;version="1.2.15"
+Import-Package: org.apache.log4j;version="1.2.15"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Activator: org.eclipse.xtend.ide.internal.XtendActivator
 Export-Package: org.eclipse.xtend.ide;x-internal:=true,


### PR DESCRIPTION
[eclipse/xtext#1738] removed no longer needed icu dependency
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>