### PR TITLE
[eclipse/xtext#1875] Remove redundant project version

### DIFF
--- a/maven-pom.xml
+++ b/maven-pom.xml
@@ -11,7 +11,6 @@
 
 	<artifactId>org.eclipse.xtend.root</artifactId>
 	<packaging>pom</packaging>
-	<version>2.26.0-SNAPSHOT</version>
 
 	<modules>
 		<module>releng/org.eclipse.xtend.maven.parent</module>


### PR DESCRIPTION
The version is already inherited. The 'prepare-release-branches' only
replaces the first version occurance. The redundant second entry has to
be removed.

See https://github.com/eclipse/xtext-umbrella/pull/252#issuecomment-791181220
