### PR TITLE
[eclipse/xtext-xtend#1301] fix name clashes with anony. inner classes

### DIFF
--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/AnonymousClassCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/AnonymousClassCompilerTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2022 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -2424,6 +2424,51 @@ class AnonymousClassCompilerTest extends AbstractXtendCompilerTest {
 		        return null;
 		      }
 		    };
+		  }
+		}
+		''')
+	}
+	
+	@Test
+	def void testXtendIssue1301() {
+		'''
+		import org.eclipse.emf.ecore.EObject
+		import org.eclipse.emf.common.notify.impl.AdapterImpl
+		class Sample {
+			def getMyAdapter(extension EObject it) {
+				eAdapters.filter(AdapterImpl).head ?: (new AdapterImpl() => [eAdapters += it])
+			}
+		}
+		'''.assertCompilesTo('''
+		import com.google.common.collect.Iterables;
+		import org.eclipse.emf.common.notify.Adapter;
+		import org.eclipse.emf.common.notify.impl.AdapterImpl;
+		import org.eclipse.emf.common.util.EList;
+		import org.eclipse.emf.ecore.EObject;
+		import org.eclipse.xtext.xbase.lib.Extension;
+		import org.eclipse.xtext.xbase.lib.IterableExtensions;
+		import org.eclipse.xtext.xbase.lib.ObjectExtensions;
+		import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
+		
+		@SuppressWarnings("all")
+		public class Sample {
+		  public AdapterImpl getMyAdapter(@Extension final EObject it) {
+		    AdapterImpl _elvis = null;
+		    AdapterImpl _head = IterableExtensions.<AdapterImpl>head(Iterables.<AdapterImpl>filter(it.eAdapters(), AdapterImpl.class));
+		    if (_head != null) {
+		      _elvis = _head;
+		    } else {
+		      AdapterImpl _adapterImpl = new AdapterImpl();
+		      final Procedure1<AdapterImpl> _function = new Procedure1<AdapterImpl>() {
+		        public void apply(final AdapterImpl it_1) {
+		          EList<Adapter> _eAdapters = it.eAdapters();
+		          _eAdapters.add(it_1);
+		        }
+		      };
+		      AdapterImpl _doubleArrow = ObjectExtensions.<AdapterImpl>operator_doubleArrow(_adapterImpl, _function);
+		      _elvis = _doubleArrow;
+		    }
+		    return _elvis;
 		  }
 		}
 		''')

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBugTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/CompilerBugTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2022 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -1131,12 +1131,12 @@ class CompilerBugTest extends AbstractXtendCompilerTest {
 			  
 			  public void m(final Iterable<JvmTypeReference> refs, final ITreeAppendable it) {
 			    final Procedure1<LoopParams> _function = new Procedure1<LoopParams>() {
-			      public void apply(final LoopParams it) {
+			      public void apply(final LoopParams it_1) {
 			      }
 			    };
 			    final Procedure2<JvmTypeReference, ITreeAppendable> _function_1 = new Procedure2<JvmTypeReference, ITreeAppendable>() {
-			      public void apply(final JvmTypeReference it, final ITreeAppendable app) {
-			        app.trace(it).append(it.getType());
+			      public void apply(final JvmTypeReference it_1, final ITreeAppendable app) {
+			        app.trace(it_1).append(it_1.getType());
 			      }
 			    };
 			    this._errorSafeExtensions.<JvmTypeReference>forEachSafely(it, refs, _function, _function_1);

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/ParameterizedInnerTypesCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/ParameterizedInnerTypesCompilerTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2022 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -82,8 +82,8 @@ class ParameterizedInnerTypesCompilerTest extends AbstractXtendCompilerTest {
 			public class EitherTest {
 			  public Boolean m(final Either<Integer, Boolean> it) {
 			    final Function<Integer, Boolean> _function = new Function<Integer, Boolean>() {
-			      public Boolean apply(final Integer it) {
-			        int _intValue = it.intValue();
+			      public Boolean apply(final Integer it_1) {
+			        int _intValue = it_1.intValue();
 			        return Boolean.valueOf((_intValue == 0));
 			      }
 			    };
@@ -152,8 +152,8 @@ class ParameterizedInnerTypesCompilerTest extends AbstractXtendCompilerTest {
 			public class EitherTest {
 			  public Either<String, Integer> m(final Either<Integer, Boolean> it) {
 			    final Function<Boolean, String> _function = new Function<Boolean, String>() {
-			      public String apply(final Boolean it) {
-			        return it.toString();
+			      public String apply(final Boolean it_1) {
+			        return it_1.toString();
 			      }
 			    };
 			    return it.<String>map(_function).swap();

--- a/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.xtend
+++ b/org.eclipse.xtend.core.tests/src/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.xtend
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2022 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -1133,8 +1133,8 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 				      protected T computeNext() {
 				        T _elvis = null;
 				        final Function1<T, Boolean> _function = new Function1<T, Boolean>() {
-				          public Boolean apply(final T it) {
-				            return Boolean.valueOf((!Objects.equal(it, null)));
+				          public Boolean apply(final T it_1) {
+				            return Boolean.valueOf((!Objects.equal(it_1, null)));
 				          }
 				        };
 				        T _findFirst = IteratorExtensions.<T>findFirst(it, _function);
@@ -3957,8 +3957,8 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 			      final Function1<String, String> _function = new Function1<String, String>() {
 			        public String apply(final String it) {
 			          final Function1<String, String> _function = new Function1<String, String>() {
-			            public String apply(final String it) {
-			              return it;
+			            public String apply(final String it_1) {
+			              return it_1;
 			            }
 			          };
 			          return _function.apply(it);
@@ -4287,8 +4287,8 @@ class XtendCompilerTest extends AbstractXtendCompilerTest {
 				public class FindFirstOnIt {
 				  public <T extends Object> T useExtension(final Iterable<T> it) {
 				    final Function1<T, Boolean> _function = new Function1<T, Boolean>() {
-				      public Boolean apply(final T it) {
-				        return Boolean.valueOf((it != null));
+				      public Boolean apply(final T it_1) {
+				        return Boolean.valueOf((it_1 != null));
 				      }
 				    };
 				    return IterableExtensions.<T>findFirst(it, _function);

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/AnonymousClassCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/AnonymousClassCompilerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2022 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -5731,6 +5731,109 @@ public class AnonymousClassCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.newLine();
     _builder_1.append("    ");
     _builder_1.append("};");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("}");
+    _builder_1.newLine();
+    this.assertCompilesTo(_builder, _builder_1);
+  }
+  
+  @Test
+  public void testXtendIssue1301() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("import org.eclipse.emf.ecore.EObject");
+    _builder.newLine();
+    _builder.append("import org.eclipse.emf.common.notify.impl.AdapterImpl");
+    _builder.newLine();
+    _builder.append("class Sample {");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("def getMyAdapter(extension EObject it) {");
+    _builder.newLine();
+    _builder.append("\t\t");
+    _builder.append("eAdapters.filter(AdapterImpl).head ?: (new AdapterImpl() => [eAdapters += it])");
+    _builder.newLine();
+    _builder.append("\t");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    StringConcatenation _builder_1 = new StringConcatenation();
+    _builder_1.append("import com.google.common.collect.Iterables;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.emf.common.notify.Adapter;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.emf.common.notify.impl.AdapterImpl;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.emf.common.util.EList;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.emf.ecore.EObject;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Extension;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.IterableExtensions;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.ObjectExtensions;");
+    _builder_1.newLine();
+    _builder_1.append("import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;");
+    _builder_1.newLine();
+    _builder_1.newLine();
+    _builder_1.append("@SuppressWarnings(\"all\")");
+    _builder_1.newLine();
+    _builder_1.append("public class Sample {");
+    _builder_1.newLine();
+    _builder_1.append("  ");
+    _builder_1.append("public AdapterImpl getMyAdapter(@Extension final EObject it) {");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("AdapterImpl _elvis = null;");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("AdapterImpl _head = IterableExtensions.<AdapterImpl>head(Iterables.<AdapterImpl>filter(it.eAdapters(), AdapterImpl.class));");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("if (_head != null) {");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("_elvis = _head;");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("} else {");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("AdapterImpl _adapterImpl = new AdapterImpl();");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("final Procedure1<AdapterImpl> _function = new Procedure1<AdapterImpl>() {");
+    _builder_1.newLine();
+    _builder_1.append("        ");
+    _builder_1.append("public void apply(final AdapterImpl it_1) {");
+    _builder_1.newLine();
+    _builder_1.append("          ");
+    _builder_1.append("EList<Adapter> _eAdapters = it.eAdapters();");
+    _builder_1.newLine();
+    _builder_1.append("          ");
+    _builder_1.append("_eAdapters.add(it_1);");
+    _builder_1.newLine();
+    _builder_1.append("        ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("};");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("AdapterImpl _doubleArrow = ObjectExtensions.<AdapterImpl>operator_doubleArrow(_adapterImpl, _function);");
+    _builder_1.newLine();
+    _builder_1.append("      ");
+    _builder_1.append("_elvis = _doubleArrow;");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("}");
+    _builder_1.newLine();
+    _builder_1.append("    ");
+    _builder_1.append("return _elvis;");
     _builder_1.newLine();
     _builder_1.append("  ");
     _builder_1.append("}");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBugTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/CompilerBugTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2013, 2018 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2013, 2022 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -2566,7 +2566,7 @@ public class CompilerBugTest extends AbstractXtendCompilerTest {
     _builder_1.append("final Procedure1<LoopParams> _function = new Procedure1<LoopParams>() {");
     _builder_1.newLine();
     _builder_1.append("      ");
-    _builder_1.append("public void apply(final LoopParams it) {");
+    _builder_1.append("public void apply(final LoopParams it_1) {");
     _builder_1.newLine();
     _builder_1.append("      ");
     _builder_1.append("}");
@@ -2578,10 +2578,10 @@ public class CompilerBugTest extends AbstractXtendCompilerTest {
     _builder_1.append("final Procedure2<JvmTypeReference, ITreeAppendable> _function_1 = new Procedure2<JvmTypeReference, ITreeAppendable>() {");
     _builder_1.newLine();
     _builder_1.append("      ");
-    _builder_1.append("public void apply(final JvmTypeReference it, final ITreeAppendable app) {");
+    _builder_1.append("public void apply(final JvmTypeReference it_1, final ITreeAppendable app) {");
     _builder_1.newLine();
     _builder_1.append("        ");
-    _builder_1.append("app.trace(it).append(it.getType());");
+    _builder_1.append("app.trace(it_1).append(it_1.getType());");
     _builder_1.newLine();
     _builder_1.append("      ");
     _builder_1.append("}");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/ParameterizedInnerTypesCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/ParameterizedInnerTypesCompilerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014, 2016 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2014, 2022 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -149,10 +149,10 @@ public class ParameterizedInnerTypesCompilerTest extends AbstractXtendCompilerTe
     _builder_1.append("final Function<Integer, Boolean> _function = new Function<Integer, Boolean>() {");
     _builder_1.newLine();
     _builder_1.append("      ");
-    _builder_1.append("public Boolean apply(final Integer it) {");
+    _builder_1.append("public Boolean apply(final Integer it_1) {");
     _builder_1.newLine();
     _builder_1.append("        ");
-    _builder_1.append("int _intValue = it.intValue();");
+    _builder_1.append("int _intValue = it_1.intValue();");
     _builder_1.newLine();
     _builder_1.append("        ");
     _builder_1.append("return Boolean.valueOf((_intValue == 0));");
@@ -289,10 +289,10 @@ public class ParameterizedInnerTypesCompilerTest extends AbstractXtendCompilerTe
     _builder_1.append("final Function<Boolean, String> _function = new Function<Boolean, String>() {");
     _builder_1.newLine();
     _builder_1.append("      ");
-    _builder_1.append("public String apply(final Boolean it) {");
+    _builder_1.append("public String apply(final Boolean it_1) {");
     _builder_1.newLine();
     _builder_1.append("        ");
-    _builder_1.append("return it.toString();");
+    _builder_1.append("return it_1.toString();");
     _builder_1.newLine();
     _builder_1.append("      ");
     _builder_1.append("}");

--- a/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.java
+++ b/org.eclipse.xtend.core.tests/xtend-gen/org/eclipse/xtend/core/tests/compiler/XtendCompilerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2012, 2020 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2012, 2022 itemis AG (http://www.itemis.eu) and others.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
@@ -2622,10 +2622,10 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("final Function1<T, Boolean> _function = new Function1<T, Boolean>() {");
     _builder_1.newLine();
     _builder_1.append("          ");
-    _builder_1.append("public Boolean apply(final T it) {");
+    _builder_1.append("public Boolean apply(final T it_1) {");
     _builder_1.newLine();
     _builder_1.append("            ");
-    _builder_1.append("return Boolean.valueOf((!Objects.equal(it, null)));");
+    _builder_1.append("return Boolean.valueOf((!Objects.equal(it_1, null)));");
     _builder_1.newLine();
     _builder_1.append("          ");
     _builder_1.append("}");
@@ -8976,10 +8976,10 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("final Function1<String, String> _function = new Function1<String, String>() {");
     _builder_1.newLine();
     _builder_1.append("            ");
-    _builder_1.append("public String apply(final String it) {");
+    _builder_1.append("public String apply(final String it_1) {");
     _builder_1.newLine();
     _builder_1.append("              ");
-    _builder_1.append("return it;");
+    _builder_1.append("return it_1;");
     _builder_1.newLine();
     _builder_1.append("            ");
     _builder_1.append("}");
@@ -9680,10 +9680,10 @@ public class XtendCompilerTest extends AbstractXtendCompilerTest {
     _builder_1.append("final Function1<T, Boolean> _function = new Function1<T, Boolean>() {");
     _builder_1.newLine();
     _builder_1.append("      ");
-    _builder_1.append("public Boolean apply(final T it) {");
+    _builder_1.append("public Boolean apply(final T it_1) {");
     _builder_1.newLine();
     _builder_1.append("        ");
-    _builder_1.append("return Boolean.valueOf((it != null));");
+    _builder_1.append("return Boolean.valueOf((it_1 != null));");
     _builder_1.newLine();
     _builder_1.append("      ");
     _builder_1.append("}");


### PR DESCRIPTION
[eclipse/xtext-xtend#1301] fix name clashes with anony. inner classes