### PR TITLE
Bug 568152 - Use FrameworkUtil#getBundle instead of Platform#getBundle

### DIFF
--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/refactoring/JavaRefactoringIntegrationTest.java
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/refactoring/JavaRefactoringIntegrationTest.java
@@ -24,6 +24,7 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.Version;
 
 /**
@@ -34,7 +35,7 @@ public class JavaRefactoringIntegrationTest extends AbstractXtendRenameRefactori
 	@Before
 	public void doNotRunOnOxygen() {
 		//FIXME workaround for https://github.com/eclipse/xtext-xtend/issues/767
-		Version version = Platform.getBundle("org.eclipse.core.runtime").getVersion();
+		Version version = FrameworkUtil.getBundle(Platform.class).getVersion();
 		// in case it was not obvious: 3.13 == Oxygen
 		Assume.assumeFalse(version.getMajor() == 3 && version.getMinor() == 13);
 	}


### PR DESCRIPTION
Refactor usages where a class can be referenced for the requested
bundle.

Signed-off-by: Karsten Thoms <karsten.thoms@karakun.com>