### PR TITLE
[eclipse/xtext#2125] set minimum junit version to 4.13.2

### DIFF
--- a/org.eclipse.xtend.core.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.core.tests/META-INF/MANIFEST.MF
@@ -29,12 +29,12 @@ Require-Bundle: org.eclipse.xtend.core,
 Import-Package: javax.inject;version="1.0.0",
  org.apache.log4j;version="1.2.19",
  org.apache.log4j.spi;version="1.2.19",
- org.junit;version="4.12.0",
- org.junit.internal;version="4.12.0",
- org.junit.internal.builders;version="4.12.0",
- org.junit.rules;version="4.12.0";resolution:=optional,
- org.junit.runner;version="4.12.0",
- org.junit.runners;version="4.12.0"
+ org.junit;version="4.13.2",
+ org.junit.internal;version="4.13.2",
+ org.junit.internal.builders;version="4.13.2",
+ org.junit.rules;version="4.13.2";resolution:=optional,
+ org.junit.runner;version="4.13.2",
+ org.junit.runners;version="4.13.2"
 Bundle-ClassPath: .
 Export-Package: .;x-internal:=true,
  bug380058;x-internal:=true,

--- a/org.eclipse.xtend.examples/projects/xtend-annotation-examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.examples/projects/xtend-annotation-examples/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,
  com.google.guava;bundle-version="[30.1.0,31.0.0)",
  org.eclipse.xtext.xbase.lib;bundle-version="2.30.0",
- org.junit;bundle-version="4.12.0",
+ org.junit;bundle-version="4.13.2",
  org.eclipse.xtend.core,
  org.eclipse.xtext,
  org.eclipse.xtext.xbase.testing,

--- a/org.eclipse.xtend.examples/projects/xtend-examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.examples/projects/xtend-examples/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 2.30.0.qualifier
 Bundle-Vendor: Eclipse Xtext
 Require-Bundle: org.eclipse.xtext.xbase.lib;bundle-version="2.30.0",
  org.eclipse.xtend.lib,
- org.junit;bundle-version="4.12.0"
+ org.junit;bundle-version="4.13.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: xtend-examples
 Export-Package: example1;x-internal:=true,

--- a/org.eclipse.xtend.ide.swtbot.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.ide.swtbot.tests/META-INF/MANIFEST.MF
@@ -6,11 +6,11 @@ Bundle-Version: 2.30.0.qualifier
 Bundle-Vendor: Eclipse Xtext
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.apache.log4j;version="1.2.19",
- org.junit;version="4.12.0",
- org.junit.rules;version="4.12.0",
- org.junit.runner;version="4.12.0",
- org.junit.runner.notification;version="4.12.0",
- org.junit.runners;version="4.12.0",
+ org.junit;version="4.13.2",
+ org.junit.rules;version="4.13.2",
+ org.junit.runner;version="4.13.2",
+ org.junit.runner.notification;version="4.13.2",
+ org.junit.runners;version="4.13.2",
  org.slf4j;resolution:=optional
 Export-Package: org.eclipse.xtend.ide.tests;x-friends:="org.eclipse.xtend.performance.tests"
 Require-Bundle: org.eclipse.swtbot.eclipse.core;bundle-version="2.6.0",

--- a/org.eclipse.xtend.ide.tests.data/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.ide.tests.data/META-INF/MANIFEST.MF
@@ -11,5 +11,5 @@ Export-Package: org.eclipse.xtend.core.tests.internal;x-internal:=true,
  org.eclipse.xtend.ide.tests.data.contentassist,
  org.eclipse.xtend.ide.tests.data.highlighting,
  org.eclipse.xtend.ide.tests.data.quickfix
-Import-Package: org.junit;version="4.12.0"
+Import-Package: org.junit;version="4.13.2"
 Automatic-Module-Name: org.eclipse.xtend.ide.tests.data

--- a/org.eclipse.xtend.ide.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtend.ide.tests/META-INF/MANIFEST.MF
@@ -37,10 +37,10 @@ Require-Bundle: org.eclipse.xtend.core,
  org.eclipse.xtext.xbase.testing
 Import-Package: org.apache.log4j;version="1.2.19",
  org.apache.log4j.spi;version="1.2.19",
- org.junit;version="4.12.0",
- org.junit.rules;version="4.12.0",
- org.junit.runner;version="4.12.0",
- org.junit.runners;version="4.12.0",
- org.junit.runners.model;version="4.12.0"
+ org.junit;version="4.13.2",
+ org.junit.rules;version="4.13.2",
+ org.junit.runner;version="4.13.2",
+ org.junit.runners;version="4.13.2",
+ org.junit.runners.model;version="4.13.2"
 Export-Package: org.eclipse.xtend.ide.tests;x-friends:="org.eclipse.xtend.performance.tests"
 Automatic-Module-Name: org.eclipse.xtend.ide.tests


### PR DESCRIPTION
[eclipse/xtext#2125] set minimum junit version to 4.13.2