### PR TITLE
Bug 568152 - Use FrameworkUtil#getBundle instead of Platform#getBundle

### DIFF
--- a/org.eclipse.xtend.ide/src-gen/org/eclipse/xtend/ide/XtendExecutableExtensionFactory.java
+++ b/org.eclipse.xtend.ide/src-gen/org/eclipse/xtend/ide/XtendExecutableExtensionFactory.java
@@ -9,10 +9,10 @@
 package org.eclipse.xtend.ide;
 
 import com.google.inject.Injector;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.xtend.ide.internal.XtendActivator;
 import org.eclipse.xtext.ui.guice.AbstractGuiceAwareExecutableExtensionFactory;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -22,7 +22,7 @@ public class XtendExecutableExtensionFactory extends AbstractGuiceAwareExecutabl
 
 	@Override
 	protected Bundle getBundle() {
-		return Platform.getBundle(XtendActivator.PLUGIN_ID);
+		return FrameworkUtil.getBundle(XtendActivator.class);
 	}
 	
 	@Override


### PR DESCRIPTION
Signed-off-by: Karsten Thoms <karsten.thoms@karakun.com>