### PR TITLE
[#1143] Disable theme manager due to regression

### DIFF
--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/XtendActivator.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/XtendActivator.java
@@ -8,29 +8,19 @@
  *******************************************************************************/
 package org.eclipse.xtend.ide;
 
-import static java.util.Collections.*;
-
-import java.util.Optional;
-
-import org.eclipse.e4.core.services.events.IEventBroker;
-import org.eclipse.e4.ui.css.swt.theme.IThemeEngine;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.PlatformUI;
-import org.eclipse.xtend.ide.highlighting.XtendThemeManager;
 import org.osgi.framework.BundleContext;
-import org.osgi.service.event.Event;
 
 /**
  * @author Karsten Thoms - Initial contribution and API
  */
-@SuppressWarnings("restriction")
 public class XtendActivator extends org.eclipse.xtend.ide.internal.XtendActivator {
 
-	private XtendThemeManager themeManager;
+	// private XtendThemeManager themeManager;
 
 	@Override
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
+		/* disabled due to issue#1173
 		getEventBroker().ifPresent(eventBroker -> {
 			themeManager = new XtendThemeManager();
 			eventBroker.subscribe(IThemeEngine.Events.THEME_CHANGED, themeManager);
@@ -38,20 +28,25 @@ public class XtendActivator extends org.eclipse.xtend.ide.internal.XtendActivato
 				themeManager.handleEvent(new Event(IThemeEngine.Events.THEME_CHANGED, emptyMap()))
 			);
 		});
+		*/
 	}
 
 	@Override
 	public void stop(BundleContext context) throws Exception {
+		/* disabled due to issue#1173
 		getEventBroker().ifPresent(eventBroker -> {
 			if (themeManager != null) {
 				eventBroker.unsubscribe(themeManager);
 			}
 		});
+		*/
 		super.stop(context);
 	}
 
+	/* disabled due to issue#1173
 	private Optional<IEventBroker> getEventBroker() {
 		return Optional.ofNullable(PlatformUI.getWorkbench().getService(IEventBroker.class));
 	}
+	*/
 
 }


### PR DESCRIPTION
It was enough to disable the event listener. No need to change the plugin.xml to come back to the previous state.

<img width="1160" alt="Bildschirmfoto 2020-11-23 um 09 34 13" src="https://user-images.githubusercontent.com/265597/99941991-3ba1a080-2d6f-11eb-895f-cb892bcf9ec7.png">
<img width="1160" alt="Bildschirmfoto 2020-11-23 um 09 34 29" src="https://user-images.githubusercontent.com/265597/99942003-3e9c9100-2d6f-11eb-934c-77b9373d469d.png">

The dark theme support will be reconsidered for 2.25.