### PR TITLE
use 'unsuccessful' to catch all failure cases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,7 @@ pipeline {
         }
       }
     }
-    failure {
+    unsuccessful {
       archiveArtifacts artifacts: 'org.eclipse.xtend.ide.swtbot.tests/screenshots/**, build/**, **/target/work/data/.metadata/.log, **/hs_err_pid*.log'
     }
     cleanup {


### PR DESCRIPTION
use 'unsuccessful' to catch all failure cases
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>