### PR TITLE
Update to M2E 2.0

### DIFF
--- a/org.eclipse.xtend.m2e/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.m2e/META-INF/MANIFEST.MF
@@ -5,15 +5,12 @@ Bundle-SymbolicName: org.eclipse.xtend.m2e;singleton:=true
 Bundle-Version: 2.28.0.qualifier
 Bundle-Localization: plugin
 Bundle-Vendor: %providerName
-Require-Bundle: org.eclipse.m2e.core;bundle-version="[1.8.3,2.0.0)";resolution:=optional,
- org.eclipse.core.resources;bundle-version="3.12.0",
- org.eclipse.equinox.registry;bundle-version="3.7.0",
+Require-Bundle: org.eclipse.m2e.core;bundle-version="[1.8.3,3.0.0)";resolution:=optional,
  org.eclipse.xtext.ui,
  org.eclipse.xtext.builder,
  org.eclipse.xtend.core,
- org.eclipse.m2e.maven.runtime;bundle-version="[1.8.3,2.0.0)";resolution:=optional
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.8.3,4.0.0)";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xtend.m2e;x-internal:=true
-Import-Package: org.apache.maven.plugin;provider=m2e;resolution:=optional,
- org.apache.maven.project;provider=m2e;resolution:=optional
+Import-Package: org.apache.maven.plugin;provider=m2e;resolution:=optional
 Automatic-Module-Name: org.eclipse.xtend.m2e


### PR DESCRIPTION
This PR aims to update `org.eclipse.xtend.m2e` Plugin to the M2E 2.0.1 release that is contributed to Eclipse 2022-09 M3 SimRel.
M2E 2.0 is a major release that has breaking changes in its API, that are incompatible with previous 1.x releases.

I updated the code and adjusted required bundle version ranges accordingly. Furthermore I update the target file to include the latest m2e release 2.0.1. That release is not yet in the 2022-09 release repo but will be with M3, so this change in advance should prevent trouble with the xText contribution.
I hope that is all correct, but please let me know if anything is wrong or missing.
