### PR TITLE
[eclipse/xtext#1928] Bootstrap against MWE(2) 1.6.1/2.12.1 Final

### DIFF
--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-latest.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-latest.target
@@ -104,7 +104,7 @@
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.emf.mwe2.lib" version="0.0.0"/>
 		<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
-		<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/milestones/S202102011009/"/>
+		<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.12.1/"/>
 	</location>
 	
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
[eclipse/xtext#1928] Bootstrap against MWE(2) 1.6.1/2.12.1 Final
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>