### PR TITLE
[#1050] Xtend precompile step should not blindly run annotations processors by default

### DIFF
--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/batch/XtendBatchCompiler.java
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/compiler/batch/XtendBatchCompiler.java
@@ -167,6 +167,12 @@ public class XtendBatchCompiler {
 	protected boolean writeStorageFiles = false;
 	private GeneratorConfig generatorConfig = new GeneratorConfig();
 	protected ClassLoader currentClassLoader = getClass().getClassLoader();
+	/**
+	 * Additional arguments to the Eclipse batch compiler for the precompile step.
+	 * Defaults to '-proc:none' to disable annotation processing. Clients may override.
+	 * @since 2.22
+	 */
+	protected String additionalPreCompileArgs = "-proc:none";
 
 	private URI baseURI;
 
@@ -214,6 +220,20 @@ public class XtendBatchCompiler {
 	 */
 	public void setWriteStorageFiles(boolean writeStorageFiles) {
 		this.writeStorageFiles = writeStorageFiles;
+	}
+	
+	/**
+	 * @since 2.22
+	 */
+	public void setAdditionalPreCompileArgs(String additionalPreCompileArgs) {
+		this.additionalPreCompileArgs = additionalPreCompileArgs;
+	}
+	
+	/**
+	 * @since 2.22
+	 */
+	public String getAdditionalPreCompileArgs() {
+		return additionalPreCompileArgs;
 	}
 	
 	@Inject
@@ -654,6 +674,9 @@ public class XtendBatchCompiler {
 		commandLine.add("-proceedOnError");
 		if (encodingProvider.getDefaultEncoding() != null) {
 			commandLine.add("-encoding \"" + encodingProvider.getDefaultEncoding() + "\"");
+		}
+		if (additionalPreCompileArgs != null) {
+			commandLine.add(additionalPreCompileArgs);
 		}
 		List<String> sourceDirectories = newArrayList(sourcePathDirectories);
 		commandLine.add(concat(" ", transform(sourceDirectories, new Function<String, String>() {

--- a/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/AbstractXtendCompilerMojo.java
+++ b/org.eclipse.xtend.maven.plugin/src/main/java/org/eclipse/xtend/maven/AbstractXtendCompilerMojo.java
@@ -55,7 +55,7 @@ public abstract class AbstractXtendCompilerMojo extends AbstractXtendMojo {
 	/**
 	 * Create Java Source Code that is compatible to this Java version.
 	 * 
-	 * Supported values: 1.5, 1.6, 1.7, 1.8, 9 and 10
+	 * Supported values: 1.5, 1.6, 1.7, 1.8, 9, 10, 11, 12, 13 and so forth
 	 */
 	@Parameter(property="maven.compiler.source", defaultValue="1.6")
 	private String javaSourceVersion;
@@ -113,6 +113,12 @@ public abstract class AbstractXtendCompilerMojo extends AbstractXtendMojo {
 	 */
 	@Parameter
 	private String generatedAnnotationComment;
+	
+	/**
+	 * Additional Java compiler arguments for the internal pre-built step of the XtendBatchCompiler.
+	 */
+	@Parameter(defaultValue="-proc:none")
+	private String additionalPreCompileArgs;
 
 	@Inject
 	private Provider<XtendBatchCompiler> xtendBatchCompilerProvider;
@@ -161,6 +167,8 @@ public abstract class AbstractXtendCompilerMojo extends AbstractXtendMojo {
 		compiler.setFileEncoding(encoding);
 		log.debug("Set writeTraceFiles: " + writeTraceFiles);
 		compiler.setWriteTraceFiles(writeTraceFiles);
+		log.debug("Set additional precompile args: " + additionalPreCompileArgs);
+		compiler.setAdditionalPreCompileArgs(additionalPreCompileArgs);
 		if (!compiler.compile()) {
 			String dir = concat(File.pathSeparator, newArrayList(filtered));
 			throw new MojoExecutionException("Error compiling xtend sources in '" + dir + "'.");


### PR DESCRIPTION
Allow to pass arguments to the pre built Java compiler. By default disable annotation processing.

closes #1050