### PR TITLE
[#1362] remove workaround as classes in jdt are now no longer abstract

### DIFF
--- a/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/formatting/preferences/AbstractModifyDialogTab.java
+++ b/org.eclipse.xtend.ide/src/org/eclipse/xtend/ide/formatting/preferences/AbstractModifyDialogTab.java
@@ -97,16 +97,4 @@ public abstract class AbstractModifyDialogTab extends ModifyDialogTabPage {
 				Boolean.FALSE.toString(), Boolean.TRUE.toString() });
 	}
 
-	public void doSetAll(boolean value) {
-		
-	}
-
-	public void resetValues() {
-		
-	}
-
-	public void setDefaults() {
-		
-	}
-
 }


### PR DESCRIPTION
[#1362] remove workaround as classes in jdt are now no longer abstract