### PR TITLE
[eclipse/xtext#2068] use 4.25 I-builds in latest

### DIFF
--- a/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-latest.target
+++ b/releng/org.eclipse.xtend.target/org.eclipse.xtend.target-latest.target
@@ -87,7 +87,7 @@
 		<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.pde.api.tools.ee.feature.feature.group" version="0.0.0"/>
-		<repository location="https://download.eclipse.org/eclipse/updates/4.24-I-builds"/>
+		<repository location="https://download.eclipse.org/eclipse/updates/4.25-I-builds"/>
 	</location>
 
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
[eclipse/xtext#2068] use 4.25 I-builds in latest