### PR TITLE
[eclipse/xtext#1452] add common JavaRuntimeVersion utility to avoid code duplication between modules

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/AbstractXtendTestCase.java
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/AbstractXtendTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -53,72 +53,6 @@ import com.google.inject.Provider;
 @RunWith(XtextRunner.class)
 @InjectWith(RuntimeInjectorProvider.class)
 public abstract class AbstractXtendTestCase extends Assert {
-
-	private static final boolean isJava11OrLater = determineJava11OrLater();
-
-	public static boolean isJava11OrLater() {
-		return isJava11OrLater;
-	}
-
-	private static final boolean isJava12OrLater = determineJava12OrLater();
-
-	public static boolean isJava12OrLater() {
-		return isJava12OrLater;
-	}
-	
-	private static final boolean isJava13OrLater = determineJava13OrLater();
-	
-	public static boolean isJava13OrLater() {
-		return isJava13OrLater;
-	}
-
-	private static boolean determineJava11OrLater() {
-		String javaVersion = System.getProperty("java.version");
-		try {
-			Pattern p = Pattern.compile("(\\d+)(.)*");
-			Matcher matcher = p.matcher(javaVersion);
-			if (matcher.matches()) {
-				String first = matcher.group(1);
-				int version = Integer.parseInt(first);
-				return version >= 11;
-			}
-		} catch (NumberFormatException e) {
-			// ok
-		}
-		return false;
-	}
-
-	private static boolean determineJava12OrLater() {
-		String javaVersion = System.getProperty("java.version");
-		try {
-			Pattern p = Pattern.compile("(\\d+)(.)*");
-			Matcher matcher = p.matcher(javaVersion);
-			if (matcher.matches()) {
-				String first = matcher.group(1);
-				int version = Integer.parseInt(first);
-				return version >= 12;
-			}
-		} catch (NumberFormatException e) {
-			// ok
-		}
-		return false;
-	}
-	
-	private static boolean determineJava13OrLater() {
-		String javaVersion = System.getProperty("java.version");
-		try {
-			Pattern p = Pattern.compile("(\\d+)(.)*");
-			Matcher matcher = p.matcher(javaVersion);
-			if (matcher.matches()) {
-				String first = matcher.group(1);
-				int version = Integer.parseInt(first);
-				return version >= 13;
-			}
-		} catch (NumberFormatException e) {
-			// ok
-		}
-		return false;
-	}
 
 	@Rule
 	@Inject public TemporaryFolder temporaryFolder;

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/ConfiguredCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/ConfiguredCompilerTest.xtend
@@ -11,6 +11,7 @@ package org.eclipse.xtend.core.tests.compiler
 import org.eclipse.xtend.core.tests.SingletonGeneratorConfigRuntimeInjectorProvider
 import org.eclipse.xtext.testing.InjectWith
 import org.junit.Test
+import org.eclipse.xtext.util.JavaRuntimeVersion
 
 /**
  * @author Sebastian Zarnekow - Initial contribution and API
@@ -168,7 +169,7 @@ class ConfiguredCompilerTest extends AbstractXtendCompilerTest {
 			'''
 				package foo;
 				
-				«IF !isJava11OrLater»
+				«IF !JavaRuntimeVersion.isJava11OrLater»
 				import javax.annotation.Generated;
 				
 				@Generated("org.eclipse.xtend.core.compiler.XtendGenerator")
@@ -194,7 +195,7 @@ class ConfiguredCompilerTest extends AbstractXtendCompilerTest {
 			'''
 				package foo;
 				
-				«IF !isJava11OrLater»
+				«IF !JavaRuntimeVersion.isJava11OrLater»
 				import javax.annotation.Generated;
 				
 				@Generated(value = "org.eclipse.xtend.core.compiler.XtendGenerator", comments = "Source: Bar.xtend")

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/batch/TestBatchCompiler.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/batch/TestBatchCompiler.xtend
@@ -21,8 +21,10 @@ import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.XtextRunner
 import org.eclipse.xtext.testing.logging.LoggingTester
 import org.eclipse.xtext.testing.smoketest.IgnoredBySmokeTest
+import org.eclipse.xtext.util.JavaRuntimeVersion
 import org.junit.After
 import org.junit.AfterClass
+import org.junit.Assume
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
@@ -30,8 +32,6 @@ import org.junit.runner.RunWith
 
 import static org.eclipse.xtext.util.Files.*
 import static org.junit.Assert.*
-import org.eclipse.xtend.core.tests.AbstractXtendTestCase
-import org.junit.Assume
 
 /**
  * Batch compiler tests.
@@ -498,7 +498,7 @@ class TestBatchCompiler {
 	
 	@Test
 	def void testGeneratedAnnotation() {
-		Assume.assumeFalse(AbstractXtendTestCase.isJava11OrLater)
+		Assume.assumeFalse(JavaRuntimeVersion.isJava11OrLater)
 		batchCompiler.generateGeneratedAnnotation = true
 		batchCompiler.sourcePath = "./batch-compiler-data/xtendClass"
 		assertTrue(batchCompiler.compile)
@@ -507,7 +507,7 @@ class TestBatchCompiler {
 	
 	@Test
 	def void testGeneratedAnnotationComment() {
-		Assume.assumeFalse(AbstractXtendTestCase.isJava11OrLater)
+		Assume.assumeFalse(JavaRuntimeVersion.isJava11OrLater)
 		batchCompiler.generateGeneratedAnnotation = true
 		batchCompiler.generatedAnnotationComment = "FooComment"
 		batchCompiler.sourcePath = "./batch-compiler-data/xtendClass"
@@ -519,7 +519,7 @@ class TestBatchCompiler {
 	
 	@Test
 	def void testGeneratedAnnotationDate1() {
-		Assume.assumeFalse(AbstractXtendTestCase.isJava11OrLater)
+		Assume.assumeFalse(JavaRuntimeVersion.isJava11OrLater)
 		batchCompiler.generateGeneratedAnnotation = true
 		batchCompiler.includeDateInGeneratedAnnotation = true
 		batchCompiler.sourcePath = "./batch-compiler-data/xtendClass"

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/imports/ImportsCollectorTests.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/imports/ImportsCollectorTests.xtend
@@ -17,6 +17,7 @@ import org.eclipse.xtext.xbase.imports.ImportsAcceptor.DefaultImportsAcceptor
 import org.eclipse.xtext.xbase.imports.ImportsCollector
 import org.junit.Test
 import org.junit.Assume
+import org.eclipse.xtext.util.JavaRuntimeVersion
 
 /**
  * @author Dennis Huebner - Initial contribution and API
@@ -306,7 +307,7 @@ class ImportsCollectorTests extends AbstractXtendTestCase {
 
 	@Test
 	def void testEnum_01() {
-		Assume.assumeFalse(isJava11OrLater)
+		Assume.assumeFalse(JavaRuntimeVersion.isJava11OrLater)
 		'''
 			import javax.annotation.Resource
 			import static javax.annotation.Resource.AuthenticationType.*

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/ActualTypeArgumentMergeTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/ActualTypeArgumentMergeTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -22,6 +22,7 @@ import org.eclipse.xtext.xbase.typesystem.util.VarianceInfo
 import org.junit.Test
 
 import static org.eclipse.xtext.xbase.typesystem.util.VarianceInfo.*
+import org.eclipse.xtext.util.JavaRuntimeVersion
 
 /**
  * @author Sebastian Zarnekow
@@ -310,7 +311,7 @@ class ActualTypeArgumentMergeTest extends AbstractTestingTypeReferenceOwner {
 	}
 	
 	@Test def void testUpperBound_11() {
-		if (isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater) {
 			'T'.mappedBy('java.util.Map<? extends T, ? extends T>', 'java.util.Map<String, Integer>')
 				.merge('T').to('Comparable<?> & Constable & ConstantDesc & Serializable', INVARIANT)
 		} else {

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/BoundTypeArgumentMergerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/BoundTypeArgumentMergerTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -19,6 +19,7 @@ import org.eclipse.xtext.xbase.typesystem.util.VarianceInfo
 import org.junit.Test
 
 import static org.eclipse.xtext.xbase.typesystem.util.VarianceInfo.*
+import org.eclipse.xtext.util.JavaRuntimeVersion
 
 /**
  * @author Sebastian Zarnekow
@@ -440,7 +441,7 @@ class BoundTypeArgumentMergerTest extends AbstractTestingTypeReferenceOwner {
 	}
 
 	@Test def void testMergeMultiType_01() {
-		if (isJava11OrLater) {
+		if (JavaRuntimeVersion.isJava11OrLater) {
 			merge('StringBuilder'->OUT->OUT, 'StringBuffer'->OUT->OUT).to('AbstractStringBuilder & Serializable & Comparable<?>', INVARIANT)
 		} else {
 			merge('StringBuilder'->OUT->OUT, 'StringBuffer'->OUT->OUT).to('AbstractStringBuilder & Serializable', INVARIANT)
@@ -448,7 +449,7 @@ class BoundTypeArgumentMergerTest extends AbstractTestingTypeReferenceOwner {
 	}
 
 	@Test def void testMergeMultiType_02() {
-		if (isJava11OrLater) {
+		if (JavaRuntimeVersion.isJava11OrLater) {
 			mergeSuccessive('StringBuilder'->OUT->OUT, 'StringBuffer'->OUT->OUT, 'StringBuilder'->OUT->OUT).to('AbstractStringBuilder & Serializable & Comparable<?>', INVARIANT)
 		} else {
 			mergeSuccessive('StringBuilder'->OUT->OUT, 'StringBuffer'->OUT->OUT, 'StringBuilder'->OUT->OUT).to('AbstractStringBuilder & Serializable', INVARIANT)
@@ -456,7 +457,7 @@ class BoundTypeArgumentMergerTest extends AbstractTestingTypeReferenceOwner {
 	}
 	
 	@Test def void testMergeMultiType_03() {
-		if (isJava11OrLater) {
+		if (JavaRuntimeVersion.isJava11OrLater) {
 			merge('StringBuilder'->OUT->INVARIANT, 'StringBuffer'->OUT->INVARIANT, 'String'->OUT->INVARIANT).to('Serializable & Comparable<?> & CharSequence', INVARIANT)
 		} else {
 			merge('StringBuilder'->OUT->INVARIANT, 'StringBuffer'->OUT->INVARIANT, 'String'->OUT->INVARIANT).to('Serializable & CharSequence', INVARIANT)
@@ -468,7 +469,7 @@ class BoundTypeArgumentMergerTest extends AbstractTestingTypeReferenceOwner {
 	}
 	
 	@Test def void testBug470766_01() {
-		if (isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater) {
 			merge('void'->OUT->INVARIANT, 'Integer'->OUT->INVARIANT, 'Long'->OUT->INVARIANT).to('Number & Comparable<?> & Constable & ConstantDesc', INVARIANT)
 		} else {
 			merge('void'->OUT->INVARIANT, 'Integer'->OUT->INVARIANT, 'Long'->OUT->INVARIANT).to('Number & Comparable<?>', INVARIANT)

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/CommonSuperTypeTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/CommonSuperTypeTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -16,6 +16,7 @@ import org.eclipse.xtext.xbase.typesystem.references.FunctionTypeReference
 import org.eclipse.xtext.xbase.typesystem.references.LightweightTypeReference
 import org.eclipse.xtext.xbase.typesystem.references.ParameterizedTypeReference
 import org.junit.Test
+import org.eclipse.xtext.util.JavaRuntimeVersion
 
 /**
  * @author Sebastian Zarnekow
@@ -91,7 +92,7 @@ class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
 	
 	@Test
 	def void testCommonSuperType_01() {
-		if (isJava11OrLater) {
+		if (JavaRuntimeVersion.isJava11OrLater) {
 			"Serializable & Comparable<?> & CharSequence".isSuperTypeOf("String", "StringBuilder")
 		} else {
 			"Serializable & CharSequence".isSuperTypeOf("String", "StringBuilder")
@@ -125,7 +126,7 @@ class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
 	
 	@Test
 	def void testCommonSuperType_07() {
-		if (isJava11OrLater) {
+		if (JavaRuntimeVersion.isJava11OrLater) {
 			"Comparable<?> & Appendable & CharSequence".isSuperTypeOf("StringBuilder", "java.nio.CharBuffer")
 		} else {
 			"Appendable & CharSequence".isSuperTypeOf("StringBuilder", "java.nio.CharBuffer")
@@ -149,7 +150,7 @@ class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
 	
 	@Test
 	def void testCommonSuperType_11() {
-		if (isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater) {
 			"Comparable<?> & Constable & ConstantDesc & Serializable".isSuperTypeOf("String", "Integer")
 		} else {
 			"Comparable<?> & Serializable".isSuperTypeOf("String", "Integer")
@@ -158,7 +159,7 @@ class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
 	
 	@Test
 	def void testCommonSuperType_12() {
-		if (isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater) {
 			"Number & Comparable<?> & Constable & ConstantDesc".isSuperTypeOf("Double", "Integer")
 		} else {
 			"Number & Comparable<?>".isSuperTypeOf("Double", "Integer")
@@ -167,7 +168,7 @@ class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
 	
 	@Test
 	def void testCommonSuperType_13() {
-		if (isJava11OrLater) {
+		if (JavaRuntimeVersion.isJava11OrLater) {
 			"AbstractStringBuilder & Serializable & Comparable<?>".isSuperTypeOf("StringBuilder", "StringBuffer")
 		} else {
 			"AbstractStringBuilder & Serializable".isSuperTypeOf("StringBuilder", "StringBuffer")
@@ -230,7 +231,7 @@ class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
 	
 	@Test
 	def void testCommonSuperType_24() {
-		if (isJava11OrLater) {
+		if (JavaRuntimeVersion.isJava11OrLater) {
 			"Collection<? extends AbstractStringBuilder & Serializable & Comparable<?>>".isSuperTypeOf("java.util.List<StringBuilder>", "java.util.Set<StringBuffer>")
 		} else {
 			"Collection<? extends AbstractStringBuilder & Serializable>".isSuperTypeOf("java.util.List<StringBuilder>", "java.util.Set<StringBuffer>")
@@ -254,7 +255,7 @@ class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
 	
 	@Test
 	def void testCommonSuperType_28() {
-		if (isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater) {
 			"Number[] & Comparable<?>[] & Constable[] & ConstantDesc[]".isSuperTypeOf("Integer[]", "Double[]")
 		} else {
 			"Number[] & Comparable<?>[]".isSuperTypeOf("Integer[]", "Double[]")
@@ -313,7 +314,7 @@ class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
 	
 	@Test
 	def void testCommonSuperType_39() {
-		if (isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater) {
 			"Number[][][] & Comparable<?>[][][] & Constable[][][] & ConstantDesc[][][]".isSuperTypeOf("Integer[][][]", "Double[][][]")
 		} else {
 			"Number[][][] & Comparable<?>[][][]".isSuperTypeOf("Integer[][][]", "Double[][][]")
@@ -327,7 +328,7 @@ class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
 	
 	@Test
 	def void testCommonSuperType_41() {
-		if (isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater) {
 			"Comparable<?> & Constable & ConstantDesc & Serializable".isSuperTypeOf("String", "int")
 		} else {
 			"Comparable<?> & Serializable".isSuperTypeOf("String", "int")
@@ -381,7 +382,7 @@ class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
 	
 	@Test
 	def void testCommonSuperType_51() {
-		if (isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater) {
 			"()=>Number & Comparable<?> & Constable & ConstantDesc".isSuperTypeOf("()=>int", "()=>long").isFunctionAndEquivalentTo("Function0<? extends Number & Comparable<?> & Constable & ConstantDesc>")
 		} else {
 			"()=>Number & Comparable<?>".isSuperTypeOf("()=>int", "()=>long").isFunctionAndEquivalentTo("Function0<? extends Number & Comparable<?>>")
@@ -390,7 +391,7 @@ class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
 	
 	@Test
 	def void testCommonSuperType_52() {
-		if (isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater) {
 			"()=>Number & Comparable<?> & Constable & ConstantDesc".isSuperTypeOf("()=>Integer", "()=>Long").isFunctionAndEquivalentTo("Function0<? extends Number & Comparable<?> & Constable & ConstantDesc>")
 		} else {
 			"()=>Number & Comparable<?>".isSuperTypeOf("()=>Integer", "()=>Long").isFunctionAndEquivalentTo("Function0<? extends Number & Comparable<?>>")
@@ -469,7 +470,7 @@ class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
 	
 	@Test
 	def void testCommonSuperType_67() {
-		if (isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater) {
 			"Comparable<?> & Constable & ConstantDesc & Serializable".isSuperTypeOf("Integer", "String")
 		} else {
 			"Comparable<?> & Serializable".isSuperTypeOf("Integer", "String")
@@ -478,7 +479,7 @@ class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
 	
 	@Test
 	def void testCommonSuperType_68() {
-		if (isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater) {
 			"Comparable<?> & Constable & ConstantDesc & Serializable".isSuperTypeOf("Integer", "String", "String")
 		} else {
 			"Comparable<?> & Serializable".isSuperTypeOf("Integer", "String", "String")

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/SuperTypeTests.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/typesystem/SuperTypeTests.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -17,6 +17,7 @@ import org.eclipse.xtend.core.jvmmodel.IXtendJvmAssociations
 import org.eclipse.xtext.xbase.typesystem.references.LightweightTypeReference
 import org.junit.Ignore
 import org.junit.Test
+import org.eclipse.xtext.util.JavaRuntimeVersion
 
 /**
  * @author Sebastian Zarnekow
@@ -128,7 +129,7 @@ class SuperTypesTest extends AbstractSuperTypesTest {
 	
 	@Test
 	override void testString() {
-		if (isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater) {
 			typeof(String).assertSuperTypes("Serializable", "Comparable<String>", "CharSequence", "Constable", "ConstantDesc")
 		} else {
 			typeof(String).assertSuperTypes("Serializable", "Comparable<String>", "CharSequence")
@@ -147,7 +148,7 @@ class SuperTypesTest extends AbstractSuperTypesTest {
 	
 	@Test
 	override void testStringArray() {
-		if (isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater) {
 			"String[]".assertSuperTypes("Serializable[]", "Comparable<String>[]", "CharSequence[]", "Constable[]", "ConstantDesc[]")
 		} else {
 			"String[]".assertSuperTypes("Serializable[]", "Comparable<String>[]", "CharSequence[]")
@@ -238,7 +239,7 @@ class AllSuperTypesTest extends AbstractSuperTypesTest {
 	
 	@Test
 	override void testString() {
-		if (isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater) {
 			typeof(String).assertSuperTypes("Serializable", "Comparable<String>", "CharSequence", "Constable", "ConstantDesc", "Object")
 		} else {
 			typeof(String).assertSuperTypes("Serializable", "Comparable<String>", "CharSequence", "Object")
@@ -257,7 +258,7 @@ class AllSuperTypesTest extends AbstractSuperTypesTest {
 	
 	@Test
 	override void testStringArray() {
-		if (isJava12OrLater) {
+		if (JavaRuntimeVersion.isJava12OrLater) {
 			"String[]".assertSuperTypes("Serializable[]", "Comparable<String>[]", "CharSequence[]", "Constable[]", "ConstantDesc[]", "Object[]", "Cloneable", "Serializable", "Object")
 		} else {
 			"String[]".assertSuperTypes("Serializable[]", "Comparable<String>[]", "CharSequence[]", "Object[]", "Cloneable", "Serializable", "Object")

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/ConfiguredCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/ConfiguredCompilerTest.java
@@ -8,10 +8,10 @@
  */
 package org.eclipse.xtend.core.tests.compiler;
 
-import org.eclipse.xtend.core.tests.AbstractXtendTestCase;
 import org.eclipse.xtend.core.tests.SingletonGeneratorConfigRuntimeInjectorProvider;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.xbase.compiler.GeneratorConfig;
 import org.junit.Test;
 
@@ -270,7 +270,7 @@ public class ConfiguredCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     {
-      boolean _isJava11OrLater = AbstractXtendTestCase.isJava11OrLater();
+      boolean _isJava11OrLater = JavaRuntimeVersion.isJava11OrLater();
       boolean _not = (!_isJava11OrLater);
       if (_not) {
         _builder_1.append("import javax.annotation.Generated;");
@@ -306,7 +306,7 @@ public class ConfiguredCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.newLine();
     {
-      boolean _isJava11OrLater = AbstractXtendTestCase.isJava11OrLater();
+      boolean _isJava11OrLater = JavaRuntimeVersion.isJava11OrLater();
       boolean _not = (!_isJava11OrLater);
       if (_not) {
         _builder_1.append("import javax.annotation.Generated;");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/batch/TestBatchCompiler.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/batch/TestBatchCompiler.java
@@ -18,7 +18,6 @@ import java.util.Set;
 import java.util.function.Consumer;
 import org.apache.log4j.Level;
 import org.eclipse.xtend.core.compiler.batch.XtendBatchCompiler;
-import org.eclipse.xtend.core.tests.AbstractXtendTestCase;
 import org.eclipse.xtend.core.tests.RuntimeInjectorProvider;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.generator.OutputConfiguration;
@@ -27,6 +26,7 @@ import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.testing.logging.LoggingTester;
 import org.eclipse.xtext.testing.smoketest.IgnoredBySmokeTest;
 import org.eclipse.xtext.util.Files;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.workspace.FileProjectConfig;
 import org.eclipse.xtext.workspace.FileSourceFolder;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
@@ -732,7 +732,7 @@ public class TestBatchCompiler {
   
   @Test
   public void testGeneratedAnnotation() {
-    Assume.assumeFalse(AbstractXtendTestCase.isJava11OrLater());
+    Assume.assumeFalse(JavaRuntimeVersion.isJava11OrLater());
     this.batchCompiler.setGenerateGeneratedAnnotation(true);
     this.batchCompiler.setSourcePath("./batch-compiler-data/xtendClass");
     Assert.assertTrue(this.batchCompiler.compile());
@@ -741,7 +741,7 @@ public class TestBatchCompiler {
   
   @Test
   public void testGeneratedAnnotationComment() {
-    Assume.assumeFalse(AbstractXtendTestCase.isJava11OrLater());
+    Assume.assumeFalse(JavaRuntimeVersion.isJava11OrLater());
     this.batchCompiler.setGenerateGeneratedAnnotation(true);
     this.batchCompiler.setGeneratedAnnotationComment("FooComment");
     this.batchCompiler.setSourcePath("./batch-compiler-data/xtendClass");
@@ -753,7 +753,7 @@ public class TestBatchCompiler {
   
   @Test
   public void testGeneratedAnnotationDate1() {
-    Assume.assumeFalse(AbstractXtendTestCase.isJava11OrLater());
+    Assume.assumeFalse(JavaRuntimeVersion.isJava11OrLater());
     this.batchCompiler.setGenerateGeneratedAnnotation(true);
     this.batchCompiler.setIncludeDateInGeneratedAnnotation(true);
     this.batchCompiler.setSourcePath("./batch-compiler-data/xtendClass");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/imports/ImportsCollectorTests.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/imports/ImportsCollectorTests.java
@@ -14,6 +14,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtend.core.tests.AbstractXtendTestCase;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.util.TextRegion;
 import org.eclipse.xtext.xbase.imports.ImportsAcceptor;
 import org.eclipse.xtext.xbase.imports.ImportsCollector;
@@ -468,7 +469,7 @@ public class ImportsCollectorTests extends AbstractXtendTestCase {
   
   @Test
   public void testEnum_01() {
-    Assume.assumeFalse(AbstractXtendTestCase.isJava11OrLater());
+    Assume.assumeFalse(JavaRuntimeVersion.isJava11OrLater());
     StringConcatenation _builder = new StringConcatenation();
     _builder.append("import javax.annotation.Resource");
     _builder.newLine();

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/AbstractSuperTypesTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/AbstractSuperTypesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/ActualTypeArgumentMergeTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/ActualTypeArgumentMergeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -15,11 +15,11 @@ import java.util.Map;
 import java.util.Set;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.xtend.core.jvmmodel.IXtendJvmAssociations;
-import org.eclipse.xtend.core.tests.AbstractXtendTestCase;
 import org.eclipse.xtend.core.xtend.XtendFunction;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.common.types.JvmOperation;
 import org.eclipse.xtext.common.types.JvmTypeParameter;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Extension;
@@ -363,7 +363,7 @@ public class ActualTypeArgumentMergeTest extends AbstractTestingTypeReferenceOwn
   
   @Test
   public void testUpperBound_11() {
-    boolean _isJava12OrLater = AbstractXtendTestCase.isJava12OrLater();
+    boolean _isJava12OrLater = JavaRuntimeVersion.isJava12OrLater();
     if (_isJava12OrLater) {
       this.to(this.merge(this.mappedBy("T", "java.util.Map<? extends T, ? extends T>", "java.util.Map<String, Integer>"), "T"), "Comparable<?> & Constable & ConstantDesc & Serializable", VarianceInfo.INVARIANT);
     } else {

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/AllSuperTypesTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/AllSuperTypesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -10,7 +10,7 @@ package org.eclipse.xtend.core.tests.typesystem;
 
 import java.util.Collection;
 import java.util.List;
-import org.eclipse.xtend.core.tests.AbstractXtendTestCase;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.xbase.lib.Pair;
 import org.eclipse.xtext.xbase.typesystem.references.LightweightTypeReference;
 import org.junit.Ignore;
@@ -29,7 +29,7 @@ public class AllSuperTypesTest extends AbstractSuperTypesTest {
   @Test
   @Override
   public void testString() {
-    boolean _isJava12OrLater = AbstractXtendTestCase.isJava12OrLater();
+    boolean _isJava12OrLater = JavaRuntimeVersion.isJava12OrLater();
     if (_isJava12OrLater) {
       this.assertSuperTypes(String.class, "Serializable", "Comparable<String>", "CharSequence", "Constable", "ConstantDesc", "Object");
     } else {
@@ -52,7 +52,7 @@ public class AllSuperTypesTest extends AbstractSuperTypesTest {
   @Test
   @Override
   public void testStringArray() {
-    boolean _isJava12OrLater = AbstractXtendTestCase.isJava12OrLater();
+    boolean _isJava12OrLater = JavaRuntimeVersion.isJava12OrLater();
     if (_isJava12OrLater) {
       this.assertSuperTypes("String[]", "Serializable[]", "Comparable<String>[]", "CharSequence[]", "Constable[]", "ConstantDesc[]", "Object[]", "Cloneable", "Serializable", "Object");
     } else {

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/BoundTypeArgumentMergerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/BoundTypeArgumentMergerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -13,11 +13,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import org.eclipse.xtend.core.jvmmodel.IXtendJvmAssociations;
-import org.eclipse.xtend.core.tests.AbstractXtendTestCase;
 import org.eclipse.xtend.core.xtend.XtendFunction;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.common.types.JvmFormalParameter;
 import org.eclipse.xtext.common.types.JvmOperation;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.util.Triple;
 import org.eclipse.xtext.util.Tuples;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
@@ -949,7 +949,7 @@ public class BoundTypeArgumentMergerTest extends AbstractTestingTypeReferenceOwn
   
   @Test
   public void testMergeMultiType_01() {
-    boolean _isJava11OrLater = AbstractXtendTestCase.isJava11OrLater();
+    boolean _isJava11OrLater = JavaRuntimeVersion.isJava11OrLater();
     if (_isJava11OrLater) {
       Pair<String, VarianceInfo> _mappedTo = Pair.<String, VarianceInfo>of("StringBuilder", VarianceInfo.OUT);
       Triple<String, VarianceInfo, VarianceInfo> _mappedTo_1 = this.operator_mappedTo(_mappedTo, VarianceInfo.OUT);
@@ -967,7 +967,7 @@ public class BoundTypeArgumentMergerTest extends AbstractTestingTypeReferenceOwn
   
   @Test
   public void testMergeMultiType_02() {
-    boolean _isJava11OrLater = AbstractXtendTestCase.isJava11OrLater();
+    boolean _isJava11OrLater = JavaRuntimeVersion.isJava11OrLater();
     if (_isJava11OrLater) {
       Pair<String, VarianceInfo> _mappedTo = Pair.<String, VarianceInfo>of("StringBuilder", VarianceInfo.OUT);
       Triple<String, VarianceInfo, VarianceInfo> _mappedTo_1 = this.operator_mappedTo(_mappedTo, VarianceInfo.OUT);
@@ -989,7 +989,7 @@ public class BoundTypeArgumentMergerTest extends AbstractTestingTypeReferenceOwn
   
   @Test
   public void testMergeMultiType_03() {
-    boolean _isJava11OrLater = AbstractXtendTestCase.isJava11OrLater();
+    boolean _isJava11OrLater = JavaRuntimeVersion.isJava11OrLater();
     if (_isJava11OrLater) {
       Pair<String, VarianceInfo> _mappedTo = Pair.<String, VarianceInfo>of("StringBuilder", VarianceInfo.OUT);
       Triple<String, VarianceInfo, VarianceInfo> _mappedTo_1 = this.operator_mappedTo(_mappedTo, VarianceInfo.INVARIANT);
@@ -1022,7 +1022,7 @@ public class BoundTypeArgumentMergerTest extends AbstractTestingTypeReferenceOwn
   
   @Test
   public void testBug470766_01() {
-    boolean _isJava12OrLater = AbstractXtendTestCase.isJava12OrLater();
+    boolean _isJava12OrLater = JavaRuntimeVersion.isJava12OrLater();
     if (_isJava12OrLater) {
       Pair<String, VarianceInfo> _mappedTo = Pair.<String, VarianceInfo>of("void", VarianceInfo.OUT);
       Triple<String, VarianceInfo, VarianceInfo> _mappedTo_1 = this.operator_mappedTo(_mappedTo, VarianceInfo.INVARIANT);

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/CommonSuperTypeTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/CommonSuperTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -15,11 +15,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import org.eclipse.xtend.core.jvmmodel.IXtendJvmAssociations;
-import org.eclipse.xtend.core.tests.AbstractXtendTestCase;
 import org.eclipse.xtend.core.xtend.XtendFunction;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.common.types.JvmFormalParameter;
 import org.eclipse.xtext.common.types.JvmOperation;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.Extension;
@@ -214,7 +214,7 @@ public class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
   
   @Test
   public void testCommonSuperType_01() {
-    boolean _isJava11OrLater = AbstractXtendTestCase.isJava11OrLater();
+    boolean _isJava11OrLater = JavaRuntimeVersion.isJava11OrLater();
     if (_isJava11OrLater) {
       this.isSuperTypeOf("Serializable & Comparable<?> & CharSequence", "String", "StringBuilder");
     } else {
@@ -249,7 +249,7 @@ public class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
   
   @Test
   public void testCommonSuperType_07() {
-    boolean _isJava11OrLater = AbstractXtendTestCase.isJava11OrLater();
+    boolean _isJava11OrLater = JavaRuntimeVersion.isJava11OrLater();
     if (_isJava11OrLater) {
       this.isSuperTypeOf("Comparable<?> & Appendable & CharSequence", "StringBuilder", "java.nio.CharBuffer");
     } else {
@@ -274,7 +274,7 @@ public class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
   
   @Test
   public void testCommonSuperType_11() {
-    boolean _isJava12OrLater = AbstractXtendTestCase.isJava12OrLater();
+    boolean _isJava12OrLater = JavaRuntimeVersion.isJava12OrLater();
     if (_isJava12OrLater) {
       this.isSuperTypeOf("Comparable<?> & Constable & ConstantDesc & Serializable", "String", "Integer");
     } else {
@@ -284,7 +284,7 @@ public class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
   
   @Test
   public void testCommonSuperType_12() {
-    boolean _isJava12OrLater = AbstractXtendTestCase.isJava12OrLater();
+    boolean _isJava12OrLater = JavaRuntimeVersion.isJava12OrLater();
     if (_isJava12OrLater) {
       this.isSuperTypeOf("Number & Comparable<?> & Constable & ConstantDesc", "Double", "Integer");
     } else {
@@ -294,7 +294,7 @@ public class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
   
   @Test
   public void testCommonSuperType_13() {
-    boolean _isJava11OrLater = AbstractXtendTestCase.isJava11OrLater();
+    boolean _isJava11OrLater = JavaRuntimeVersion.isJava11OrLater();
     if (_isJava11OrLater) {
       this.isSuperTypeOf("AbstractStringBuilder & Serializable & Comparable<?>", "StringBuilder", "StringBuffer");
     } else {
@@ -365,7 +365,7 @@ public class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
   
   @Test
   public void testCommonSuperType_24() {
-    boolean _isJava11OrLater = AbstractXtendTestCase.isJava11OrLater();
+    boolean _isJava11OrLater = JavaRuntimeVersion.isJava11OrLater();
     if (_isJava11OrLater) {
       this.isSuperTypeOf("Collection<? extends AbstractStringBuilder & Serializable & Comparable<?>>", "java.util.List<StringBuilder>", "java.util.Set<StringBuffer>");
     } else {
@@ -390,7 +390,7 @@ public class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
   
   @Test
   public void testCommonSuperType_28() {
-    boolean _isJava12OrLater = AbstractXtendTestCase.isJava12OrLater();
+    boolean _isJava12OrLater = JavaRuntimeVersion.isJava12OrLater();
     if (_isJava12OrLater) {
       this.isSuperTypeOf("Number[] & Comparable<?>[] & Constable[] & ConstantDesc[]", "Integer[]", "Double[]");
     } else {
@@ -450,7 +450,7 @@ public class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
   
   @Test
   public void testCommonSuperType_39() {
-    boolean _isJava12OrLater = AbstractXtendTestCase.isJava12OrLater();
+    boolean _isJava12OrLater = JavaRuntimeVersion.isJava12OrLater();
     if (_isJava12OrLater) {
       this.isSuperTypeOf("Number[][][] & Comparable<?>[][][] & Constable[][][] & ConstantDesc[][][]", "Integer[][][]", "Double[][][]");
     } else {
@@ -465,7 +465,7 @@ public class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
   
   @Test
   public void testCommonSuperType_41() {
-    boolean _isJava12OrLater = AbstractXtendTestCase.isJava12OrLater();
+    boolean _isJava12OrLater = JavaRuntimeVersion.isJava12OrLater();
     if (_isJava12OrLater) {
       this.isSuperTypeOf("Comparable<?> & Constable & ConstantDesc & Serializable", "String", "int");
     } else {
@@ -520,7 +520,7 @@ public class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
   
   @Test
   public void testCommonSuperType_51() {
-    boolean _isJava12OrLater = AbstractXtendTestCase.isJava12OrLater();
+    boolean _isJava12OrLater = JavaRuntimeVersion.isJava12OrLater();
     if (_isJava12OrLater) {
       this.isFunctionAndEquivalentTo(this.isSuperTypeOf("()=>Number & Comparable<?> & Constable & ConstantDesc", "()=>int", "()=>long"), "Function0<? extends Number & Comparable<?> & Constable & ConstantDesc>");
     } else {
@@ -530,7 +530,7 @@ public class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
   
   @Test
   public void testCommonSuperType_52() {
-    boolean _isJava12OrLater = AbstractXtendTestCase.isJava12OrLater();
+    boolean _isJava12OrLater = JavaRuntimeVersion.isJava12OrLater();
     if (_isJava12OrLater) {
       this.isFunctionAndEquivalentTo(this.isSuperTypeOf("()=>Number & Comparable<?> & Constable & ConstantDesc", "()=>Integer", "()=>Long"), "Function0<? extends Number & Comparable<?> & Constable & ConstantDesc>");
     } else {
@@ -610,7 +610,7 @@ public class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
   
   @Test
   public void testCommonSuperType_67() {
-    boolean _isJava12OrLater = AbstractXtendTestCase.isJava12OrLater();
+    boolean _isJava12OrLater = JavaRuntimeVersion.isJava12OrLater();
     if (_isJava12OrLater) {
       this.isSuperTypeOf("Comparable<?> & Constable & ConstantDesc & Serializable", "Integer", "String");
     } else {
@@ -620,7 +620,7 @@ public class CommonSuperTypeTest extends AbstractTestingTypeReferenceOwner {
   
   @Test
   public void testCommonSuperType_68() {
-    boolean _isJava12OrLater = AbstractXtendTestCase.isJava12OrLater();
+    boolean _isJava12OrLater = JavaRuntimeVersion.isJava12OrLater();
     if (_isJava12OrLater) {
       this.isSuperTypeOf("Comparable<?> & Constable & ConstantDesc & Serializable", "Integer", "String", "String");
     } else {

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/SuperTypesTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/typesystem/SuperTypesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -10,7 +10,7 @@ package org.eclipse.xtend.core.tests.typesystem;
 
 import java.util.Collection;
 import java.util.List;
-import org.eclipse.xtend.core.tests.AbstractXtendTestCase;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.xbase.lib.Pair;
 import org.eclipse.xtext.xbase.typesystem.references.LightweightTypeReference;
 import org.junit.Ignore;
@@ -29,7 +29,7 @@ public class SuperTypesTest extends AbstractSuperTypesTest {
   @Test
   @Override
   public void testString() {
-    boolean _isJava12OrLater = AbstractXtendTestCase.isJava12OrLater();
+    boolean _isJava12OrLater = JavaRuntimeVersion.isJava12OrLater();
     if (_isJava12OrLater) {
       this.assertSuperTypes(String.class, "Serializable", "Comparable<String>", "CharSequence", "Constable", "ConstantDesc");
     } else {
@@ -52,7 +52,7 @@ public class SuperTypesTest extends AbstractSuperTypesTest {
   @Test
   @Override
   public void testStringArray() {
-    boolean _isJava12OrLater = AbstractXtendTestCase.isJava12OrLater();
+    boolean _isJava12OrLater = JavaRuntimeVersion.isJava12OrLater();
     if (_isJava12OrLater) {
       this.assertSuperTypes("String[]", "Serializable[]", "Comparable<String>[]", "CharSequence[]", "Constable[]", "ConstantDesc[]");
     } else {

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/AbstractXtendUITestCase.java
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/AbstractXtendUITestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -7,9 +7,6 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package org.eclipse.xtend.ide.tests;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.launching.JavaRuntime;
@@ -39,71 +36,6 @@ import com.google.inject.Injector;
 @InjectWith(XtendIDEInjectorProvider.class)
 @RunWith(XtextRunner.class)
 public abstract class AbstractXtendUITestCase extends Assert {
-
-	private static final boolean isJava11OrLater = determineJava11OrLater();
-
-	public static boolean isJava11OrLater() {
-		return isJava11OrLater;
-	}
-
-	private static boolean determineJava11OrLater() {
-		String javaVersion = System.getProperty("java.version");
-		try {
-			Pattern p = Pattern.compile("(\\d+)(.)*");
-			Matcher matcher = p.matcher(javaVersion);
-			if (matcher.matches()) {
-				String first = matcher.group(1);
-				int version = Integer.parseInt(first);
-				return version >= 11;
-			}
-		} catch (NumberFormatException e) {
-			// ok
-		}
-		return false;
-	}
-	private static final boolean isJava13OrLater = determineJava13OrLater();
-	
-	public static boolean isJava13OrLater() {
-		return isJava13OrLater;
-	}
-	
-	private static boolean determineJava13OrLater() {
-		String javaVersion = System.getProperty("java.version");
-		try {
-			Pattern p = Pattern.compile("(\\d+)(.)*");
-			Matcher matcher = p.matcher(javaVersion);
-			if (matcher.matches()) {
-				String first = matcher.group(1);
-				int version = Integer.parseInt(first);
-				return version >= 13;
-			}
-		} catch (NumberFormatException e) {
-			// ok
-		}
-		return false;
-	}
-
-	private static final boolean isJava14OrLater = determineJava14OrLater();
-	
-	public static boolean isJava14OrLater() {
-		return isJava14OrLater;
-	}
-	
-	private static boolean determineJava14OrLater() {
-		String javaVersion = System.getProperty("java.version");
-		try {
-			Pattern p = Pattern.compile("(\\d+)(.)*");
-			Matcher matcher = p.matcher(javaVersion);
-			if (matcher.matches()) {
-				String first = matcher.group(1);
-				int version = Integer.parseInt(first);
-				return version >= 14;
-			}
-		} catch (NumberFormatException e) {
-			// ok
-		}
-		return false;
-	}
 
 	@Inject
 	private Injector injector;

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/AbstractXbaseContentAssistTest.java
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/AbstractXbaseContentAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -28,7 +28,6 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase;
 import org.eclipse.xtext.Constants;
 import org.eclipse.xtext.common.types.access.IJvmTypeProvider;
 import org.eclipse.xtext.common.types.access.jdt.IJavaProjectProvider;
@@ -38,6 +37,7 @@ import org.eclipse.xtext.resource.XtextResourceSet;
 import org.eclipse.xtext.ui.testing.ContentAssistProcessorTestBuilder;
 import org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil;
 import org.eclipse.xtext.ui.testing.util.ResourceLoadHelper;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.util.StringInputStream;
 import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.xbase.XExpression;
@@ -249,7 +249,7 @@ public abstract class AbstractXbaseContentAssistTest extends Assert implements R
 		addMethods(stringType, features, staticFeatures, featuresOrTypes);
 		// compareTo(T) is actually overridden by compareTo(String) but contained twice in String.class#getMethods
 		features.remove("compareTo()");
-		if (AbstractXtendUITestCase.isJava13OrLater()) {
+		if (JavaRuntimeVersion.isJava13OrLater()) {
 			// resolveConstantDesc(MethodHandles.Lookup) is there twice too
 			features.remove("resolveConstantDesc()");
 		}
@@ -309,7 +309,7 @@ public abstract class AbstractXbaseContentAssistTest extends Assert implements R
 		List<String> features = Lists.newArrayList();
 		List<String> staticFeatures = Lists.newArrayList();
 		addMethods(classType, features, staticFeatures, featuresOrTypes);
-		if (AbstractXtendUITestCase.isJava13OrLater()) {
+		if (JavaRuntimeVersion.isJava13OrLater()) {
 			features.remove("componentType");
 			features.remove("arrayType");
 			features.add("getComponentType");

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/Bug427440Test.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/Bug427440Test.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -12,6 +12,7 @@ import org.eclipse.jface.text.contentassist.ICompletionProposal
 import org.eclipse.xtext.ui.editor.contentassist.ConfigurableCompletionProposal
 import org.eclipse.xtext.ui.editor.contentassist.ReplacementTextApplier
 import org.junit.Test
+import org.eclipse.xtext.util.JavaRuntimeVersion
 
 /**
  * @author Holger Schill - Initial contribution and API
@@ -39,7 +40,7 @@ class Bug427440Test extends AbstractXtendContentAssistBugTest {
 		proposals.next.assertContains("annotations")
 		proposals.next.assertContains("anonymousClass")
 		proposals.next.assertContains("array")
-		if (isJava13OrLater) {
+		if (JavaRuntimeVersion.isJava13OrLater) {
 			proposals.next.assertContains("arrayType")
 		}
 		proposals.next.assertContains("asSubclass()")

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/Bug435184Test.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/Bug435184Test.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -9,6 +9,7 @@
 package org.eclipse.xtend.ide.tests.contentassist
 
 import org.junit.Test
+import org.eclipse.xtext.util.JavaRuntimeVersion
 
 /**
  * @author Sebastian Zarnekow - Initial contribution and API
@@ -30,7 +31,7 @@ class Bug435184Test extends AbstractXtendContentAssistBugTest {
 			  }
 			}
 		''')
-		if (isJava11OrLater)
+		if (JavaRuntimeVersion.isJava11OrLater)
 			b.assertTextAtCursorPosition('|', 'read', "read()", "read()", "readAllBytes", "readNBytes()", "readNBytes()")
 		else
 			b.assertTextAtCursorPosition('|', 'read', "read()", "read()")

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/ContentAssistInElseBlockTest.java
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/ContentAssistInElseBlockTest.java
@@ -10,7 +10,7 @@ package org.eclipse.xtend.ide.tests.contentassist;
 
 import java.util.List;
 
-import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
@@ -55,9 +55,9 @@ public class ContentAssistInElseBlockTest extends ContentAssistTest {
 	
 	@Override
 	@Test public void testForLoop_02() throws Exception {
-		if (AbstractXtendUITestCase.isJava13OrLater()) {
+		if (JavaRuntimeVersion.isJava13OrLater()) {
 			newBuilder().append("for (String string: null) string").assertTextAtCursorPosition(") string", 6, "string", "strip", "stripIndent", "stripLeading", "stripTrailing");
-		} else if (AbstractXtendUITestCase.isJava11OrLater()) {
+		} else if (JavaRuntimeVersion.isJava11OrLater()) {
 			newBuilder().append("for (String string: null) string").assertTextAtCursorPosition(") string", 6, "string", "strip", "stripLeading", "stripTrailing");
 		} else {
 			newBuilder().append("for (String string: null) string").assertTextAtCursorPosition(") string", 6, "string");

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/ContentAssistInLambdaTest2.java
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/ContentAssistInLambdaTest2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -10,7 +10,7 @@ package org.eclipse.xtend.ide.tests.contentassist;
 
 import java.util.List;
 
-import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
@@ -57,9 +57,9 @@ public class ContentAssistInLambdaTest2 extends ContentAssistTest {
 	
 	@Override
 	@Test public void testForLoop_02() throws Exception {
-		if (AbstractXtendUITestCase.isJava13OrLater()) {
+		if (JavaRuntimeVersion.isJava13OrLater()) {
 			newBuilder().append("for (String string: null) string").assertTextAtCursorPosition(") string", 6, "string", "strip", "stripIndent", "stripLeading", "stripTrailing");
-		} else if (AbstractXtendUITestCase.isJava11OrLater()) {
+		} else if (JavaRuntimeVersion.isJava11OrLater()) {
 			newBuilder().append("for (String string: null) string").assertTextAtCursorPosition(") string", 6, "string", "strip", "stripLeading", "stripTrailing");
 		} else {
 			newBuilder().append("for (String string: null) string").assertTextAtCursorPosition(") string", 6, "string");

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/DataContentAssistTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/contentassist/DataContentAssistTest.xtend
@@ -12,6 +12,7 @@ import org.eclipse.xtend.ide.tests.contentassist.AbstractXtendContentAssistBugTe
 import org.junit.Test
 import org.eclipse.xtext.testing.Flaky
 import org.eclipse.jdt.ui.PreferenceConstants
+import org.eclipse.xtext.util.JavaRuntimeVersion
 
 /**
  * @author Stefan Oehme - Initial contribution and API
@@ -20,7 +21,7 @@ class DataContentAssistTest extends AbstractXtendContentAssistBugTest {
 	
 	@Flaky
 	@Test def void testDataAnnotation() throws Exception {
-		if (isJava11OrLater) {
+		if (JavaRuntimeVersion.isJava11OrLater) {
 			val typeFilter = PreferenceConstants.getPreferenceStore().getDefaultString(
 				"org.eclipse.jdt.ui.typefilter.enabled")
 			if (typeFilter !== null && typeFilter.contains("jdk.*")) {

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/hover/JvmAnnotationReferencePrinterTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/hover/JvmAnnotationReferencePrinterTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -20,6 +20,7 @@ import org.eclipse.xtext.ui.resource.IResourceSetProvider
 import org.eclipse.emf.common.util.URI
 import org.eclipse.xtext.xbase.ui.hover.JvmAnnotationReferencePrinter
 import org.junit.Assume
+import org.eclipse.xtext.util.JavaRuntimeVersion
 
 /**
  * @author Sven Efftinge - Initial contribution and API
@@ -63,19 +64,19 @@ class JvmAnnotationReferencePrinterTest extends AbstractXtendUITestCase {
 		assertPrinted('@!Retention!(!RetentionPolicy!.!SOURCE!)', '@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.SOURCE)')
 	}
 	@Test def void testPrintedAnnotationValue_08() {
-		Assume.assumeFalse(isJava11OrLater)
+		Assume.assumeFalse(JavaRuntimeVersion.isJava11OrLater)
 		assertPrinted('@!Generated!(!value!="foo", !date!="bar", !comments!="baz")', '@javax.annotation.Generated(value="foo", date="bar", comments="baz")')
 	}
 	@Test def void testPrintedAnnotationValue_09() {
-		Assume.assumeFalse(isJava11OrLater)
+		Assume.assumeFalse(JavaRuntimeVersion.isJava11OrLater)
 		assertPrinted('@!XmlElements!(#[@!XmlElement!])', '@javax.xml.bind.annotation.XmlElements(#[@javax.xml.bind.annotation.XmlElement()])')
 	}
 	@Test def void testPrintedAnnotationValue_10() {
-		Assume.assumeFalse(isJava11OrLater)
+		Assume.assumeFalse(JavaRuntimeVersion.isJava11OrLater)
 		assertPrinted('@!XmlElements!(@!XmlElement!)', '@javax.xml.bind.annotation.XmlElements(@javax.xml.bind.annotation.XmlElement())')
 	}
 	@Test def void testPrintedAnnotationValue_11() {
-		Assume.assumeFalse(isJava11OrLater)
+		Assume.assumeFalse(JavaRuntimeVersion.isJava11OrLater)
 		assertPrinted('@!XmlElements!(#[@!XmlElement!(!nillable!=true), @!XmlElement!(!type!=!String![][])])', '@javax.xml.bind.annotation.XmlElements(@javax.xml.bind.annotation.XmlElement(nillable=true), @javax.xml.bind.annotation.XmlElement(type=typeof(String[][])))')
 	}
 	

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/hover/XtendHoverDocumentationProviderTest.xtend
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/hover/XtendHoverDocumentationProviderTest.xtend
@@ -1,3 +1,11 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
 package org.eclipse.xtend.ide.tests.hover
 
 import com.google.inject.Inject
@@ -19,6 +27,7 @@ import org.junit.After
 import org.junit.Test
 import org.eclipse.xtext.common.types.JvmAnnotationTarget
 import org.junit.Assume
+import org.eclipse.xtext.util.JavaRuntimeVersion
 
 class XtendHoverDocumentationProviderTest extends AbstractXtendUITestCase {
 	
@@ -530,7 +539,7 @@ class XtendHoverDocumentationProviderTest extends AbstractXtendUITestCase {
     // The necessary change was in org.eclipse.xtext.xbase.ui.hover.XbaseHoverProvider.isValidationDisabled(EObject)
     @Test
     def bug380551_TestLinkToNativeJavaType(){
-    	Assume.assumeFalse(isJava11OrLater)
+    	Assume.assumeFalse(JavaRuntimeVersion.isJava11OrLater)
         val xtendFile = parseHelper.parse('''
         package testpackage
         import javax.annotation.Resource

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/outline/JvmQuickOutlineTests.java
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/outline/JvmQuickOutlineTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -10,6 +10,7 @@ package org.eclipse.xtend.ide.tests.outline;
 
 import static org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.*;
 
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.junit.Test;
 
 /**
@@ -45,9 +46,9 @@ public class JvmQuickOutlineTests extends QuickOutlineTests {
 		setShowInherited(true);
 		assertBuilder = newAssertBuilder(model).numChildren(3);
 
-		sub = assertBuilder.child(1, "Foo - test").numChildren(isJava14OrLater() ? 14 : 15);
+		sub = assertBuilder.child(1, "Foo - test").numChildren(JavaRuntimeVersion.isJava14OrLater() ? 14 : 15);
 		checkExtendedMethods(sub, "Foo");
-		sub2 = assertBuilder.child(2, "Foo2 - test").numChildren(isJava14OrLater() ? 14 : 15);
+		sub2 = assertBuilder.child(2, "Foo2 - test").numChildren(JavaRuntimeVersion.isJava14OrLater() ? 14 : 15);
 		checkExtendedMethods(sub2, "Foo2");
 	}
 
@@ -59,15 +60,15 @@ public class JvmQuickOutlineTests extends QuickOutlineTests {
 		setShowInherited(true);
 		AssertBuilder assertBuilder = newAssertBuilder("enum Foo { BAR, BAZ }");
 		int numChildren = 30;
-		if (isJava14OrLater()) {
+		if (JavaRuntimeVersion.isJava14OrLater()) {
 			numChildren = 32;
-		} else if (isJava13OrLater()) {
+		} else if (JavaRuntimeVersion.isJava13OrLater()) {
 			numChildren = 33;
 		}
 		AssertBuilder interfaze = assertBuilder.numChildren(1).child(0, "Foo - (default package)").numChildren(numChildren);
 		interfaze.child(0, "BAR - Foo").numChildren(0);
 		interfaze.child(1, "BAZ - Foo").numChildren(0);
-		if (isJava13OrLater()) {
+		if (JavaRuntimeVersion.isJava13OrLater()) {
 			interfaze.nextChild("EnumDesc<E extends Enum<E>> - Enum").hasTextRegion(false);
 		}
 		interfaze.nextChild("valueOf(Class<T>, String) <T extends Enum<T>> : T - Enum<Foo>").hasTextRegion(false);
@@ -76,7 +77,7 @@ public class JvmQuickOutlineTests extends QuickOutlineTests {
 		interfaze.nextChild("new(String, int) - Enum<Foo>").hasTextRegion(false);
 		interfaze.nextChild("clone() : Object - Enum<Foo>").hasTextRegion(false);
 		interfaze.nextChild("compareTo(Foo) : int - Enum<Foo>").hasTextRegion(false);
-		if (isJava13OrLater()) {
+		if (JavaRuntimeVersion.isJava13OrLater()) {
 			interfaze.nextChild("describeConstable() : Optional<EnumDesc<Foo>> - Enum<Foo>").hasTextRegion(false);
 		}
 		interfaze.nextChild("equals(Object) : boolean - Enum<Foo>").hasTextRegion(false);
@@ -89,12 +90,12 @@ public class JvmQuickOutlineTests extends QuickOutlineTests {
 		interfaze.nextChild("readObjectNoData() : void - Enum<Foo>").hasTextRegion(false);
 		interfaze.nextChild("toString() : String - Enum<Foo>").hasTextRegion(false);
 		
-		if (isJava13OrLater()) {
+		if (JavaRuntimeVersion.isJava13OrLater()) {
 			interfaze.nextChild("describeConstable() : Optional<? extends ConstantDesc> - Constable").hasTextRegion(false);
 		}
 		interfaze.nextChild("compareTo(Foo) : int - Comparable<Foo>").hasTextRegion(false);
 		
-		if (!isJava14OrLater()) {
+		if (!JavaRuntimeVersion.isJava14OrLater()) {
 			interfaze.nextChild("registerNatives() : void - Object").hasTextRegion(false);
 		}
 		interfaze.nextChild("clone() : Object - Object").hasTextRegion(false);
@@ -114,7 +115,7 @@ public class JvmQuickOutlineTests extends QuickOutlineTests {
 		sub.child(0, "baz : Number - " + parentName).numChildren(0).hasTextRegion(true);
 		sub.nextChild("bar : String - Super").numChildren(0).hasTextRegion(false);
 		sub.nextChild("foo : int - Super").numChildren(0).hasTextRegion(false);
-		if (!isJava14OrLater()) {
+		if (!JavaRuntimeVersion.isJava14OrLater()) {
 			sub.nextChild("registerNatives() : void - Object").hasTextRegion(false);
 		}
 		sub.nextChild("clone() : Object - Object").hasTextRegion(false);
@@ -149,7 +150,7 @@ public class JvmQuickOutlineTests extends QuickOutlineTests {
 		setShowInherited(true);
 		assertBuilder = newAssertBuilder(model).numChildren(2);
 		int numChildren = 16;
-		if (isJava14OrLater()) {
+		if (JavaRuntimeVersion.isJava14OrLater()) {
 			numChildren = 15;
 		}
 		sub = assertBuilder.child(1, "Foo - test").numChildren(numChildren);
@@ -157,7 +158,7 @@ public class JvmQuickOutlineTests extends QuickOutlineTests {
 		sub.nextChild("toString() : String - Foo").numChildren(0).hasTextRegion(true);
 		sub.nextChild("bar() : String - Super").hasTextRegion(false);
 		sub.nextChild("foo(String) : int - Super").hasTextRegion(false);
-		if (!isJava14OrLater()) {
+		if (!JavaRuntimeVersion.isJava14OrLater()) {
 			sub.nextChild("registerNatives() : void - Object").hasTextRegion(false);
 		}
 		sub.nextChild("clone() : Object - Object").hasTextRegion(false);
@@ -189,14 +190,14 @@ public class JvmQuickOutlineTests extends QuickOutlineTests {
 		setShowInherited(true);
 		assertBuilder = newAssertBuilder(model).numChildren(2);
 		int numChildren = 15;
-		if (isJava14OrLater()) {
+		if (JavaRuntimeVersion.isJava14OrLater()) {
 			numChildren = 14;
 		}
 		sub = assertBuilder.child(1, "Foo - test").numChildren(numChildren).hasTextRegion(true);
 		sub.nextChild("_foo(Number) : void - Foo").hasTextRegion(true);
 		sub.nextChild("foo(Serializable) : void - Foo");
 		sub.nextChild("_foo(String) : void - Super").numChildren(0).hasTextRegion(false);
-		if (!isJava14OrLater()) {
+		if (!JavaRuntimeVersion.isJava14OrLater()) {
 			sub.nextChild("registerNatives() : void - Object").hasTextRegion(false);
 		}
 		sub.nextChild("clone() : Object - Object").hasTextRegion(false);

--- a/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/outline/QuickOutlineTests.java
+++ b/org.eclipse.xtend.ide.tests/src/org/eclipse/xtend/ide/tests/outline/QuickOutlineTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2011, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -12,6 +12,7 @@ import static org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.*;
 
 import org.eclipse.xtext.ui.editor.outline.impl.OutlineFilterAndSorter;
 import org.eclipse.xtext.ui.editor.outline.quickoutline.QuickOutlineFilterAndSorter;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.junit.Test;
 
 import com.google.inject.Inject;
@@ -78,7 +79,7 @@ public class QuickOutlineTests extends AbstractOutlineTests {
 		setShowInherited(true);
 		assertBuilder = newAssertBuilder(model).numChildren(2);
 		int numChildren = 16;
-		if (isJava14OrLater()) {
+		if (JavaRuntimeVersion.isJava14OrLater()) {
 			numChildren = 15;
 		}
 		sub = assertBuilder.child(1, "Foo - test").numChildren(numChildren);
@@ -87,7 +88,7 @@ public class QuickOutlineTests extends AbstractOutlineTests {
 		sub.child(counter++, "SubOfFoo - Super").hasTextRegion(false);
 		sub.child(counter++, "bar : String - Super").numChildren(0).hasTextRegion(false);
 		sub.child(counter++, "foo : int - Super").numChildren(0).hasTextRegion(false);
-		if (!isJava14OrLater()) {
+		if (!JavaRuntimeVersion.isJava14OrLater()) {
 			sub.child(counter++, "registerNatives() : void - Object").hasTextRegion(false);
 		}
 		sub.child(counter++, "clone() : Object - Object").hasTextRegion(false);
@@ -119,7 +120,7 @@ public class QuickOutlineTests extends AbstractOutlineTests {
 		setShowInherited(true);
 		assertBuilder = newAssertBuilder(model).numChildren(2);
 		int numChildren = 15;
-		if (isJava14OrLater()) {
+		if (JavaRuntimeVersion.isJava14OrLater()) {
 			numChildren = 14;
 		}
 		sub = assertBuilder.child(1, "Foo - test").numChildren(numChildren);
@@ -127,7 +128,7 @@ public class QuickOutlineTests extends AbstractOutlineTests {
 		sub.child(counter++, "baz() : Number - Foo").numChildren(0).hasTextRegion(true);
 		sub.child(counter++, "bar() : String - Super").hasTextRegion(false);
 		sub.child(counter++, "foo(String) : int - Super").hasTextRegion(false);
-		if (!isJava14OrLater()) {
+		if (!JavaRuntimeVersion.isJava14OrLater()) {
 			sub.child(counter++, "registerNatives() : void - Object").hasTextRegion(false);
 		}
 		sub.child(counter++, "clone() : Object - Object").hasTextRegion(false);
@@ -154,13 +155,13 @@ public class QuickOutlineTests extends AbstractOutlineTests {
 		setShowInherited(true);
 		assertBuilder = newAssertBuilder(model).numChildren(2);
 		int numChildren = 13;
-		if (isJava14OrLater()) {
+		if (JavaRuntimeVersion.isJava14OrLater()) {
 			numChildren = 12;
 		}
 		sub = assertBuilder.child(1, "C - pack.name").numChildren(numChildren);
 		int counter = 0;
 		sub.child(counter++, "E - C").hasTextRegion(true);
-		if (!isJava14OrLater()) {
+		if (!JavaRuntimeVersion.isJava14OrLater()) {
 			sub.child(counter++, "registerNatives() : void - Object").hasTextRegion(false);
 		}
 		sub.child(counter++, "clone() : Object - Object").hasTextRegion(false);
@@ -191,7 +192,7 @@ public class QuickOutlineTests extends AbstractOutlineTests {
 		setShowInherited(true);
 		assertBuilder = newAssertBuilder(model).numChildren(2);
 		int numChildren = 13;
-		if (isJava14OrLater()) {
+		if (JavaRuntimeVersion.isJava14OrLater()) {
 			numChildren = 12;
 		}
 		sub = assertBuilder.child(1, "Foo - test").numChildren(numChildren).hasTextRegion(true);
@@ -200,7 +201,7 @@ public class QuickOutlineTests extends AbstractOutlineTests {
 		foo.child(counter++, "_foo(String) : void - Super").numChildren(0).hasTextRegion(false);
 		foo.child(counter++, "foo(Number) : void - Foo").numChildren(0).hasTextRegion(true);
 		counter = 1;
-		if (!isJava14OrLater()) {
+		if (!JavaRuntimeVersion.isJava14OrLater()) {
 			sub.child(counter++, "registerNatives() : void - Object").hasTextRegion(false);
 		}
 		sub.child(counter++, "clone() : Object - Object").hasTextRegion(false);
@@ -242,7 +243,7 @@ public class QuickOutlineTests extends AbstractOutlineTests {
 		setShowInherited(true);
 		assertBuilder = newAssertBuilder(model).numChildren(2);
 		int numChildren = 18;
-		if (isJava14OrLater()) {
+		if (JavaRuntimeVersion.isJava14OrLater()) {
 			numChildren = 17;
 		}
 		sub = assertBuilder.child(1, "Foo - test").numChildren(numChildren).hasTextRegion(true);
@@ -253,7 +254,7 @@ public class QuickOutlineTests extends AbstractOutlineTests {
 		sub.child(i++, "c : Map<List<String>, String> - Super<String>").hasTextRegion(false);
 		sub.child(i++, "new(List<String>) - Super<String>").hasTextRegion(false);
 		sub.child(i++, "foo(List<String>) : String - Super<String>").hasTextRegion(false);
-		if (!isJava14OrLater()) {
+		if (!JavaRuntimeVersion.isJava14OrLater()) {
 			sub.child(i++, "registerNatives() : void - Object").hasTextRegion(false);
 		}
 		sub.child(i++, "clone() : Object - Object").hasTextRegion(false);

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/contentassist/Bug427440Test.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/contentassist/Bug427440Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -11,11 +11,11 @@ package org.eclipse.xtend.ide.tests.contentassist;
 import java.util.Iterator;
 import java.util.List;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
-import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.ui.editor.contentassist.ConfigurableCompletionProposal;
 import org.eclipse.xtext.ui.editor.contentassist.ReplacementTextApplier;
 import org.eclipse.xtext.ui.testing.ContentAssistProcessorTestBuilder;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.xbase.lib.Conversions;
 import org.junit.Assert;
 import org.junit.Test;
@@ -60,7 +60,7 @@ public class Bug427440Test extends AbstractXtendContentAssistBugTest {
     this.assertContains(proposals.next(), "annotations");
     this.assertContains(proposals.next(), "anonymousClass");
     this.assertContains(proposals.next(), "array");
-    boolean _isJava13OrLater = AbstractXtendUITestCase.isJava13OrLater();
+    boolean _isJava13OrLater = JavaRuntimeVersion.isJava13OrLater();
     if (_isJava13OrLater) {
       this.assertContains(proposals.next(), "arrayType");
     }

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/contentassist/Bug435184Test.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/contentassist/Bug435184Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -8,9 +8,9 @@
  */
 package org.eclipse.xtend.ide.tests.contentassist;
 
-import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.ui.testing.ContentAssistProcessorTestBuilder;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.junit.Test;
 
 /**
@@ -54,7 +54,7 @@ public class Bug435184Test extends AbstractXtendContentAssistBugTest {
     _builder.append("}");
     _builder.newLine();
     final ContentAssistProcessorTestBuilder b = _newBuilder.append(_builder.toString());
-    boolean _isJava11OrLater = AbstractXtendUITestCase.isJava11OrLater();
+    boolean _isJava11OrLater = JavaRuntimeVersion.isJava11OrLater();
     if (_isJava11OrLater) {
       b.assertTextAtCursorPosition("|", "read", "read()", "read()", "readAllBytes", "readNBytes()", "readNBytes()");
     } else {

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/contentassist/DataContentAssistTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/contentassist/DataContentAssistTest.java
@@ -9,8 +9,8 @@
 package org.eclipse.xtend.ide.tests.contentassist;
 
 import org.eclipse.jdt.ui.PreferenceConstants;
-import org.eclipse.xtend.ide.tests.AbstractXtendUITestCase;
 import org.eclipse.xtext.testing.Flaky;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.junit.Test;
 
 /**
@@ -21,7 +21,7 @@ public class DataContentAssistTest extends AbstractXtendContentAssistBugTest {
   @Flaky
   @Test
   public void testDataAnnotation() throws Exception {
-    boolean _isJava11OrLater = AbstractXtendUITestCase.isJava11OrLater();
+    boolean _isJava11OrLater = JavaRuntimeVersion.isJava11OrLater();
     if (_isJava11OrLater) {
       final String typeFilter = PreferenceConstants.getPreferenceStore().getDefaultString(
         "org.eclipse.jdt.ui.typefilter.enabled");

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/hover/JvmAnnotationReferencePrinterTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/hover/JvmAnnotationReferencePrinterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2015, 2021 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -19,6 +19,7 @@ import org.eclipse.xtext.common.types.JvmAnnotationReference;
 import org.eclipse.xtext.common.types.JvmGenericType;
 import org.eclipse.xtext.testing.util.ParseHelper;
 import org.eclipse.xtext.ui.resource.IResourceSetProvider;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.xbase.lib.Exceptions;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.ui.hover.JvmAnnotationReferencePrinter;
@@ -83,25 +84,25 @@ public class JvmAnnotationReferencePrinterTest extends AbstractXtendUITestCase {
   
   @Test
   public void testPrintedAnnotationValue_08() {
-    Assume.assumeFalse(AbstractXtendUITestCase.isJava11OrLater());
+    Assume.assumeFalse(JavaRuntimeVersion.isJava11OrLater());
     this.assertPrinted("@!Generated!(!value!=\"foo\", !date!=\"bar\", !comments!=\"baz\")", "@javax.annotation.Generated(value=\"foo\", date=\"bar\", comments=\"baz\")");
   }
   
   @Test
   public void testPrintedAnnotationValue_09() {
-    Assume.assumeFalse(AbstractXtendUITestCase.isJava11OrLater());
+    Assume.assumeFalse(JavaRuntimeVersion.isJava11OrLater());
     this.assertPrinted("@!XmlElements!(#[@!XmlElement!])", "@javax.xml.bind.annotation.XmlElements(#[@javax.xml.bind.annotation.XmlElement()])");
   }
   
   @Test
   public void testPrintedAnnotationValue_10() {
-    Assume.assumeFalse(AbstractXtendUITestCase.isJava11OrLater());
+    Assume.assumeFalse(JavaRuntimeVersion.isJava11OrLater());
     this.assertPrinted("@!XmlElements!(@!XmlElement!)", "@javax.xml.bind.annotation.XmlElements(@javax.xml.bind.annotation.XmlElement())");
   }
   
   @Test
   public void testPrintedAnnotationValue_11() {
-    Assume.assumeFalse(AbstractXtendUITestCase.isJava11OrLater());
+    Assume.assumeFalse(JavaRuntimeVersion.isJava11OrLater());
     this.assertPrinted("@!XmlElements!(#[@!XmlElement!(!nillable!=true), @!XmlElement!(!type!=!String![][])])", "@javax.xml.bind.annotation.XmlElements(@javax.xml.bind.annotation.XmlElement(nillable=true), @javax.xml.bind.annotation.XmlElement(type=typeof(String[][])))");
   }
   

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/hover/TestingXbaseHoverProvider.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/hover/TestingXbaseHoverProvider.java
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.xtend.ide.tests.hover;
 
 import org.eclipse.emf.ecore.EObject;

--- a/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/hover/XtendHoverDocumentationProviderTest.java
+++ b/org.eclipse.xtend.ide.tests/xtend-gen/org/eclipse/xtend/ide/tests/hover/XtendHoverDocumentationProviderTest.java
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) 2012, 2021 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.xtend.ide.tests.hover;
 
 import com.google.common.collect.Iterables;
@@ -19,6 +27,7 @@ import org.eclipse.xtext.common.types.JvmGenericType;
 import org.eclipse.xtext.testing.util.ParseHelper;
 import org.eclipse.xtext.ui.editor.hover.html.IEObjectHoverDocumentationProvider;
 import org.eclipse.xtext.ui.resource.IResourceSetProvider;
+import org.eclipse.xtext.util.JavaRuntimeVersion;
 import org.eclipse.xtext.xbase.XAbstractFeatureCall;
 import org.eclipse.xtext.xbase.XBlockExpression;
 import org.eclipse.xtext.xbase.XExpression;
@@ -1030,7 +1039,7 @@ public class XtendHoverDocumentationProviderTest extends AbstractXtendUITestCase
   @Test
   public void bug380551_TestLinkToNativeJavaType() {
     try {
-      Assume.assumeFalse(AbstractXtendUITestCase.isJava11OrLater());
+      Assume.assumeFalse(JavaRuntimeVersion.isJava11OrLater());
       StringConcatenation _builder = new StringConcatenation();
       _builder.append("package testpackage");
       _builder.newLine();


### PR DESCRIPTION
[eclipse/xtext#1452] add common JavaRuntimeVersion utility to avoid code duplication between modules

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>