### PR TITLE
[#1075] Provide missing implementation for MethodDeclaration

### DIFF
--- a/org.eclipse.xtend.core.tests.java8/src/org/eclipse/xtend/core/tests/java8/macro/DeclarationsTest.xtend
+++ b/org.eclipse.xtend.core.tests.java8/src/org/eclipse/xtend/core/tests/java8/macro/DeclarationsTest.xtend
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sebastian Zarnekow 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtend.core.tests.java8.macro
+
+import org.eclipse.xtend.core.tests.java8.Java8RuntimeInjectorProvider
+import org.eclipse.xtend.lib.macro.declaration.InterfaceDeclaration
+import org.eclipse.xtext.testing.InjectWith
+import org.junit.Test
+
+@InjectWith(Java8RuntimeInjectorProvider)
+class DeclarationsTest extends org.eclipse.xtend.core.tests.macro.declaration.DeclarationsTest {
+	
+	@Test def testXtendInterfaceWithDefaultMethod() {
+		validFile('''
+			package p
+			
+			interface MyIntf {
+				
+				def String dflt() { "" }
+				def String abstrct()
+				def static String statc() { "" }
+				
+			}
+		''').asCompilationUnit [
+			assertEquals('p', packageName)
+			val intf = sourceTypeDeclarations.head as InterfaceDeclaration
+			
+			assertEquals('p.MyIntf', intf.qualifiedName)
+			assertTrue(intf.extendedInterfaces.empty)
+			assertEquals(3, intf.declaredMembers.size)
+			
+			val dflt = intf.declaredMethods.head
+			assertTrue(dflt.isDefault)
+			assertFalse(dflt.isAbstract)
+			
+			val abstract = intf.declaredMethods.get(1)
+			assertFalse(abstract.isDefault)
+			assertTrue(abstract.isAbstract)
+			
+			val static = intf.declaredMethods.get(2)
+			assertFalse(static.isDefault)
+			assertFalse(static.isAbstract)
+			assertTrue(static.isStatic)
+		]
+	}
+}

--- a/org.eclipse.xtend.core.tests.java8/xtend-gen/org/eclipse/xtend/core/tests/java8/macro/DeclarationsTest.java
+++ b/org.eclipse.xtend.core.tests.java8/xtend-gen/org/eclipse/xtend/core/tests/java8/macro/DeclarationsTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2020 Sebastian Zarnekow
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.xtend.core.tests.java8.macro;
+
+import org.eclipse.xtend.core.macro.declaration.CompilationUnitImpl;
+import org.eclipse.xtend.core.tests.java8.Java8RuntimeInjectorProvider;
+import org.eclipse.xtend.lib.macro.declaration.InterfaceDeclaration;
+import org.eclipse.xtend.lib.macro.declaration.MethodDeclaration;
+import org.eclipse.xtend.lib.macro.declaration.TypeDeclaration;
+import org.eclipse.xtend2.lib.StringConcatenation;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.xbase.lib.Conversions;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+import org.junit.Assert;
+import org.junit.Test;
+
+@InjectWith(Java8RuntimeInjectorProvider.class)
+@SuppressWarnings("all")
+public class DeclarationsTest extends org.eclipse.xtend.core.tests.macro.declaration.DeclarationsTest {
+  @Test
+  public void testXtendInterfaceWithDefaultMethod() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package p");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("interface MyIntf {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def String dflt() { \"\" }");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def String abstrct()");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def static String statc() { \"\" }");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    final Procedure1<CompilationUnitImpl> _function = (CompilationUnitImpl it) -> {
+      Assert.assertEquals("p", it.getPackageName());
+      TypeDeclaration _head = IterableExtensions.head(it.getSourceTypeDeclarations());
+      final InterfaceDeclaration intf = ((InterfaceDeclaration) _head);
+      Assert.assertEquals("p.MyIntf", intf.getQualifiedName());
+      Assert.assertTrue(IterableExtensions.isEmpty(intf.getExtendedInterfaces()));
+      Assert.assertEquals(3, IterableExtensions.size(intf.getDeclaredMembers()));
+      final MethodDeclaration dflt = IterableExtensions.head(intf.getDeclaredMethods());
+      Assert.assertTrue(dflt.isDefault());
+      Assert.assertFalse(dflt.isAbstract());
+      final MethodDeclaration abstract_ = ((MethodDeclaration[])Conversions.unwrapArray(intf.getDeclaredMethods(), MethodDeclaration.class))[1];
+      Assert.assertFalse(abstract_.isDefault());
+      Assert.assertTrue(abstract_.isAbstract());
+      final MethodDeclaration static_ = ((MethodDeclaration[])Conversions.unwrapArray(intf.getDeclaredMethods(), MethodDeclaration.class))[2];
+      Assert.assertFalse(static_.isDefault());
+      Assert.assertFalse(static_.isAbstract());
+      Assert.assertTrue(static_.isStatic());
+    };
+    this.asCompilationUnit(this.validFile(_builder), _function);
+  }
+}

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/declaration/DeclarationsTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/macro/declaration/DeclarationsTest.xtend
@@ -235,6 +235,38 @@ class DeclarationsTest extends AbstractXtendTestCase {
 		]
 	}
 	
