### PR TITLE
https://github.com/eclipse/xtext-eclipse/issues/1505 Update Xtend tests.

### DIFF
--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/EqualsWithNullMultiQuickfixTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/EqualsWithNullMultiQuickfixTest.xtend
@@ -40,7 +40,7 @@ class EqualsWithNullMultiQuickfixTest extends AbstractMultiQuickfixTest {
 					if(a <0<==>0> null || b <1<!=>1> null || c === null) 0 else 1
 				}
 			}
-			---------------------------------------------------------------------
+			-----
 			0: message=The operator '==' should be replaced by '===' when null is one of the arguments.
 			1: message=The operator '!=' should be replaced by '!==' when null is one of the arguments.
 		''','''
@@ -50,7 +50,7 @@ class EqualsWithNullMultiQuickfixTest extends AbstractMultiQuickfixTest {
 					if(a === null || b !== null || c === null) 0 else 1
 				}
 			}
-			-----------------------------------------------------------
+			-----
 			(no markers found)
 		''')
 	}

--- a/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/RemoveUnnecessaryModifiersMultiQuickfixTest.xtend
+++ b/org.eclipse.xtend.ide.tests/longrunning/src/org/eclipse/xtend/ide/tests/quickfix/RemoveUnnecessaryModifiersMultiQuickfixTest.xtend
@@ -53,7 +53,7 @@ class RemoveUnnecessaryModifiersMultiQuickfixTest extends AbstractMultiQuickfixT
 					}
 				}
 			}
-			---------------------------------------------------
+			-----
 			0: message=The public modifier is unnecessary on class Foo
 			1: message=The private modifier is unnecessary on field A
 			2: message=The final modifier is unnecessary on field A
@@ -72,7 +72,7 @@ class RemoveUnnecessaryModifiersMultiQuickfixTest extends AbstractMultiQuickfixT
 					}
 				}
 			}
-			----------------------------
+			-----
 			(no markers found)
 		''')
 	}

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/EqualsWithNullMultiQuickfixTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/EqualsWithNullMultiQuickfixTest.java
@@ -68,7 +68,7 @@ public class EqualsWithNullMultiQuickfixTest extends AbstractMultiQuickfixTest {
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    _builder_1.append("---------------------------------------------------------------------");
+    _builder_1.append("-----");
     _builder_1.newLine();
     _builder_1.append("0: message=The operator \'==\' should be replaced by \'===\' when null is one of the arguments.");
     _builder_1.newLine();
@@ -90,7 +90,7 @@ public class EqualsWithNullMultiQuickfixTest extends AbstractMultiQuickfixTest {
     _builder_2.newLine();
     _builder_2.append("}");
     _builder_2.newLine();
-    _builder_2.append("-----------------------------------------------------------");
+    _builder_2.append("-----");
     _builder_2.newLine();
     _builder_2.append("(no markers found)");
     _builder_2.newLine();

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/RemoveUnnecessaryModifiersMultiQuickfixTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/quickfix/RemoveUnnecessaryModifiersMultiQuickfixTest.java
@@ -104,7 +104,7 @@ public class RemoveUnnecessaryModifiersMultiQuickfixTest extends AbstractMultiQu
     _builder_1.newLine();
     _builder_1.append("}");
     _builder_1.newLine();
-    _builder_1.append("---------------------------------------------------");
+    _builder_1.append("-----");
     _builder_1.newLine();
     _builder_1.append("0: message=The public modifier is unnecessary on class Foo");
     _builder_1.newLine();
@@ -149,7 +149,7 @@ public class RemoveUnnecessaryModifiersMultiQuickfixTest extends AbstractMultiQu
     _builder_2.newLine();
     _builder_2.append("}");
     _builder_2.newLine();
-    _builder_2.append("----------------------------");
+    _builder_2.append("-----");
     _builder_2.newLine();
     _builder_2.append("(no markers found)");
     _builder_2.newLine();


### PR DESCRIPTION
- Update the Xtend EqualsWithNullMultiQuickfixTest and
RemoveUnnecessaryModifiersMultiQuickfixTest test cases to use a fix
lenght delimiter.

Signed-off-by: miklossy <miklossy@itemis.de>