### PR TITLE
[releng] Update Orbit URL to https://download.eclipse.org/tools/orbit/downloads/2020-12

### DIFF
--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-latest.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-latest.target
@@ -126,7 +126,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-oxygen.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-oxygen.target
@@ -118,7 +118,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-photon.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-photon.target
@@ -118,7 +118,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201809.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201809.target
@@ -118,7 +118,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201812.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201812.target
@@ -118,7 +118,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201903.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201903.target
@@ -118,7 +118,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201906.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201906.target
@@ -118,7 +118,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201909.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201909.target
@@ -118,7 +118,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201912.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r201912.target
@@ -118,7 +118,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r202003.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r202003.target
@@ -118,7 +118,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r202006.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r202006.target
@@ -118,7 +118,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r202009.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-r202009.target
@@ -118,7 +118,7 @@
 		<unit id="org.objectweb.asm" version="8.0.1.v20200420-1007"/>
 		<unit id="org.objectweb.asm.tree" version="8.0.1.v20200420-1007"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2020-12"/>
 	</location>
 </locations>
 </target>


### PR DESCRIPTION
This change was brought to you by your friendly Xtext Genie.