### PR TITLE
[eclipse/xtext#1784] use download.eclipse.org/releases/2020-09 in latest

### DIFF
--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-latest.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-latest.target
@@ -93,7 +93,7 @@
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 		<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
-		<repository location="https://download.eclipse.org/releases/2020-06"/>
+		<repository location="https://download.eclipse.org/releases/2020-09"/>
 	</location>
 
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">


### PR DESCRIPTION
[eclipse/xtext#1784] use download.eclipse.org/releases/2020-09 in latest
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>