### PR TITLE
[eclipse/xtext-xtend#1132] do restriction checks also on type literal member feature calls

### DIFF
--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/validation/AccessRestrictionInWorkspaceTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/validation/AccessRestrictionInWorkspaceTest.xtend
@@ -27,6 +27,7 @@ import org.junit.Test
 
 import static org.eclipse.xtend.ide.tests.WorkbenchTestHelper.*
 import static org.eclipse.xtext.common.types.TypesPackage$Literals.*
+import static org.eclipse.xtext.xbase.XbasePackage$Literals.*
 import static org.eclipse.xtext.xbase.validation.IssueCodes.*
 
 import static extension org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.*
@@ -41,21 +42,34 @@ class AccessRestrictionInWorkspaceTest extends AbstractXtendUITestCase {
 	extension IResourceSetProvider
 	
 	@Test
-	def void testForbiddenReferenceInOtherProject() {
+	def void testForbiddenReferenceInOtherProject() throws Exception {
 		val xtendFile = 'secondProject/src/Dummy.xtend'.createFile('class D { restricted.A a }').parse
 		val c = xtendFile.xtendTypes.head as XtendClass
 		c.assertError(JVM_TYPE_REFERENCE, FORBIDDEN_REFERENCE, 'Access restriction: The type A is not accessible', 'on required project firstProject')
 	}
 	
 	@Test
-	def void testDiscouragedReferenceInOtherProject() {
+	def void testForbiddenReferenceInOtherProjectAsMemberFeatureCall() throws Exception {
+		val xtendFile = 'secondProject/src/Dummy.xtend'.createFile('class Dummy { public var n = restricted.A.name }').parse
+		val c = xtendFile.xtendTypes.head as XtendClass
+		c.assertError(XMEMBER_FEATURE_CALL, FORBIDDEN_REFERENCE, 'Access restriction: The type A is not accessible', 'on required project firstProject')
+	}
+	@Test
+	def void testForbiddenReferenceInOtherProjectAsFeatureCall() throws Exception {
+		val xtendFile = 'secondProject/src/Dummy.xtend'.createFile('import restricted.A; class Dummy { public var n = A.name }').parse
+		val c = xtendFile.xtendTypes.head as XtendClass
+		c.assertError(XFEATURE_CALL, FORBIDDEN_REFERENCE, 'Access restriction: The type A is not accessible', 'on required project firstProject')
+	}
+	
+	@Test
+	def void testDiscouragedReferenceInOtherProject() throws Exception {
 		val xtendFile = 'secondProject/src/Dummy.xtend'.createFile('class D { discouraged.B b }').parse
 		val c = xtendFile.xtendTypes.head as XtendClass
 		c.assertWarning(JVM_TYPE_REFERENCE, DISCOURAGED_REFERENCE, 'Discouraged access: The type B is not accessible', 'on required project firstProject')
 	}
 	
 	@Test
-	def void testForbiddenReferenceInSameProject() {
+	def void testForbiddenReferenceInSameProject() throws Exception {
 		val xtendFile = 'firstProject/src/Dummy.xtend'.createFile('class D { restricted.A a }').parse
 		val c = xtendFile.xtendTypes.head as XtendClass
 		c.assertNoError(DISCOURAGED_REFERENCE)
@@ -63,7 +77,7 @@ class AccessRestrictionInWorkspaceTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void testDiscouragedReferenceInSameProject() {
+	def void testDiscouragedReferenceInSameProject() throws Exception {
 		val xtendFile = 'firstProject/src/Dummy.xtend'.createFile('class D { discouraged.B b }').parse
 		val c = xtendFile.xtendTypes.head as XtendClass
 		c.assertNoError(DISCOURAGED_REFERENCE)
@@ -71,7 +85,7 @@ class AccessRestrictionInWorkspaceTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void testExportedByOtherProject() {
+	def void testExportedByOtherProject() throws Exception {
 		val xtendFile = 'secondProject/src/Dummy.xtend'.createFile('class D { allowed.C c }').parse
 		val c = xtendFile.xtendTypes.head as XtendClass
 		c.assertNoError(DISCOURAGED_REFERENCE)
@@ -79,21 +93,21 @@ class AccessRestrictionInWorkspaceTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void testForbiddenReferenceInReexportedProject() {
+	def void testForbiddenReferenceInReexportedProject() throws Exception {
 		val xtendFile = 'thirdProject/src/Dummy.xtend'.createFile('class D { restricted.A a }').parse
 		val c = xtendFile.xtendTypes.head as XtendClass
 		c.assertError(JVM_TYPE_REFERENCE, FORBIDDEN_REFERENCE, 'Access restriction: The type A is not accessible', 'on required project firstProject')
 	}
 	
 	@Test
-	def void testDiscouragedReferenceInReexportedProject() {
+	def void testDiscouragedReferenceInReexportedProject() throws Exception {
 		val xtendFile = 'thirdProject/src/Dummy.xtend'.createFile('class D { discouraged.B b }').parse
 		val c = xtendFile.xtendTypes.head as XtendClass
 		c.assertWarning(JVM_TYPE_REFERENCE, DISCOURAGED_REFERENCE, 'Discouraged access: The type B is not accessible', 'on required project firstProject')
 	}
 	
 	@Test
-	def void testReexported() {
+	def void testReexported() throws Exception {
 		val xtendFile = 'thirdProject/src/Dummy.xtend'.createFile('class D { allowed.C c }').parse
 		val c = xtendFile.xtendTypes.head as XtendClass
 		c.assertNoError(DISCOURAGED_REFERENCE)
@@ -101,7 +115,7 @@ class AccessRestrictionInWorkspaceTest extends AbstractXtendUITestCase {
 	}
 	
 	@Test
-	def void testForbiddenReferenceInImplicitLambdaParameter() {
+	def void testForbiddenReferenceInImplicitLambdaParameter() throws Exception {
 		val xtendFile = 'secondProject/src/Dummy.xtend'.createFile('class D { new () { new discouraged.B().accept[] } }').parse
 		val c = xtendFile.xtendTypes.head as XtendClass
 		c.assertError(JVM_TYPE_REFERENCE, FORBIDDEN_REFERENCE, 'Access restriction: The type A is not accessible', 'on required project firstProject')
@@ -138,7 +152,7 @@ class AccessRestrictionInWorkspaceTest extends AbstractXtendUITestCase {
 		cleanWorkspace();
 	}
 	
-	private def configureExportedPackages(IJavaProject pluginProject) {
+	private def configureExportedPackages(IJavaProject pluginProject) throws Exception {
 		val manifestFile = pluginProject.project.getFile("META-INF/MANIFEST.MF")
 		val contents = manifestFile.contents
 		val manifest = try {

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/validation/AccessRestrictionInWorkspaceTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/validation/AccessRestrictionInWorkspaceTest.java
@@ -31,8 +31,8 @@ import org.eclipse.xtext.testing.validation.ValidationTestHelper;
 import org.eclipse.xtext.ui.resource.IResourceSetProvider;
 import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.util.MergeableManifest2;
+import org.eclipse.xtext.xbase.XbasePackage;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
-import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.validation.IssueCodes;
@@ -54,115 +54,95 @@ public class AccessRestrictionInWorkspaceTest extends AbstractXtendUITestCase {
   private IResourceSetProvider _iResourceSetProvider;
   
   @Test
-  public void testForbiddenReferenceInOtherProject() {
-    try {
-      final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("secondProject/src/Dummy.xtend", "class D { restricted.A a }"));
-      XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
-      final XtendClass c = ((XtendClass) _head);
-      this._validationTestHelper.assertError(c, TypesPackage.Literals.JVM_TYPE_REFERENCE, IssueCodes.FORBIDDEN_REFERENCE, "Access restriction: The type A is not accessible", "on required project firstProject");
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
-    }
+  public void testForbiddenReferenceInOtherProject() throws Exception {
+    final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("secondProject/src/Dummy.xtend", "class D { restricted.A a }"));
+    XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
+    final XtendClass c = ((XtendClass) _head);
+    this._validationTestHelper.assertError(c, TypesPackage.Literals.JVM_TYPE_REFERENCE, IssueCodes.FORBIDDEN_REFERENCE, "Access restriction: The type A is not accessible", "on required project firstProject");
   }
   
   @Test
-  public void testDiscouragedReferenceInOtherProject() {
-    try {
-      final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("secondProject/src/Dummy.xtend", "class D { discouraged.B b }"));
-      XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
-      final XtendClass c = ((XtendClass) _head);
-      this._validationTestHelper.assertWarning(c, TypesPackage.Literals.JVM_TYPE_REFERENCE, IssueCodes.DISCOURAGED_REFERENCE, "Discouraged access: The type B is not accessible", "on required project firstProject");
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
-    }
+  public void testForbiddenReferenceInOtherProjectAsMemberFeatureCall() throws Exception {
+    final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("secondProject/src/Dummy.xtend", "class Dummy { public var n = restricted.A.name }"));
+    XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
+    final XtendClass c = ((XtendClass) _head);
+    this._validationTestHelper.assertError(c, XbasePackage.Literals.XMEMBER_FEATURE_CALL, IssueCodes.FORBIDDEN_REFERENCE, "Access restriction: The type A is not accessible", "on required project firstProject");
   }
   
   @Test
-  public void testForbiddenReferenceInSameProject() {
-    try {
-      final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("firstProject/src/Dummy.xtend", "class D { restricted.A a }"));
-      XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
-      final XtendClass c = ((XtendClass) _head);
-      this._validationTestHelper.assertNoError(c, IssueCodes.DISCOURAGED_REFERENCE);
-      this._validationTestHelper.assertNoError(c, IssueCodes.FORBIDDEN_REFERENCE);
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
-    }
+  public void testForbiddenReferenceInOtherProjectAsFeatureCall() throws Exception {
+    final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("secondProject/src/Dummy.xtend", "import restricted.A; class Dummy { public var n = A.name }"));
+    XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
+    final XtendClass c = ((XtendClass) _head);
+    this._validationTestHelper.assertError(c, XbasePackage.Literals.XFEATURE_CALL, IssueCodes.FORBIDDEN_REFERENCE, "Access restriction: The type A is not accessible", "on required project firstProject");
   }
   
   @Test
-  public void testDiscouragedReferenceInSameProject() {
-    try {
-      final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("firstProject/src/Dummy.xtend", "class D { discouraged.B b }"));
-      XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
-      final XtendClass c = ((XtendClass) _head);
-      this._validationTestHelper.assertNoError(c, IssueCodes.DISCOURAGED_REFERENCE);
-      this._validationTestHelper.assertNoError(c, IssueCodes.FORBIDDEN_REFERENCE);
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
-    }
+  public void testDiscouragedReferenceInOtherProject() throws Exception {
+    final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("secondProject/src/Dummy.xtend", "class D { discouraged.B b }"));
+    XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
+    final XtendClass c = ((XtendClass) _head);
+    this._validationTestHelper.assertWarning(c, TypesPackage.Literals.JVM_TYPE_REFERENCE, IssueCodes.DISCOURAGED_REFERENCE, "Discouraged access: The type B is not accessible", "on required project firstProject");
   }
   
   @Test
-  public void testExportedByOtherProject() {
-    try {
-      final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("secondProject/src/Dummy.xtend", "class D { allowed.C c }"));
-      XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
-      final XtendClass c = ((XtendClass) _head);
-      this._validationTestHelper.assertNoError(c, IssueCodes.DISCOURAGED_REFERENCE);
-      this._validationTestHelper.assertNoError(c, IssueCodes.FORBIDDEN_REFERENCE);
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
-    }
+  public void testForbiddenReferenceInSameProject() throws Exception {
+    final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("firstProject/src/Dummy.xtend", "class D { restricted.A a }"));
+    XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
+    final XtendClass c = ((XtendClass) _head);
+    this._validationTestHelper.assertNoError(c, IssueCodes.DISCOURAGED_REFERENCE);
+    this._validationTestHelper.assertNoError(c, IssueCodes.FORBIDDEN_REFERENCE);
   }
   
   @Test
-  public void testForbiddenReferenceInReexportedProject() {
-    try {
-      final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("thirdProject/src/Dummy.xtend", "class D { restricted.A a }"));
-      XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
-      final XtendClass c = ((XtendClass) _head);
-      this._validationTestHelper.assertError(c, TypesPackage.Literals.JVM_TYPE_REFERENCE, IssueCodes.FORBIDDEN_REFERENCE, "Access restriction: The type A is not accessible", "on required project firstProject");
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
-    }
+  public void testDiscouragedReferenceInSameProject() throws Exception {
+    final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("firstProject/src/Dummy.xtend", "class D { discouraged.B b }"));
+    XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
+    final XtendClass c = ((XtendClass) _head);
+    this._validationTestHelper.assertNoError(c, IssueCodes.DISCOURAGED_REFERENCE);
+    this._validationTestHelper.assertNoError(c, IssueCodes.FORBIDDEN_REFERENCE);
   }
   
   @Test
-  public void testDiscouragedReferenceInReexportedProject() {
-    try {
-      final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("thirdProject/src/Dummy.xtend", "class D { discouraged.B b }"));
-      XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
-      final XtendClass c = ((XtendClass) _head);
-      this._validationTestHelper.assertWarning(c, TypesPackage.Literals.JVM_TYPE_REFERENCE, IssueCodes.DISCOURAGED_REFERENCE, "Discouraged access: The type B is not accessible", "on required project firstProject");
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
-    }
+  public void testExportedByOtherProject() throws Exception {
+    final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("secondProject/src/Dummy.xtend", "class D { allowed.C c }"));
+    XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
+    final XtendClass c = ((XtendClass) _head);
+    this._validationTestHelper.assertNoError(c, IssueCodes.DISCOURAGED_REFERENCE);
+    this._validationTestHelper.assertNoError(c, IssueCodes.FORBIDDEN_REFERENCE);
   }
   
   @Test
-  public void testReexported() {
-    try {
-      final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("thirdProject/src/Dummy.xtend", "class D { allowed.C c }"));
-      XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
-      final XtendClass c = ((XtendClass) _head);
-      this._validationTestHelper.assertNoError(c, IssueCodes.DISCOURAGED_REFERENCE);
-      this._validationTestHelper.assertNoError(c, IssueCodes.FORBIDDEN_REFERENCE);
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
-    }
+  public void testForbiddenReferenceInReexportedProject() throws Exception {
+    final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("thirdProject/src/Dummy.xtend", "class D { restricted.A a }"));
+    XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
+    final XtendClass c = ((XtendClass) _head);
+    this._validationTestHelper.assertError(c, TypesPackage.Literals.JVM_TYPE_REFERENCE, IssueCodes.FORBIDDEN_REFERENCE, "Access restriction: The type A is not accessible", "on required project firstProject");
   }
   
   @Test
-  public void testForbiddenReferenceInImplicitLambdaParameter() {
-    try {
-      final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("secondProject/src/Dummy.xtend", "class D { new () { new discouraged.B().accept[] } }"));
-      XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
-      final XtendClass c = ((XtendClass) _head);
-      this._validationTestHelper.assertError(c, TypesPackage.Literals.JVM_TYPE_REFERENCE, IssueCodes.FORBIDDEN_REFERENCE, "Access restriction: The type A is not accessible", "on required project firstProject");
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
-    }
+  public void testDiscouragedReferenceInReexportedProject() throws Exception {
+    final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("thirdProject/src/Dummy.xtend", "class D { discouraged.B b }"));
+    XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
+    final XtendClass c = ((XtendClass) _head);
+    this._validationTestHelper.assertWarning(c, TypesPackage.Literals.JVM_TYPE_REFERENCE, IssueCodes.DISCOURAGED_REFERENCE, "Discouraged access: The type B is not accessible", "on required project firstProject");
+  }
+  
+  @Test
+  public void testReexported() throws Exception {
+    final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("thirdProject/src/Dummy.xtend", "class D { allowed.C c }"));
+    XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
+    final XtendClass c = ((XtendClass) _head);
+    this._validationTestHelper.assertNoError(c, IssueCodes.DISCOURAGED_REFERENCE);
+    this._validationTestHelper.assertNoError(c, IssueCodes.FORBIDDEN_REFERENCE);
+  }
+  
+  @Test
+  public void testForbiddenReferenceInImplicitLambdaParameter() throws Exception {
+    final XtendFile xtendFile = this.parse(IResourcesSetupUtil.createFile("secondProject/src/Dummy.xtend", "class D { new () { new discouraged.B().accept[] } }"));
+    XtendTypeDeclaration _head = IterableExtensions.<XtendTypeDeclaration>head(xtendFile.getXtendTypes());
+    final XtendClass c = ((XtendClass) _head);
+    this._validationTestHelper.assertError(c, TypesPackage.Literals.JVM_TYPE_REFERENCE, IssueCodes.FORBIDDEN_REFERENCE, "Access restriction: The type A is not accessible", "on required project firstProject");
   }
   
   public XtendFile parse(final IFile file) {
@@ -215,26 +195,22 @@ public class AccessRestrictionInWorkspaceTest extends AbstractXtendUITestCase {
     IResourcesSetupUtil.cleanWorkspace();
   }
   
-  private IJavaProject configureExportedPackages(final IJavaProject pluginProject) {
+  private IJavaProject configureExportedPackages(final IJavaProject pluginProject) throws Exception {
+    final IFile manifestFile = pluginProject.getProject().getFile("META-INF/MANIFEST.MF");
+    final InputStream contents = manifestFile.getContents();
+    MergeableManifest2 _xtrycatchfinallyexpression = null;
     try {
-      final IFile manifestFile = pluginProject.getProject().getFile("META-INF/MANIFEST.MF");
-      final InputStream contents = manifestFile.getContents();
-      MergeableManifest2 _xtrycatchfinallyexpression = null;
-      try {
-        _xtrycatchfinallyexpression = new MergeableManifest2(contents);
-      } finally {
-        contents.close();
-      }
-      final MergeableManifest2 manifest = _xtrycatchfinallyexpression;
-      manifest.addExportedPackages(Collections.<String>unmodifiableSet(CollectionLiterals.<String>newHashSet("allowed", "discouraged;x-internal:=true")));
-      final ByteArrayOutputStream out = new ByteArrayOutputStream();
-      manifest.write(out);
-      byte[] _byteArray = out.toByteArray();
-      final ByteArrayInputStream in = new ByteArrayInputStream(_byteArray);
-      manifestFile.setContents(in, true, true, null);
-      return pluginProject;
-    } catch (Throwable _e) {
-      throw Exceptions.sneakyThrow(_e);
+      _xtrycatchfinallyexpression = new MergeableManifest2(contents);
+    } finally {
+      contents.close();
     }
+    final MergeableManifest2 manifest = _xtrycatchfinallyexpression;
+    manifest.addExportedPackages(Collections.<String>unmodifiableSet(CollectionLiterals.<String>newHashSet("allowed", "discouraged;x-internal:=true")));
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    manifest.write(out);
+    byte[] _byteArray = out.toByteArray();
+    final ByteArrayInputStream in = new ByteArrayInputStream(_byteArray);
+    manifestFile.setContents(in, true, true, null);
+    return pluginProject;
   }
 }


### PR DESCRIPTION
[eclipse/xtext-xtend#1132] do restriction checks also on type literal member feature calls

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>