+	@Test def testOverriddenMethodFromSource() {
+		validFile('''
+			package p
+			
+			abstract class C extends java.util.AbstractList<String> implements I {
+				override add(String s);
+			}
+			interface I {
+				def boolean add(String s)
+			}
+		''').asCompilationUnit [
+			assertEquals('p', packageName)
+			val clazz = sourceTypeDeclarations.head as ClassDeclaration
+			
+			assertEquals('p.C', clazz.qualifiedName)
+			
+			
+			val add = clazz.declaredMethods.head
+			val allOverridden = add.overriddenOrImplementedMethods
+			
+			assertEquals(2, allOverridden.size)
+			
+			val listAdd = allOverridden.head
+			assertEquals("add", listAdd.simpleName)
+			assertEquals("E", listAdd.parameters.head.type.simpleName)
+			
+			val intfAdd = allOverridden.last
+			assertEquals("add", intfAdd.simpleName)
+			assertEquals("String", intfAdd.parameters.head.type.simpleName)
+		]
+	}
+	
 	@Test def testMutableClassDeclaration() {
 		validFile('''
 		package foo

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/declaration/DeclarationsTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/macro/declaration/DeclarationsTest.java
@@ -336,6 +336,44 @@ public class DeclarationsTest extends AbstractXtendTestCase {
   }
   
   @Test
+  public void testOverriddenMethodFromSource() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package p");
+    _builder.newLine();
+    _builder.newLine();
+    _builder.append("abstract class C extends java.util.AbstractList<String> implements I {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("override add(String s);");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("interface I {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def boolean add(String s)");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    final Procedure1<CompilationUnitImpl> _function = (CompilationUnitImpl it) -> {
+      Assert.assertEquals("p", it.getPackageName());
+      TypeDeclaration _head = IterableExtensions.head(it.getSourceTypeDeclarations());
+      final ClassDeclaration clazz = ((ClassDeclaration) _head);
+      Assert.assertEquals("p.C", clazz.getQualifiedName());
+      final MethodDeclaration add = IterableExtensions.head(clazz.getDeclaredMethods());
+      final Iterable<? extends MethodDeclaration> allOverridden = add.getOverriddenOrImplementedMethods();
+      Assert.assertEquals(2, IterableExtensions.size(allOverridden));
+      final MethodDeclaration listAdd = IterableExtensions.head(allOverridden);
+      Assert.assertEquals("add", listAdd.getSimpleName());
+      Assert.assertEquals("E", IterableExtensions.head(listAdd.getParameters()).getType().getSimpleName());
+      final MethodDeclaration intfAdd = IterableExtensions.last(allOverridden);
+      Assert.assertEquals("add", intfAdd.getSimpleName());
+      Assert.assertEquals("String", IterableExtensions.head(intfAdd.getParameters()).getType().getSimpleName());
+    };
+    this.asCompilationUnit(this.validFile(_builder), _function);
+  }
+  
+  @Test
   public void testMutableClassDeclaration() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package foo");

--- a/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/XtendBasedDeclarations.xtend
+++ b/org.eclipse.xtend.core/src/org/eclipse/xtend/core/macro/declaration/XtendBasedDeclarations.xtend
@@ -285,18 +285,21 @@ class XtendMethodDeclarationImpl extends XtendMemberDeclarationImpl<XtendFunctio
 	}
 	
 	override isSynchronized() {
+		// not supported in interfaces
 		false
 	}
 
 	override isDefault() {
-		false
+		!delegate.isStatic && delegate.expression !== null && declaringType instanceof InterfaceDeclaration
 	}
 	
 	override isStrictFloatingPoint() {
-		false	
+		// not supported in Xtend interfaces
+		false
 	}
 	
 	override isNative() {
+		// not supported in Xtend interfaces
 		false	
 	}
 	
@@ -335,7 +338,14 @@ class XtendMethodDeclarationImpl extends XtendMemberDeclarationImpl<XtendFunctio
 	}
 	
 	override getOverriddenOrImplementedMethods() {
-		emptyList
+		if (delegate.isOverride) {
+			val jvmOperation = compilationUnit.jvmModelAssociations.getDirectlyInferredOperation(delegate)
+			val resolvedFeatures = compilationUnit.overrideHelper.getResolvedFeatures(jvmOperation.declaringType)
+			val resolvedOperation = resolvedFeatures.getResolvedOperation(jvmOperation)
+			val overriddenOrImplemented = resolvedOperation.overriddenAndImplementedMethods
+			return overriddenOrImplemented.map[compilationUnit.toMemberDeclaration(it.declaration)].filter(MethodDeclaration)
+		}
+		return emptyList
 	}
 	
 }

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/ResolvedParameterImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/ResolvedParameterImpl.java
@@ -71,11 +71,13 @@ public class ResolvedParameterImpl implements ResolvedParameter {
   }
   
   @Pure
+  @Override
   public ParameterDeclaration getDeclaration() {
     return this.declaration;
   }
   
   @Pure
+  @Override
   public TypeReference getResolvedType() {
     return this.resolvedType;
   }

--- a/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/XtendMethodDeclarationImpl.java
+++ b/org.eclipse.xtend.core/xtend-gen/org/eclipse/xtend/core/macro/declaration/XtendMethodDeclarationImpl.java
@@ -8,17 +8,22 @@
  */
 package org.eclipse.xtend.core.macro.declaration;
 
+import com.google.common.collect.Iterables;
+import java.util.List;
 import org.eclipse.xtend.core.macro.declaration.XtendMemberDeclarationImpl;
 import org.eclipse.xtend.core.macro.declaration.XtendParameterDeclarationImpl;
 import org.eclipse.xtend.core.macro.declaration.XtendTypeParameterDeclarationImpl;
 import org.eclipse.xtend.core.xtend.XtendFunction;
 import org.eclipse.xtend.core.xtend.XtendParameter;
+import org.eclipse.xtend.lib.macro.declaration.InterfaceDeclaration;
+import org.eclipse.xtend.lib.macro.declaration.MemberDeclaration;
 import org.eclipse.xtend.lib.macro.declaration.MethodDeclaration;
 import org.eclipse.xtend.lib.macro.declaration.ParameterDeclaration;
 import org.eclipse.xtend.lib.macro.declaration.TypeParameterDeclaration;
 import org.eclipse.xtend.lib.macro.declaration.TypeReference;
 import org.eclipse.xtend.lib.macro.declaration.Visibility;
 import org.eclipse.xtend.lib.macro.expression.Expression;
+import org.eclipse.xtext.common.types.JvmOperation;
 import org.eclipse.xtext.common.types.JvmTypeParameter;
 import org.eclipse.xtext.common.types.JvmTypeReference;
 import org.eclipse.xtext.xbase.XExpression;
@@ -26,6 +31,8 @@ import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.ListExtensions;
+import org.eclipse.xtext.xbase.typesystem.override.IResolvedOperation;
+import org.eclipse.xtext.xbase.typesystem.override.ResolvedFeatures;
 
 @SuppressWarnings("all")
 public class XtendMethodDeclarationImpl extends XtendMemberDeclarationImpl<XtendFunction> implements MethodDeclaration {
@@ -52,7 +59,7 @@ public class XtendMethodDeclarationImpl extends XtendMemberDeclarationImpl<Xtend
   
   @Override
   public boolean isDefault() {
-    return false;
+    return (((!this.getDelegate().isStatic()) && (this.getDelegate().getExpression() != null)) && (this.getDeclaringType() instanceof InterfaceDeclaration));
   }
   
   @Override
@@ -124,6 +131,17 @@ public class XtendMethodDeclarationImpl extends XtendMemberDeclarationImpl<Xtend
   
   @Override
   public Iterable<? extends MethodDeclaration> getOverriddenOrImplementedMethods() {
+    boolean _isOverride = this.getDelegate().isOverride();
+    if (_isOverride) {
+      final JvmOperation jvmOperation = this.getCompilationUnit().getJvmModelAssociations().getDirectlyInferredOperation(this.getDelegate());
+      final ResolvedFeatures resolvedFeatures = this.getCompilationUnit().getOverrideHelper().getResolvedFeatures(jvmOperation.getDeclaringType());
+      final IResolvedOperation resolvedOperation = resolvedFeatures.getResolvedOperation(jvmOperation);
+      final List<IResolvedOperation> overriddenOrImplemented = resolvedOperation.getOverriddenAndImplementedMethods();
+      final Function1<IResolvedOperation, MemberDeclaration> _function = (IResolvedOperation it) -> {
+        return this.getCompilationUnit().toMemberDeclaration(it.getDeclaration());
+      };
+      return Iterables.<MethodDeclaration>filter(ListExtensions.<IResolvedOperation, MemberDeclaration>map(overriddenOrImplemented, _function), MethodDeclaration.class);
+    }
     return CollectionLiterals.<MethodDeclaration>emptyList();
   }
 }

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/AbstractClassBuilder.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/AbstractClassBuilder.java
@@ -33,6 +33,7 @@ public abstract class AbstractClassBuilder extends AbstractCodeBuilder {
   }
   
   @Pure
+  @Override
   public String getImage() {
     return this.image;
   }

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/AbstractCodeBuilder.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/AbstractCodeBuilder.java
@@ -207,6 +207,7 @@ public abstract class AbstractCodeBuilder implements ICodeBuilder {
   }
   
   @Pure
+  @Override
   public Object getOwnerSource() {
     return this.ownerSource;
   }
@@ -216,6 +217,7 @@ public abstract class AbstractCodeBuilder implements ICodeBuilder {
   }
   
   @Pure
+  @Override
   public JvmDeclaredType getOwner() {
     return this.owner;
   }
@@ -225,6 +227,7 @@ public abstract class AbstractCodeBuilder implements ICodeBuilder {
   }
   
   @Pure
+  @Override
   public JvmVisibility getVisibility() {
     return this.visibility;
   }

--- a/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/AbstractInterfaceBuilder.java
+++ b/org.eclipse.xtend.ide/xtend-gen/org/eclipse/xtend/ide/codebuilder/AbstractInterfaceBuilder.java
@@ -33,6 +33,7 @@ public abstract class AbstractInterfaceBuilder extends AbstractCodeBuilder {
   }
   
   @Pure
+  @Override
   public String getImage() {
     return this.image;
   }


### PR DESCRIPTION
Added implementation for XtendMethodDeclaration.isDefault and getOverriddenOrImplemented

closes #1075