### PR TITLE
[#1061] Improve the Xtend MultiQuickfix test cases.

### DIFF
--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/EqualsWithNullMultiQuickfixTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/EqualsWithNullMultiQuickfixTest.xtend
@@ -1,10 +1,11 @@
-/** 
- * Copyright (c) 2012, 2020 itemis AG (http://www.itemis.eu) and others.
+/*******************************************************************************
+ * Copyright (c) 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
+ * 
  * SPDX-License-Identifier: EPL-2.0
- */
+ *******************************************************************************/
 package org.eclipse.xtend.ide.tests.quickfix
 
 import org.eclipse.xtend.ide.tests.XtendIDEInjectorProvider
@@ -24,25 +25,7 @@ import static extension org.eclipse.xtend.ide.tests.WorkbenchTestHelper.createPl
 @InjectWith(XtendIDEInjectorProvider)
 class EqualsWithNullMultiQuickfixTest extends AbstractMultiQuickfixTest {
 
-	override String getFileName() {
-		return "Foo"
-	}
-
-	override dslFile(CharSequence content) {
-		super.dslFile(projectName, "src/equalsnull/" + fileName, fileExtension, content);
-	}
-
-	override void setUp() throws Exception {
-		super.setUp()
-
-		projectName.createPluginProject()
-	}
-
-	@Test
-	def void testEqualsNullQuickfixInExpression() {
-
-		// Use Xtend style API...
-		
+	@Test def equals_with_null_in_expression() {
 		'''
 			package equalsnull
 			class Foo {
@@ -60,7 +43,7 @@ class EqualsWithNullMultiQuickfixTest extends AbstractMultiQuickfixTest {
 			---------------------------------------------------------------------
 			0: message=The operator '==' should be replaced by '===' when null is one of the arguments.
 			1: message=The operator '!=' should be replaced by '!==' when null is one of the arguments.
-		''', '''
+		''','''
 			package equalsnull
 			class Foo {
 				def m(Object a, Object b, Object c) {
@@ -70,15 +53,10 @@ class EqualsWithNullMultiQuickfixTest extends AbstractMultiQuickfixTest {
 			-----------------------------------------------------------
 			(no markers found)
 		''')
-
 	}
 
-	@Test
-	def void testEqualsNullQuickfixInSwitch() {
-
-		// Use Java style API...
-		
-		val content = '''
+	@Test def equals_with_null_in_switch() {
+		val model = '''
 			package equalsnull
 			class Foo {
 				def m(Object a, Object b, Object c) {
@@ -92,14 +70,26 @@ class EqualsWithNullMultiQuickfixTest extends AbstractMultiQuickfixTest {
 			}
 		'''
 
-		val xtextEditor = openEditor(dslFile(content))
+		val xtextEditor = model.dslFile.openEditor
 
-		val offset = content.indexOf("==") + 1
-		val proposals = computeQuickAssistProposals(xtextEditor, offset)
+		val offset = model.indexOf("==") + 1
+		val proposals = xtextEditor.computeQuickAssistProposals(offset)
 
-		assertEquals(1, proposals.size())
-		assertEquals(1, proposals.filter[it instanceof QuickAssistCompletionProposal].size())
-		assertEquals("Replace '==' with '===' and '!=' with '!=='", proposals.get(0).displayString)
+		assertEquals(1, proposals.size)
+		assertEquals(1, proposals.filter(QuickAssistCompletionProposal).size)
+		assertEquals("Replace '==' with '===' and '!=' with '!=='", proposals.head.displayString)
 	}
 
+	override setUp() {
+		super.setUp
+		projectName.createPluginProject
+	}
+
+	override getFileName() {
+		"Foo"
+	}
+
+	override dslFile(CharSequence content) {
+		super.dslFile(projectName, "src/equalsnull/" + fileName, fileExtension, content)
+	}
 }

--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/RemoveUnnecessaryModifiersMultiQuickfixTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/RemoveUnnecessaryModifiersMultiQuickfixTest.xtend
@@ -8,6 +8,9 @@
  *******************************************************************************/
 package org.eclipse.xtend.ide.tests.quickfix
 
+import org.eclipse.core.resources.IFile
+import org.eclipse.core.resources.IMarker
+import org.eclipse.core.runtime.NullProgressMonitor
 import org.eclipse.xtend.ide.tests.XtendIDEInjectorProvider
 import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
@@ -25,71 +28,20 @@ import static extension org.eclipse.xtend.ide.tests.WorkbenchTestHelper.createPl
 @InjectWith(XtendIDEInjectorProvider)
 class RemoveUnnecessaryModifiersMultiQuickfixTest extends AbstractMultiQuickfixTest {
 
-	static final String MODEL_WITH_UNNECESSARY_MODIFIERS = '''
-		package unnecessarymodifiers
-		public class Foo {
-			private final val A = 1
-			def public m() {
-				new Runnable {
-					public override def run() {
-						println(A)
+	@Test def remove_unnecessary_modifiers001() {
+		'''
+			package unnecessarymodifiers
+			public class Foo {
+				private final val A = 1
+				def public m() {
+					new Runnable {
+						public override def run() {
+							println(A)
+						}
 					}
 				}
 			}
-		}
-	'''
-
-	override String getFileName() {
-		return "Foo"
-	}
-
-	override dslFile(CharSequence content) {
-		super.dslFile(projectName, "src/unnecessarymodifiers/" + fileName, fileExtension, content);
-	}
-
-	override void setUp() throws Exception {
-		super.setUp()
-
-		projectName.createPluginProject()
-	}
-
-	@Test
-	def void testRemoveUnnecessaryModifiersQuickfixXtend() {
-
-		// Use Xtend style API...
-		
-		// TODO...
-		// org.junit.ComparisonFailure: expected:<...nnecessarymodifiers
-		// [class Foo {
-		// 	 val A = 1
-		//	 def m() {
-		//		 new Runnable {
-		//			 override run() {
-		//				 println(A)
-		//			 }
-		//		 }
-		//	 }
-		// }
-		// ------------------
-		// (no markers found)]> but was:<...nnecessarymodifiers
-		// [<0<public>0> class Foo {
-		//	 <1<private>1> <2<final>2> val A = 1
-		//	 def <3<public>3> m() {
-		//		 new Runnable {
-		//			 <4<public>4> override <5<def>5> run() {
-		//				 println(A)
-		//			 }
-		//		 }
-		//	 }
-		// }
-		// ---------------------------------------------------
-		// 0: message=The public modifier is unnecessary on class Foo
-		// 1: message=The private modifier is unnecessary on field A
-		// 2: message=The final modifier is unnecessary on field A
-		// 3: message=The public modifier is unnecessary on method m
-		// 4: message=The public modifier is unnecessary on method run
-		// 5: message=The def modifier is unnecessary on method run]
-		MODEL_WITH_UNNECESSARY_MODIFIERS.testMultiQuickfix('''
+		'''.testMultiQuickfix('''
 			package unnecessarymodifiers
 			<0<public>0> class Foo {
 				<1<private>1> <2<final>2> val A = 1
@@ -120,22 +72,58 @@ class RemoveUnnecessaryModifiersMultiQuickfixTest extends AbstractMultiQuickfixT
 					}
 				}
 			}
-			------------------
+			----------------------------
 			(no markers found)
 		''')
 	}
 
-	@Test
-	def void testRemoveUnnecessaryModifiersQuickfixJava() {
+	@Test def remove_unnecessary_modifiers002() {
+		val model = '''
+			package unnecessarymodifiers
+			public class Foo {
+				private final val A = 1
+				def public m() {
+					new Runnable {
+						public override def run() {
+							println(A)
+						}
+					}
+				}
+			}
+		'''
 
-		// Use Java style API...
-		
-		val xtextEditor = openEditor(dslFile(MODEL_WITH_UNNECESSARY_MODIFIERS))
+		val xtextEditor = model.dslFile.openEditor
 
-		val offset = MODEL_WITH_UNNECESSARY_MODIFIERS.indexOf("public") + 1
-		val proposals = computeQuickAssistProposals(xtextEditor, offset)
+		val offset = model.indexOf("public") + 1
+		val proposals = xtextEditor.computeQuickAssistProposals(offset)
 
-		assertEquals(1, proposals.size())
-		assertEquals(1, proposals.filter[it instanceof QuickAssistCompletionProposal].size())
+		assertEquals(1, proposals.size)
+		assertEquals(1, proposals.filter(QuickAssistCompletionProposal).size)
+		assertEquals("Remove the unnecessary modifier.", proposals.head.displayString)
+	}
+
+	override setUp() {
+		super.setUp
+		projectName.createPluginProject
+	}
+
+	override getFileName() {
+		"Foo"
+	}
+
+	override dslFile(CharSequence content) {
+		super.dslFile(projectName, "src/unnecessarymodifiers/" + fileName, fileExtension, content)
+	}
+
+	// TODO: verify why this workaround is necessary
+	override protected IMarker[] getMarkers(IFile file) {
+		saveAllOpenEditors
+		super.getMarkers(file)
+	}
+
+	private def saveAllOpenEditors() {
+		activePage.editorReferences.forEach[
+			getEditor(false).doSave(new NullProgressMonitor)
+		]
 	}
 }

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/EqualsWithNullMultiQuickfixTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/EqualsWithNullMultiQuickfixTest.java
@@ -1,12 +1,14 @@
 /**
- * Copyright (c) 2012, 2020 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2020 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
+ * 
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.eclipse.xtend.ide.tests.quickfix;
 
+import com.google.common.collect.Iterables;
 import java.util.List;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
@@ -20,7 +22,6 @@ import org.eclipse.xtext.ui.editor.quickfix.QuickAssistCompletionProposal;
 import org.eclipse.xtext.ui.testing.AbstractMultiQuickfixTest;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
-import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.junit.Assert;
 import org.junit.Test;
@@ -33,27 +34,8 @@ import org.junit.runner.RunWith;
 @InjectWith(XtendIDEInjectorProvider.class)
 @SuppressWarnings("all")
 public class EqualsWithNullMultiQuickfixTest extends AbstractMultiQuickfixTest {
-  @Override
-  public String getFileName() {
-    return "Foo";
-  }
-  
-  @Override
-  public IFile dslFile(final CharSequence content) {
-    String _projectName = this.getProjectName();
-    String _fileName = this.getFileName();
-    String _plus = ("src/equalsnull/" + _fileName);
-    return super.dslFile(_projectName, _plus, this.getFileExtension(), content);
-  }
-  
-  @Override
-  public void setUp() throws Exception {
-    super.setUp();
-    WorkbenchTestHelper.createPluginProject(this.getProjectName());
-  }
-  
   @Test
-  public void testEqualsNullQuickfixInExpression() {
+  public void equals_with_null_in_expression() {
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("package equalsnull");
     _builder.newLine();
@@ -116,7 +98,7 @@ public class EqualsWithNullMultiQuickfixTest extends AbstractMultiQuickfixTest {
   }
   
   @Test
-  public void testEqualsNullQuickfixInSwitch() {
+  public void equals_with_null_in_switch() {
     try {
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("package equalsnull");
@@ -149,19 +131,39 @@ public class EqualsWithNullMultiQuickfixTest extends AbstractMultiQuickfixTest {
       _builder.newLine();
       _builder.append("}");
       _builder.newLine();
-      final String content = _builder.toString();
-      final XtextEditor xtextEditor = this.openEditor(this.dslFile(content));
-      int _indexOf = content.indexOf("==");
+      final String model = _builder.toString();
+      final XtextEditor xtextEditor = this.openEditor(this.dslFile(model));
+      int _indexOf = model.indexOf("==");
       final int offset = (_indexOf + 1);
       final ICompletionProposal[] proposals = this.computeQuickAssistProposals(xtextEditor, offset);
       Assert.assertEquals(1, ((List<ICompletionProposal>)Conversions.doWrapArray(proposals)).size());
-      final Function1<ICompletionProposal, Boolean> _function = (ICompletionProposal it) -> {
-        return Boolean.valueOf((it instanceof QuickAssistCompletionProposal));
-      };
-      Assert.assertEquals(1, IterableExtensions.size(IterableExtensions.<ICompletionProposal>filter(((Iterable<ICompletionProposal>)Conversions.doWrapArray(proposals)), _function)));
-      Assert.assertEquals("Replace \'==\' with \'===\' and \'!=\' with \'!==\'", (proposals[0]).getDisplayString());
+      Assert.assertEquals(1, IterableExtensions.size(Iterables.<QuickAssistCompletionProposal>filter(((Iterable<?>)Conversions.doWrapArray(proposals)), QuickAssistCompletionProposal.class)));
+      Assert.assertEquals("Replace \'==\' with \'===\' and \'!=\' with \'!==\'", IterableExtensions.<ICompletionProposal>head(((Iterable<ICompletionProposal>)Conversions.doWrapArray(proposals))).getDisplayString());
     } catch (Throwable _e) {
       throw Exceptions.sneakyThrow(_e);
     }
+  }
+  
+  @Override
+  public void setUp() {
+    try {
+      super.setUp();
+      WorkbenchTestHelper.createPluginProject(this.getProjectName());
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
+  
+  @Override
+  public String getFileName() {
+    return "Foo";
+  }
+  
+  @Override
+  public IFile dslFile(final CharSequence content) {
+    String _projectName = this.getProjectName();
+    String _fileName = this.getFileName();
+    String _plus = ("src/equalsnull/" + _fileName);
+    return super.dslFile(_projectName, _plus, this.getFileExtension(), content);
   }
 }

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/RemoveUnnecessaryModifiersMultiQuickfixTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/RemoveUnnecessaryModifiersMultiQuickfixTest.java
@@ -8,9 +8,15 @@
  */
 package org.eclipse.xtend.ide.tests.quickfix;
 
+import com.google.common.collect.Iterables;
 import java.util.List;
+import java.util.function.Consumer;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IEditorReference;
 import org.eclipse.xtend.ide.tests.WorkbenchTestHelper;
 import org.eclipse.xtend.ide.tests.XtendIDEInjectorProvider;
 import org.eclipse.xtend2.lib.StringConcatenation;
@@ -19,10 +25,9 @@ import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.editor.quickfix.QuickAssistCompletionProposal;
 import org.eclipse.xtext.ui.testing.AbstractMultiQuickfixTest;
+import org.eclipse.xtext.ui.testing.AbstractWorkbenchTest;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
-import org.eclipse.xtext.xbase.lib.Functions.Function0;
-import org.eclipse.xtext.xbase.lib.Functions.Function1;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,9 +40,125 @@ import org.junit.runner.RunWith;
 @InjectWith(XtendIDEInjectorProvider.class)
 @SuppressWarnings("all")
 public class RemoveUnnecessaryModifiersMultiQuickfixTest extends AbstractMultiQuickfixTest {
-  private static final String MODEL_WITH_UNNECESSARY_MODIFIERS = new Function0<String>() {
-    @Override
-    public String apply() {
+  @Test
+  public void remove_unnecessary_modifiers001() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("package unnecessarymodifiers");
+    _builder.newLine();
+    _builder.append("public class Foo {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("private final val A = 1");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def public m() {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("new Runnable {");
+    _builder.newLine();
+    _builder.append("\t\t\t");
+    _builder.append("public override def run() {");
+    _builder.newLine();
+    _builder.append("\t\t\t\t");
+    _builder.append("println(A)");
+    _builder.newLine();
+    _builder.append("\t\t\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("package unnecessarymodifiers");
+    _builder_1.newLine();
+    _builder_1.append("<0<public>0> class Foo {");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("<1<private>1> <2<final>2> val A = 1");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("def <3<public>3> m() {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("new Runnable {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t\t");
+    _builder_1.append("<4<public>4> override <5<def>5> run() {");
+    _builder_1.newLine();
+    _builder_1.append("\t\t\t\t");
+    _builder_1.append("println(A)");
+    _builder_1.newLine();
+    _builder_1.append("\t\t\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("\t");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("---------------------------------------------------");
+    _builder_1.newLine();
+    _builder_1.append("0: message=The public modifier is unnecessary on class Foo");
+    _builder_1.newLine();
+    _builder_1.append("1: message=The private modifier is unnecessary on field A");
+    _builder_1.newLine();
+    _builder_1.append("2: message=The final modifier is unnecessary on field A");
+    _builder_1.newLine();
+    _builder_1.append("3: message=The public modifier is unnecessary on method m");
+    _builder_1.newLine();
+    _builder_1.append("4: message=The public modifier is unnecessary on method run");
+    _builder_1.newLine();
+    _builder_1.append("5: message=The def modifier is unnecessary on method run");
+    _builder_1.newLine();
+    StringConcatenation _builder_2 = new StringConcatenation();
+    _builder_2.append("package unnecessarymodifiers");
+    _builder_2.newLine();
+    _builder_2.append("class Foo {");
+    _builder_2.newLine();
+    _builder_2.append("\t");
+    _builder_2.append("val A = 1");
+    _builder_2.newLine();
+    _builder_2.append("\t");
+    _builder_2.append("def m() {");
+    _builder_2.newLine();
+    _builder_2.append("\t\t");
+    _builder_2.append("new Runnable {");
+    _builder_2.newLine();
+    _builder_2.append("\t\t\t");
+    _builder_2.append("override run() {");
+    _builder_2.newLine();
+    _builder_2.append("\t\t\t\t");
+    _builder_2.append("println(A)");
+    _builder_2.newLine();
+    _builder_2.append("\t\t\t");
+    _builder_2.append("}");
+    _builder_2.newLine();
+    _builder_2.append("\t\t");
+    _builder_2.append("}");
+    _builder_2.newLine();
+    _builder_2.append("\t");
+    _builder_2.append("}");
+    _builder_2.newLine();
+    _builder_2.append("}");
+    _builder_2.newLine();
+    _builder_2.append("----------------------------");
+    _builder_2.newLine();
+    _builder_2.append("(no markers found)");
+    _builder_2.newLine();
+    this.testMultiQuickfix(_builder, _builder_1, _builder_2);
+  }
+  
+  @Test
+  public void remove_unnecessary_modifiers002() {
+    try {
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("package unnecessarymodifiers");
       _builder.newLine();
@@ -69,9 +190,28 @@ public class RemoveUnnecessaryModifiersMultiQuickfixTest extends AbstractMultiQu
       _builder.newLine();
       _builder.append("}");
       _builder.newLine();
-      return _builder.toString();
+      final String model = _builder.toString();
+      final XtextEditor xtextEditor = this.openEditor(this.dslFile(model));
+      int _indexOf = model.indexOf("public");
+      final int offset = (_indexOf + 1);
+      final ICompletionProposal[] proposals = this.computeQuickAssistProposals(xtextEditor, offset);
+      Assert.assertEquals(1, ((List<ICompletionProposal>)Conversions.doWrapArray(proposals)).size());
+      Assert.assertEquals(1, IterableExtensions.size(Iterables.<QuickAssistCompletionProposal>filter(((Iterable<?>)Conversions.doWrapArray(proposals)), QuickAssistCompletionProposal.class)));
+      Assert.assertEquals("Remove the unnecessary modifier.", IterableExtensions.<ICompletionProposal>head(((Iterable<ICompletionProposal>)Conversions.doWrapArray(proposals))).getDisplayString());
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
     }
-  }.apply();
+  }
+  
+  @Override
+  public void setUp() {
+    try {
+      super.setUp();
+      WorkbenchTestHelper.createPluginProject(this.getProjectName());
+    } catch (Throwable _e) {
+      throw Exceptions.sneakyThrow(_e);
+    }
+  }
   
   @Override
   public String getFileName() {
@@ -87,110 +227,21 @@ public class RemoveUnnecessaryModifiersMultiQuickfixTest extends AbstractMultiQu
   }
   
   @Override
-  public void setUp() throws Exception {
-    super.setUp();
-    WorkbenchTestHelper.createPluginProject(this.getProjectName());
-  }
-  
-  @Test
-  public void testRemoveUnnecessaryModifiersQuickfixXtend() {
-    StringConcatenation _builder = new StringConcatenation();
-    _builder.append("package unnecessarymodifiers");
-    _builder.newLine();
-    _builder.append("<0<public>0> class Foo {");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("<1<private>1> <2<final>2> val A = 1");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("def <3<public>3> m() {");
-    _builder.newLine();
-    _builder.append("\t\t");
-    _builder.append("new Runnable {");
-    _builder.newLine();
-    _builder.append("\t\t\t");
-    _builder.append("<4<public>4> override <5<def>5> run() {");
-    _builder.newLine();
-    _builder.append("\t\t\t\t");
-    _builder.append("println(A)");
-    _builder.newLine();
-    _builder.append("\t\t\t");
-    _builder.append("}");
-    _builder.newLine();
-    _builder.append("\t\t");
-    _builder.append("}");
-    _builder.newLine();
-    _builder.append("\t");
-    _builder.append("}");
-    _builder.newLine();
-    _builder.append("}");
-    _builder.newLine();
-    _builder.append("---------------------------------------------------");
-    _builder.newLine();
-    _builder.append("0: message=The public modifier is unnecessary on class Foo");
-    _builder.newLine();
-    _builder.append("1: message=The private modifier is unnecessary on field A");
-    _builder.newLine();
-    _builder.append("2: message=The final modifier is unnecessary on field A");
-    _builder.newLine();
-    _builder.append("3: message=The public modifier is unnecessary on method m");
-    _builder.newLine();
-    _builder.append("4: message=The public modifier is unnecessary on method run");
-    _builder.newLine();
-    _builder.append("5: message=The def modifier is unnecessary on method run");
-    _builder.newLine();
-    StringConcatenation _builder_1 = new StringConcatenation();
-    _builder_1.append("package unnecessarymodifiers");
-    _builder_1.newLine();
-    _builder_1.append("class Foo {");
-    _builder_1.newLine();
-    _builder_1.append("\t");
-    _builder_1.append("val A = 1");
-    _builder_1.newLine();
-    _builder_1.append("\t");
-    _builder_1.append("def m() {");
-    _builder_1.newLine();
-    _builder_1.append("\t\t");
-    _builder_1.append("new Runnable {");
-    _builder_1.newLine();
-    _builder_1.append("\t\t\t");
-    _builder_1.append("override run() {");
-    _builder_1.newLine();
-    _builder_1.append("\t\t\t\t");
-    _builder_1.append("println(A)");
-    _builder_1.newLine();
-    _builder_1.append("\t\t\t");
-    _builder_1.append("}");
-    _builder_1.newLine();
-    _builder_1.append("\t\t");
-    _builder_1.append("}");
-    _builder_1.newLine();
-    _builder_1.append("\t");
-    _builder_1.append("}");
-    _builder_1.newLine();
-    _builder_1.append("}");
-    _builder_1.newLine();
-    _builder_1.append("------------------");
-    _builder_1.newLine();
-    _builder_1.append("(no markers found)");
-    _builder_1.newLine();
-    this.testMultiQuickfix(RemoveUnnecessaryModifiersMultiQuickfixTest.MODEL_WITH_UNNECESSARY_MODIFIERS, _builder, _builder_1);
-  }
-  
-  @Test
-  public void testRemoveUnnecessaryModifiersQuickfixJava() {
-    try {
-      final XtextEditor xtextEditor = this.openEditor(this.dslFile(RemoveUnnecessaryModifiersMultiQuickfixTest.MODEL_WITH_UNNECESSARY_MODIFIERS));
-      int _indexOf = RemoveUnnecessaryModifiersMultiQuickfixTest.MODEL_WITH_UNNECESSARY_MODIFIERS.indexOf("public");
-      final int offset = (_indexOf + 1);
-      final ICompletionProposal[] proposals = this.computeQuickAssistProposals(xtextEditor, offset);
-      Assert.assertEquals(1, ((List<ICompletionProposal>)Conversions.doWrapArray(proposals)).size());
-      final Function1<ICompletionProposal, Boolean> _function = (ICompletionProposal it) -> {
-        return Boolean.valueOf((it instanceof QuickAssistCompletionProposal));
-      };
-      Assert.assertEquals(1, IterableExtensions.size(IterableExtensions.<ICompletionProposal>filter(((Iterable<ICompletionProposal>)Conversions.doWrapArray(proposals)), _function)));
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
+  protected IMarker[] getMarkers(final IFile file) {
+    IMarker[] _xblockexpression = null;
+    {
+      this.saveAllOpenEditors();
+      _xblockexpression = super.getMarkers(file);
     }
+    return _xblockexpression;
+  }
+  
+  private void saveAllOpenEditors() {
+    final Consumer<IEditorReference> _function = (IEditorReference it) -> {
+      IEditorPart _editor = it.getEditor(false);
+      NullProgressMonitor _nullProgressMonitor = new NullProgressMonitor();
+      _editor.doSave(_nullProgressMonitor);
+    };
+    ((List<IEditorReference>)Conversions.doWrapArray(AbstractWorkbenchTest.getActivePage().getEditorReferences())).forEach(_function);
   }
 }


### PR DESCRIPTION
- Cleaning up the EqualsWithNullMultiQuickfixTest and the
RemoveUnnecessaryModifiersMultiQuickfixTest tests cases.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>